### PR TITLE
Fixed accidental trimming of spaces put into filters

### DIFF
--- a/source/PlayniteUI/Converters/ListToStringConverter.cs
+++ b/source/PlayniteUI/Converters/ListToStringConverter.cs
@@ -30,7 +30,19 @@ namespace PlayniteUI
             }
             else
             {
-                var converted = stringVal.Split(new char[] { ',' }).SkipWhile(a => string.IsNullOrEmpty(a.Trim()));
+                IEnumerable<string> converted;
+
+                if (parameter is string s && s.Equals("true"))
+                {
+                    // don't use final trim()
+                    converted = stringVal.Split(new char[] { ',' }).SkipWhile(a => string.IsNullOrEmpty(a.Trim()));
+                }
+                else
+                {
+                    // use end trim()
+                    converted = stringVal.Split(new char[] { ',' }).SkipWhile(a => string.IsNullOrEmpty(a.Trim())).Select(a => a.Trim());
+                }
+
                 if (targetType == typeof(ComparableList<string>))
                 {
                     return new ComparableList<string>(converted);

--- a/source/PlayniteUI/Converters/ListToStringConverter.cs
+++ b/source/PlayniteUI/Converters/ListToStringConverter.cs
@@ -30,7 +30,7 @@ namespace PlayniteUI
             }
             else
             {
-                var converted = stringVal.Split(new char[] { ',' }).SkipWhile(a => string.IsNullOrEmpty(a.Trim())).Select(a => a.Trim());
+                var converted = stringVal.Split(new char[] { ',' }).SkipWhile(a => string.IsNullOrEmpty(a.Trim()));
                 if (targetType == typeof(ComparableList<string>))
                 {
                     return new ComparableList<string>(converted);

--- a/source/PlayniteUI/Converters/ListToStringConverter.cs
+++ b/source/PlayniteUI/Converters/ListToStringConverter.cs
@@ -32,7 +32,7 @@ namespace PlayniteUI
             {
                 IEnumerable<string> converted;
 
-                if (parameter is string s && s.Equals("true"))
+                if (parameter is string s && s.Equals("NoTrim"))
                 {
                     // don't use final trim()
                     converted = stringVal.Split(new char[] { ',' }).SkipWhile(a => string.IsNullOrEmpty(a.Trim()));

--- a/source/PlayniteUI/Skins/Classic/Classic.xaml
+++ b/source/PlayniteUI/Skins/Classic/Classic.xaml
@@ -943,7 +943,7 @@
                        Foreground="{TemplateBinding Foreground}">
                 <ContentPresenter RecognizesAccessKey="True" Margin="5,0,5,0" ContentSource="Header"/>
             </TextBlock>
-            <TextBlock x:Name="GestureText" Grid.Column="2" Text="{TemplateBinding InputGestureText}"                       
+            <TextBlock x:Name="GestureText" Grid.Column="2" Text="{TemplateBinding InputGestureText}"
                        TextAlignment="Left" HorizontalAlignment="Stretch" Margin="20,5,10,5"
                        VerticalAlignment="Center" Background="Transparent" Opacity="0.6"/>
             <Grid Grid.Column="3" Margin="0,0,5,0">
@@ -2776,7 +2776,7 @@
                                         </Label.Style>
                                     </Label>
                                     <ComboBox Margin="8,0,8,8" Style="{StaticResource TextableComboBox}"
-                                              ItemsSource="{Binding DatabaseFilters.Libraries}"                                              
+                                              ItemsSource="{Binding DatabaseFilters.Libraries}"
                                               Text="{Binding DatabaseFilters.LibrariesString, Mode=OneWay}">
                                         <ComboBox.ItemContainerStyle>
                                             <Style TargetType="ComboBoxItem" BasedOn="{StaticResource {x:Type ComboBoxItem}}">
@@ -2816,7 +2816,7 @@
                                             </Style>
                                         </Label.Style>
                                     </Label>
-                                    <pc:SearchBox x:Name="TextFilterGenre" Text="{Binding AppSettings.FilterSettings.Genres, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}}" Style="{StaticResource FilterTextBox}"/>
+                                    <pc:SearchBox x:Name="TextFilterGenre" Text="{Binding AppSettings.FilterSettings.Genres, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}, ConverterParameter='true'}" Style="{StaticResource FilterTextBox}"/>
 
                                     <Label Content="{DynamicResource LOCPlatformTitle}">
                                         <Label.Style>
@@ -2829,7 +2829,7 @@
                                             </Style>
                                         </Label.Style>
                                     </Label>
-                                    <pc:SearchBox x:Name="TextFilterPlatform" Text="{Binding AppSettings.FilterSettings.Platforms, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}}" Style="{StaticResource FilterTextBox}"/>
+                                    <pc:SearchBox x:Name="TextFilterPlatform" Text="{Binding AppSettings.FilterSettings.Platforms, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}, ConverterParameter='true'}" Style="{StaticResource FilterTextBox}"/>
 
                                     <Label Content="{DynamicResource LOCGameReleaseDateTitle}">
                                         <Label.Style>
@@ -2855,7 +2855,7 @@
                                             </Style>
                                         </Label.Style>
                                     </Label>
-                                    <pc:SearchBox x:Name="TextFilterDeveloper" Text="{Binding AppSettings.FilterSettings.Developers, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}}" Style="{StaticResource FilterTextBox}"/>
+                                    <pc:SearchBox x:Name="TextFilterDeveloper" Text="{Binding AppSettings.FilterSettings.Developers, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}, ConverterParameter='true'}" Style="{StaticResource FilterTextBox}"/>
 
                                     <Label Content="{DynamicResource LOCPublisherLabel}">
                                         <Label.Style>
@@ -2868,7 +2868,7 @@
                                             </Style>
                                         </Label.Style>
                                     </Label>
-                                    <pc:SearchBox x:Name="TextFilterPublisher" Text="{Binding AppSettings.FilterSettings.Publishers, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}}" Style="{StaticResource FilterTextBox}"/>
+                                    <pc:SearchBox x:Name="TextFilterPublisher" Text="{Binding AppSettings.FilterSettings.Publishers, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}, ConverterParameter='true'}" Style="{StaticResource FilterTextBox}"/>
 
                                     <Label Content="{DynamicResource LOCCategoryLabel}">
                                         <Label.Style>
@@ -2881,7 +2881,7 @@
                                             </Style>
                                         </Label.Style>
                                     </Label>
-                                    <pc:SearchBox x:Name="TextFilterCategory" Text="{Binding AppSettings.FilterSettings.Categories, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}}" Style="{StaticResource FilterTextBox}"/>
+                                    <pc:SearchBox x:Name="TextFilterCategory" Text="{Binding AppSettings.FilterSettings.Categories, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}, ConverterParameter='true'}" Style="{StaticResource FilterTextBox}"/>
 
                                     <Label Content="{DynamicResource LOCTagLabel}">
                                         <Label.Style>
@@ -2894,7 +2894,7 @@
                                             </Style>
                                         </Label.Style>
                                     </Label>
-                                    <pc:SearchBox x:Name="TextFilterTag" Text="{Binding AppSettings.FilterSettings.Tags, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}}" Style="{StaticResource FilterTextBox}"/>
+                                    <pc:SearchBox x:Name="TextFilterTag" Text="{Binding AppSettings.FilterSettings.Tags, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}, ConverterParameter='true'}" Style="{StaticResource FilterTextBox}"/>
 
                                     <Label Content="{DynamicResource LOCSeriesLabel}">
                                         <Label.Style>
@@ -2958,7 +2958,7 @@
                             <DockPanel>
                                 <pc:ExtendedListBox SelectionMode="Extended" BorderThickness="0,0,1,0"
                                                     BorderBrush="{DynamicResource NormalBorderBrush}" Width="310"
-                                                    DockPanel.Dock="Left" ScrollViewer.HorizontalScrollBarVisibility="Disabled" 
+                                                    DockPanel.Dock="Left" ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                                                     SelectedItem="{Binding SelectedGame, Mode=TwoWay}"
                                                     SelectedItemsList="{Binding SelectedGamesBinder, Mode=TwoWay}"
                                                     ScrollViewer.PanningMode="VerticalOnly"

--- a/source/PlayniteUI/Skins/Classic/Classic.xaml
+++ b/source/PlayniteUI/Skins/Classic/Classic.xaml
@@ -2816,7 +2816,7 @@
                                             </Style>
                                         </Label.Style>
                                     </Label>
-                                    <pc:SearchBox x:Name="TextFilterGenre" Text="{Binding AppSettings.FilterSettings.Genres, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}, ConverterParameter='true'}" Style="{StaticResource FilterTextBox}"/>
+                                    <pc:SearchBox x:Name="TextFilterGenre" Text="{Binding AppSettings.FilterSettings.Genres, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}, ConverterParameter='NoTrim'}" Style="{StaticResource FilterTextBox}"/>
 
                                     <Label Content="{DynamicResource LOCPlatformTitle}">
                                         <Label.Style>
@@ -2829,7 +2829,7 @@
                                             </Style>
                                         </Label.Style>
                                     </Label>
-                                    <pc:SearchBox x:Name="TextFilterPlatform" Text="{Binding AppSettings.FilterSettings.Platforms, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}, ConverterParameter='true'}" Style="{StaticResource FilterTextBox}"/>
+                                    <pc:SearchBox x:Name="TextFilterPlatform" Text="{Binding AppSettings.FilterSettings.Platforms, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}, ConverterParameter='NoTrim'}" Style="{StaticResource FilterTextBox}"/>
 
                                     <Label Content="{DynamicResource LOCGameReleaseDateTitle}">
                                         <Label.Style>
@@ -2855,7 +2855,7 @@
                                             </Style>
                                         </Label.Style>
                                     </Label>
-                                    <pc:SearchBox x:Name="TextFilterDeveloper" Text="{Binding AppSettings.FilterSettings.Developers, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}, ConverterParameter='true'}" Style="{StaticResource FilterTextBox}"/>
+                                    <pc:SearchBox x:Name="TextFilterDeveloper" Text="{Binding AppSettings.FilterSettings.Developers, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}, ConverterParameter='NoTrim'}" Style="{StaticResource FilterTextBox}"/>
 
                                     <Label Content="{DynamicResource LOCPublisherLabel}">
                                         <Label.Style>
@@ -2868,7 +2868,7 @@
                                             </Style>
                                         </Label.Style>
                                     </Label>
-                                    <pc:SearchBox x:Name="TextFilterPublisher" Text="{Binding AppSettings.FilterSettings.Publishers, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}, ConverterParameter='true'}" Style="{StaticResource FilterTextBox}"/>
+                                    <pc:SearchBox x:Name="TextFilterPublisher" Text="{Binding AppSettings.FilterSettings.Publishers, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}, ConverterParameter='NoTrim'}" Style="{StaticResource FilterTextBox}"/>
 
                                     <Label Content="{DynamicResource LOCCategoryLabel}">
                                         <Label.Style>
@@ -2881,7 +2881,7 @@
                                             </Style>
                                         </Label.Style>
                                     </Label>
-                                    <pc:SearchBox x:Name="TextFilterCategory" Text="{Binding AppSettings.FilterSettings.Categories, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}, ConverterParameter='true'}" Style="{StaticResource FilterTextBox}"/>
+                                    <pc:SearchBox x:Name="TextFilterCategory" Text="{Binding AppSettings.FilterSettings.Categories, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}, ConverterParameter='NoTrim'}" Style="{StaticResource FilterTextBox}"/>
 
                                     <Label Content="{DynamicResource LOCTagLabel}">
                                         <Label.Style>
@@ -2894,7 +2894,7 @@
                                             </Style>
                                         </Label.Style>
                                     </Label>
-                                    <pc:SearchBox x:Name="TextFilterTag" Text="{Binding AppSettings.FilterSettings.Tags, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}, ConverterParameter='true'}" Style="{StaticResource FilterTextBox}"/>
+                                    <pc:SearchBox x:Name="TextFilterTag" Text="{Binding AppSettings.FilterSettings.Tags, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}, ConverterParameter='NoTrim'}" Style="{StaticResource FilterTextBox}"/>
 
                                     <Label Content="{DynamicResource LOCSeriesLabel}">
                                         <Label.Style>

--- a/source/PlayniteUI/Skins/Modern/Modern.xaml
+++ b/source/PlayniteUI/Skins/Modern/Modern.xaml
@@ -2523,7 +2523,7 @@
             </Button.OpacityMask>
         </Button>
     </ControlTemplate>
-    
+
     <ControlTemplate x:Key="NotificationIcon">
         <ToggleButton FontWeight="Bold" DockPanel.Dock="Right" Height="30" Padding="0"
                       WindowChrome.IsHitTestVisibleInChrome="True" BorderThickness="0"
@@ -2758,7 +2758,7 @@
                                 </DataTrigger>
                             </Style.Triggers>
                         </Style>
-                    </pc:ExtendedListBox.Style>                    
+                    </pc:ExtendedListBox.Style>
                     <pc:ExtendedListBox.InputBindings>
                         <KeyBinding Command="{Binding EditSelectedGamesCommand}"
                                 Key ="{Binding EditSelectedGamesCommand.Gesture.Key}"
@@ -3071,7 +3071,7 @@
                             </CheckBox>
 
                             <Border Height="10" />
-                            
+
                             <Label Content="{DynamicResource LOCLibraries}">
                                 <Label.Style>
                                     <Style TargetType="Label" BasedOn="{StaticResource FilterLabel}">
@@ -3084,7 +3084,7 @@
                                 </Label.Style>
                             </Label>
                             <ComboBox TabIndex="5" Margin="8,0,8,8" Style="{StaticResource TextableComboBox}"
-                                      ItemsSource="{Binding DatabaseFilters.Libraries}"                                              
+                                      ItemsSource="{Binding DatabaseFilters.Libraries}"
                                       Text="{Binding DatabaseFilters.LibrariesString, Mode=OneWay}">
                                 <ComboBox.ItemContainerStyle>
                                     <Style TargetType="ComboBoxItem" BasedOn="{StaticResource {x:Type ComboBoxItem}}">
@@ -3126,7 +3126,7 @@
                                     </Style>
                                 </Label.Style>
                             </Label>
-                            <pc:SearchBox TabIndex="7" x:Name="TextFilterGenre" Text="{Binding AppSettings.FilterSettings.Genres, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}}" Style="{StaticResource FilterTextBox}"/>
+                            <pc:SearchBox TabIndex="7" x:Name="TextFilterGenre" Text="{Binding AppSettings.FilterSettings.Genres, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}, ConverterParameter='true'}" Style="{StaticResource FilterTextBox}"/>
 
                             <Label Content="{DynamicResource LOCPlatformTitle}">
                                 <Label.Style>
@@ -3139,7 +3139,7 @@
                                     </Style>
                                 </Label.Style>
                             </Label>
-                            <pc:SearchBox TabIndex="8" x:Name="TextFilterPlatform" Text="{Binding AppSettings.FilterSettings.Platforms, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}}" Style="{StaticResource FilterTextBox}"/>
+                            <pc:SearchBox TabIndex="8" x:Name="TextFilterPlatform" Text="{Binding AppSettings.FilterSettings.Platforms, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}, ConverterParameter='true'}" Style="{StaticResource FilterTextBox}"/>
 
                             <Label Content="{DynamicResource LOCGameReleaseDateTitle}">
                                 <Label.Style>
@@ -3165,7 +3165,7 @@
                                     </Style>
                                 </Label.Style>
                             </Label>
-                            <pc:SearchBox TabIndex="10" x:Name="TextFilterDeveloper" Text="{Binding AppSettings.FilterSettings.Developers, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}}" Style="{StaticResource FilterTextBox}"/>
+                            <pc:SearchBox TabIndex="10" x:Name="TextFilterDeveloper" Text="{Binding AppSettings.FilterSettings.Developers, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}, ConverterParameter='true'}" Style="{StaticResource FilterTextBox}"/>
 
                             <Label Content="{DynamicResource LOCPublisherLabel}">
                                 <Label.Style>
@@ -3178,7 +3178,7 @@
                                     </Style>
                                 </Label.Style>
                             </Label>
-                            <pc:SearchBox TabIndex="11" x:Name="TextFilterPublisher" Text="{Binding AppSettings.FilterSettings.Publishers, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}}" Style="{StaticResource FilterTextBox}"/>
+                            <pc:SearchBox TabIndex="11" x:Name="TextFilterPublisher" Text="{Binding AppSettings.FilterSettings.Publishers, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}, ConverterParameter='true'}" Style="{StaticResource FilterTextBox}"/>
 
                             <Label Content="{DynamicResource LOCCategoryLabel}">
                                 <Label.Style>
@@ -3191,7 +3191,7 @@
                                     </Style>
                                 </Label.Style>
                             </Label>
-                            <pc:SearchBox TabIndex="12" x:Name="TextFilterCategory" Text="{Binding AppSettings.FilterSettings.Categories, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}}" Style="{StaticResource FilterTextBox}"/>
+                            <pc:SearchBox TabIndex="12" x:Name="TextFilterCategory" Text="{Binding AppSettings.FilterSettings.Categories, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}, ConverterParameter='true'}" Style="{StaticResource FilterTextBox}"/>
 
                             <Label Content="{DynamicResource LOCTagLabel}">
                                 <Label.Style>
@@ -3204,7 +3204,7 @@
                                     </Style>
                                 </Label.Style>
                             </Label>
-                            <pc:SearchBox TabIndex="13" x:Name="TextFilterTag" Text="{Binding AppSettings.FilterSettings.Tags, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}}" Style="{StaticResource FilterTextBox}"/>
+                            <pc:SearchBox TabIndex="13" x:Name="TextFilterTag" Text="{Binding AppSettings.FilterSettings.Tags, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}, ConverterParameter='true'}" Style="{StaticResource FilterTextBox}"/>
                             <Label Content="{DynamicResource LOCSeriesLabel}">
                                 <Label.Style>
                                     <Style TargetType="Label" BasedOn="{StaticResource FilterLabel}">
@@ -3294,12 +3294,12 @@
                                         Visibility="{Binding IsTabStop, RelativeSource={RelativeSource Self}, Converter={StaticResource InvertedBooleanToVisibilityConverter}}"/>
                     </Border>
 
-                    <ContentControl Template="{StaticResource SteamFriendsIcon}" Margin="0,0,130,0" 
+                    <ContentControl Template="{StaticResource SteamFriendsIcon}" Margin="0,0,130,0"
                                     HorizontalAlignment="Right" DockPanel.Dock="Right"/>
 
                     <ContentControl Template="{StaticResource NotificationIcon}" Margin="0,0,20,0"
                                     HorizontalAlignment="Right" DockPanel.Dock="Right"/>
-                    
+
                     <ContentControl Template="{StaticResource ProgressView}" Margin="20,0,30,0"
                                     HorizontalAlignment="Stretch" DockPanel.Dock="Left" />
                 </DockPanel>
@@ -3388,7 +3388,7 @@
                                                                   Grid.Column="0"
                                                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                                                   Margin="{TemplateBinding Padding}" RecognizesAccessKey="True" />
-                                                <TextBlock x:Name="ShortcutText" Text="{TemplateBinding Tag}"                                                           
+                                                <TextBlock x:Name="ShortcutText" Text="{TemplateBinding Tag}"
                                                            Grid.Column="1" Margin="30,0,0,0" Opacity="0.6"
                                                            VerticalAlignment="Center"/>
                                             </Grid>
@@ -3583,7 +3583,7 @@
                                     Tag="{Binding DownloadMetadataCommand.GestureText}"/>
 
                             <Canvas Margin="0,35,0,0" />
-                            
+
                             <Button Content="{DynamicResource LOCReloadScripts}"
                                     Command="{Binding ReloadScriptsCommand}"
                                     Tag="{Binding ReloadScriptsCommand.GestureText}"/>

--- a/source/PlayniteUI/Skins/Modern/Modern.xaml
+++ b/source/PlayniteUI/Skins/Modern/Modern.xaml
@@ -3126,7 +3126,7 @@
                                     </Style>
                                 </Label.Style>
                             </Label>
-                            <pc:SearchBox TabIndex="7" x:Name="TextFilterGenre" Text="{Binding AppSettings.FilterSettings.Genres, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}, ConverterParameter='true'}" Style="{StaticResource FilterTextBox}"/>
+                            <pc:SearchBox TabIndex="7" x:Name="TextFilterGenre" Text="{Binding AppSettings.FilterSettings.Genres, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}, ConverterParameter='NoTrim'}" Style="{StaticResource FilterTextBox}"/>
 
                             <Label Content="{DynamicResource LOCPlatformTitle}">
                                 <Label.Style>
@@ -3139,7 +3139,7 @@
                                     </Style>
                                 </Label.Style>
                             </Label>
-                            <pc:SearchBox TabIndex="8" x:Name="TextFilterPlatform" Text="{Binding AppSettings.FilterSettings.Platforms, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}, ConverterParameter='true'}" Style="{StaticResource FilterTextBox}"/>
+                            <pc:SearchBox TabIndex="8" x:Name="TextFilterPlatform" Text="{Binding AppSettings.FilterSettings.Platforms, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}, ConverterParameter='NoTrim'}" Style="{StaticResource FilterTextBox}"/>
 
                             <Label Content="{DynamicResource LOCGameReleaseDateTitle}">
                                 <Label.Style>
@@ -3165,7 +3165,7 @@
                                     </Style>
                                 </Label.Style>
                             </Label>
-                            <pc:SearchBox TabIndex="10" x:Name="TextFilterDeveloper" Text="{Binding AppSettings.FilterSettings.Developers, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}, ConverterParameter='true'}" Style="{StaticResource FilterTextBox}"/>
+                            <pc:SearchBox TabIndex="10" x:Name="TextFilterDeveloper" Text="{Binding AppSettings.FilterSettings.Developers, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}, ConverterParameter='NoTrim'}" Style="{StaticResource FilterTextBox}"/>
 
                             <Label Content="{DynamicResource LOCPublisherLabel}">
                                 <Label.Style>
@@ -3178,7 +3178,7 @@
                                     </Style>
                                 </Label.Style>
                             </Label>
-                            <pc:SearchBox TabIndex="11" x:Name="TextFilterPublisher" Text="{Binding AppSettings.FilterSettings.Publishers, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}, ConverterParameter='true'}" Style="{StaticResource FilterTextBox}"/>
+                            <pc:SearchBox TabIndex="11" x:Name="TextFilterPublisher" Text="{Binding AppSettings.FilterSettings.Publishers, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}, ConverterParameter='NoTrim'}" Style="{StaticResource FilterTextBox}"/>
 
                             <Label Content="{DynamicResource LOCCategoryLabel}">
                                 <Label.Style>
@@ -3191,7 +3191,7 @@
                                     </Style>
                                 </Label.Style>
                             </Label>
-                            <pc:SearchBox TabIndex="12" x:Name="TextFilterCategory" Text="{Binding AppSettings.FilterSettings.Categories, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}, ConverterParameter='true'}" Style="{StaticResource FilterTextBox}"/>
+                            <pc:SearchBox TabIndex="12" x:Name="TextFilterCategory" Text="{Binding AppSettings.FilterSettings.Categories, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}, ConverterParameter='NoTrim'}" Style="{StaticResource FilterTextBox}"/>
 
                             <Label Content="{DynamicResource LOCTagLabel}">
                                 <Label.Style>
@@ -3204,7 +3204,7 @@
                                     </Style>
                                 </Label.Style>
                             </Label>
-                            <pc:SearchBox TabIndex="13" x:Name="TextFilterTag" Text="{Binding AppSettings.FilterSettings.Tags, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}, ConverterParameter='true'}" Style="{StaticResource FilterTextBox}"/>
+                            <pc:SearchBox TabIndex="13" x:Name="TextFilterTag" Text="{Binding AppSettings.FilterSettings.Tags, Delay=100, Mode=TwoWay, Converter={StaticResource ListToStringConverter}, ConverterParameter='NoTrim'}" Style="{StaticResource FilterTextBox}"/>
                             <Label Content="{DynamicResource LOCSeriesLabel}">
                                 <Label.Style>
                                     <Style TargetType="Label" BasedOn="{StaticResource FilterLabel}">


### PR DESCRIPTION
Fixed issue ( #782 ) where trailing space was deleted automatically preventing the entering of filters that contain whitespace (e.g. a Category named "To Be Completed")