### PR TITLE
Added news links to Steam synchronized games

### DIFF
--- a/source/Playnite/Providers/Steam/SteamLibrary.cs
+++ b/source/Playnite/Providers/Steam/SteamLibrary.cs
@@ -274,6 +274,7 @@ namespace Playnite.Providers.Steam
             game.Links = new ObservableCollection<Link>()
             {
                 new Link("Forum", @"https://steamcommunity.com/app/" + game.ProviderId),
+                new Link("News", @"http://store.steampowered.com/news/?appids=" + game.ProviderId),
                 new Link("Store", @"http://store.steampowered.com/app/" + game.ProviderId),
                 new Link("Wiki", @"http://pcgamingwiki.com/api/appid.php?appid=" + game.ProviderId)
             };


### PR DESCRIPTION
Games synchronized with Steam now have News links on the left hand side of the details panel.

Relates to #227 