### PR TITLE
Force HTTPS for BattleNet login window and Steam private account URLs

### DIFF
--- a/source/Playnite/Providers/BattleNet/WebApiClient.cs
+++ b/source/Playnite/Providers/BattleNet/WebApiClient.cs
@@ -143,7 +143,7 @@ namespace Playnite.Providers.BattleNet
         }
 
         private bool loginSuccess = false;
-        private string loginUrl = "battle.net/account/management/?logout";
+        private string loginUrl = @"https://battle.net/account/management/?logout";
         private string libraryUrl = @"battle.net/account/management/";
 
         LoginWindow loginWindow;

--- a/source/Playnite/Providers/Steam/SteamLibrary.cs
+++ b/source/Playnite/Providers/Steam/SteamLibrary.cs
@@ -154,8 +154,8 @@ namespace Playnite.Providers.Steam
 
         public List<IGame> GetLibraryGames(string userName, string apiKey)
         {
-            var userNameUrl = @"http://api.steampowered.com/ISteamUser/ResolveVanityURL/v0001/?key={0}&vanityurl={1}";
-            var libraryUrl = @"http://api.steampowered.com/IPlayerService/GetOwnedGames/v0001/?key={0}&include_appinfo=1&format=json&steamid={1}";
+            var userNameUrl = @"https://api.steampowered.com/ISteamUser/ResolveVanityURL/v0001/?key={0}&vanityurl={1}";
+            var libraryUrl = @"https://api.steampowered.com/IPlayerService/GetOwnedGames/v0001/?key={0}&include_appinfo=1&format=json&steamid={1}";
 
             ulong userId = 0;
             if (!ulong.TryParse(userName, out userId))


### PR DESCRIPTION
This is necessary for security reasons. 

BattleNet login was easily phishable in an MITM-scenario.

Steam private account requests over HTTP would broadcast apiKey and userName in plain text.