### PR TITLE
Fix: Crashes when GOG metadata download fails

### DIFF
--- a/source/Playnite/Providers/GOG/GogLibrary.cs
+++ b/source/Playnite/Providers/GOG/GogLibrary.cs
@@ -2,7 +2,6 @@
 using NLog;
 using Playnite.Database;
 using Playnite.Models;
-using Playnite.Providers;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -192,6 +191,12 @@ namespace Playnite.Providers.GOG
             }
 
             var metadata = DownloadGameMetadata(game.ProviderId, currentUrl);
+            if(metadata.GameDetails == null)
+            {
+                logger.Warn($"Could not gather metadata for game {0}.", game.Id);
+                return metadata;
+            }
+
             game.Name = metadata.GameDetails.title;
             game.Description = metadata.GameDetails.description.full;
             game.Links = new ObservableCollection<Link>()

--- a/source/Playnite/Providers/GOG/WebApiClient.cs
+++ b/source/Playnite/Providers/GOG/WebApiClient.cs
@@ -1,18 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Threading;
-using CefSharp;
+﻿using CefSharp;
 using CefSharp.Wpf;
 using Newtonsoft.Json;
 using NLog;
 using Playnite.Controls;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Windows;
 
 namespace Playnite.Providers.GOG
 {
@@ -89,7 +85,7 @@ namespace Playnite.Providers.GOG
             }
             catch (WebException exc)
             {
-                logger.Warn(exc, "Failed to download origin game details for " + id);
+                logger.Warn(exc, "Failed to download GOG game details for " + id);
                 return null;
             }
         }


### PR DESCRIPTION
Fix for #237. When a download for GOG metadata fails a `null` is returned from the GOG `WebApiClient.GetGameDetails` method. This `null` works its way up to `UpdateGameWithMetadata` as the `metadata.GameDetails` object. I've added a quick null check before that object is used. If `metadata.GameDetails` is null then the method logs a warning message and bails. 

I also ran a `Remove and Sort Usings` on the files.

Let me know if I need to improve anything, thanks!