### PR TITLE
Add support for Source mods in Steam (issue #769)

### DIFF
--- a/source/Plugins/SteamLibrary.Tests/SteamLibraryTests.cs
+++ b/source/Plugins/SteamLibrary.Tests/SteamLibraryTests.cs
@@ -68,7 +68,7 @@ namespace SteamLibrary.Tests
         {
             var steamLib = CreateLibrary();
             var games = steamLib.GetInstalledGames();
-            var state = Steam.GetAppState(int.Parse(games.Values.First().GameId));
+            var state = Steam.GetAppState(ulong.Parse(games.Values.First().GameId));
             Assert.IsTrue(state.Installed);
         }
     }

--- a/source/Plugins/SteamLibrary.Tests/SteamLibraryTests.cs
+++ b/source/Plugins/SteamLibrary.Tests/SteamLibraryTests.cs
@@ -9,6 +9,7 @@ using Moq;
 using Playnite.SDK;
 using Playnite.SDK.Models;
 using Playnite.SDK.Plugins;
+using SteamKit2;
 
 namespace SteamLibrary.Tests
 {
@@ -68,7 +69,7 @@ namespace SteamLibrary.Tests
         {
             var steamLib = CreateLibrary();
             var games = steamLib.GetInstalledGames();
-            var state = Steam.GetAppState(ulong.Parse(games.Values.First().GameId));
+            var state = Steam.GetAppState(games.Values.First().ToSteamGameID());
             Assert.IsTrue(state.Installed);
         }
     }

--- a/source/Plugins/SteamLibrary/GameExtension.cs
+++ b/source/Plugins/SteamLibrary/GameExtension.cs
@@ -1,0 +1,13 @@
+﻿using Playnite.SDK.Models;
+using SteamKit2;
+
+namespace SteamLibrary
+{
+    internal static class GameExtension
+    {
+        public static GameID ToSteamGameID(this Game game)
+        {
+            return new GameID(ulong.Parse(game.GameId));
+        }
+    }
+}

--- a/source/Plugins/SteamLibrary/ModInfo.cs
+++ b/source/Plugins/SteamLibrary/ModInfo.cs
@@ -44,9 +44,10 @@ namespace SteamLibrary
             }
         }
 
-        private ModInfo(ModType type)
+        private ModInfo(ModType type, string installFolder)
         {
             modType = type;
+            InstallFolder = installFolder;
             Name = "Unknown Mod";
             Links = new ObservableCollection<Link>();
             GameId = new GameID();
@@ -103,9 +104,7 @@ namespace SteamLibrary
                 return null;
             }
 
-            ModInfo modInfo = new ModInfo(modType);
-            modInfo.InstallFolder = path;
-
+            ModInfo modInfo = new ModInfo(modType, path);
             if (modType == ModType.HL)
             {
                 modInfo.GameId.AppID = halfLife;
@@ -165,7 +164,7 @@ namespace SteamLibrary
                 modInfo.Categories.Add("Multi-Player");
             }
 
-            modInfo.IconPath = FindIcon(path, gameInfo["icon"] == KeyValue.Invalid ? null : gameInfo["icon"].Value);
+            modInfo.IconPath = FindIcon(modInfo.InstallFolder, gameInfo["icon"] == KeyValue.Invalid ? null : gameInfo["icon"].Value);
         }
 
         static private void PopulateModInfoFromLibList(ref ModInfo modInfo, string path)
@@ -225,7 +224,7 @@ namespace SteamLibrary
                     modInfo.Categories.Add("Multi-Player");
                 }
 
-                modInfo.IconPath = FindIcon(path, icon);
+                modInfo.IconPath = FindIcon(modInfo.InstallFolder, icon);
             }
         }
 
@@ -236,10 +235,10 @@ namespace SteamLibrary
 
         static private string FindIcon(string modPath, string rawIconPath)
         {
-            rawIconPath = rawIconPath.Replace('/', Path.DirectorySeparatorChar);
-
             if (rawIconPath != null)
             {
+                rawIconPath = rawIconPath.Replace('/', Path.DirectorySeparatorChar);
+
                 // Gameinfo specifies an icon path. This is what Steam would use for all mod types, so try to do the same
                 var steamTgaBig = Path.Combine(modPath, rawIconPath) + "_big.tga";
                 if (File.Exists(steamTgaBig))

--- a/source/Plugins/SteamLibrary/ModInfo.cs
+++ b/source/Plugins/SteamLibrary/ModInfo.cs
@@ -1,0 +1,218 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+using Playnite.SDK.Models;
+using SteamKit2;
+
+namespace SteamLibrary
+{
+    internal class ModInfo
+    {
+        public enum ModType
+        {
+            HL,
+            HL2,
+        }
+
+        public string name { get; private set; }
+        public GameID gameId { get; private set; }
+        public string installFolder { get; private set; }
+        public ComparableList<string> categories { get; private set; }
+        public string developer { get; private set; }
+        public ObservableCollection<Link> links { get; private set; }
+        private readonly ModType modType;
+
+        static private Dictionary<ModType, string> infoFileName = new Dictionary<ModType, string>()
+        {
+            { ModType.HL, "liblist.gam"},
+            { ModType.HL2, "gameinfo.txt"}
+        };
+
+        // HL mods all use Half-Life as the base app. HL2 mods are split across multiple
+        // SDK base apps. This will be our differentiator
+        static private readonly uint halfLife = 70;
+
+        public bool IsInstalled
+        {
+            get
+            {
+                return File.Exists(Path.Combine(installFolder, infoFileName[modType]));
+            }
+        }
+
+        private ModInfo(ModType type)
+        {
+            modType = type;
+            name = "Unknown Mod";
+            links = new ObservableCollection<Link>();
+            gameId = new GameID();
+            developer = "Unknown";
+            categories = new ComparableList<string>();
+        }
+
+        static public ModInfo GetFromGameID(GameID gameID)
+        {
+            if (!gameID.IsMod)
+            {
+                return null;
+            }
+
+            if (gameID.AppID == halfLife && !string.IsNullOrEmpty(Steam.ModInstallPath))
+            {
+                var dirInfo = new DirectoryInfo(Steam.ModInstallPath);
+
+                foreach (var folder in dirInfo.GetDirectories())
+                {
+                    if (GetModFolderCRC(folder.Name) == gameID.ModID)
+                    {
+                        return GetFromFolder(folder.FullName, ModType.HL);
+                    }
+                }
+            }
+            else if (gameID.AppID != halfLife && !string.IsNullOrEmpty(Steam.SourceModInstallPath))
+            {
+                var dirInfo = new DirectoryInfo(Steam.SourceModInstallPath);
+
+                foreach (var folder in dirInfo.GetDirectories())
+                {
+                    if (GetModFolderCRC(folder.Name) == gameID.ModID)
+                    {
+                        return GetFromFolder(folder.FullName, ModType.HL2);
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        static public ModInfo GetFromFolder(string path, ModType modType)
+        {
+            if (!Directory.Exists(path))
+            {
+                return null;
+            }
+
+            var dirInfo = new DirectoryInfo(path);
+            var gameInfoPath = Path.Combine(path, infoFileName[modType]);
+            if (!File.Exists(gameInfoPath))
+            {
+                return null;
+            }
+
+            ModInfo modInfo = new ModInfo(modType);
+            modInfo.installFolder = path;
+
+            if (modType == ModType.HL)
+            {
+                modInfo.gameId.AppID = halfLife;
+                PopulateModInfoFromLibList(ref modInfo, gameInfoPath);
+            }
+            else
+            {
+                PopulateModInfoFromGameInfo(ref modInfo, gameInfoPath);
+            }
+
+            modInfo.gameId.AppType = GameID.GameType.GameMod;
+            modInfo.gameId.ModID = GetModFolderCRC(dirInfo.Name);
+
+            return modInfo;
+        }
+
+        static private uint GetModFolderCRC(string folder)
+        {
+            uint crc = BitConverter.ToUInt32(CryptoHelper.CRCHash(Encoding.ASCII.GetBytes(folder)), 0);
+
+            // For mods and shortcut game IDs, the high bit is always set. SteamKit doesn't do this automatically (yet).
+            crc |= 0x80000000;
+
+            return crc;
+        }
+
+        static private void PopulateModInfoFromGameInfo(ref ModInfo modInfo, string path)
+        {
+            var gameInfo = new KeyValue();
+            gameInfo.ReadFileAsText(path);
+
+            modInfo.gameId.AppID = gameInfo["FileSystem"]["SteamAppId"].AsUnsignedInteger();
+            modInfo.name = gameInfo["game"].Value;
+
+            if (gameInfo["developer"] != KeyValue.Invalid)
+            {
+                modInfo.developer = gameInfo["developer"].Value;
+            }
+
+            if (gameInfo["manual"] != KeyValue.Invalid)
+            {
+                modInfo.links.Add(new Link("Manual", gameInfo["manual"].Value));
+            }
+
+            if (gameInfo["developer_url"] != KeyValue.Invalid)
+            {
+                modInfo.links.Add(new Link("Developer URL", gameInfo["developer_url"].Value));
+            }
+
+            if (gameInfo["type"] == KeyValue.Invalid || gameInfo["type"].Value == "singleplayer_only")
+            {
+                modInfo.categories.Add("Single-Player");
+            }
+
+            if (gameInfo["type"] == KeyValue.Invalid || gameInfo["type"].Value == "multiplayer_only")
+            {
+                modInfo.categories.Add("Multi-Player");
+            }
+        }
+
+        static private void PopulateModInfoFromLibList(ref ModInfo modInfo, string path)
+        {
+            using (var reader = new StreamReader(path))
+            {
+                string type = null;
+
+                var pattern = new Regex("\\s*(\\w+)\\s+\"([^\"]*)\".*", RegexOptions.Singleline);
+
+                string line;
+                while ((line = reader.ReadLine()) != null)
+                {
+                    var match = pattern.Match(line);
+                    if (match.Success)
+                    {
+                        if (match.Groups[1].Value == "game")
+                        {
+                            modInfo.name = match.Groups[2].Value;
+                        }
+                        else if (match.Groups[1].Value == "manual")
+                        {
+                            modInfo.links.Add(new Link("Manual", match.Groups[2].Value));
+                        }
+                        else if (match.Groups[1].Value == "developer_url")
+                        {
+                            modInfo.links.Add(new Link("Developer URL", match.Groups[2].Value));
+                        }
+                        else if (match.Groups[1].Value == "type")
+                        {
+                            type = match.Groups[2].Value;
+                        }
+                    }
+                }
+
+                if (type == null || type == "singleplayer_only")
+                {
+                    modInfo.categories.Add("Single-Player");
+                }
+
+                if (type == null || type == "multiplayer_only")
+                {
+                    modInfo.categories.Add("Multi-Player");
+                }
+            }
+        }
+
+        static public ModType GetModTypeOfGameID(GameID gameId)
+        {
+            return gameId.AppID == halfLife ? ModType.HL : ModType.HL2;
+        }
+    }
+}

--- a/source/Plugins/SteamLibrary/ModInfo.cs
+++ b/source/Plugins/SteamLibrary/ModInfo.cs
@@ -195,6 +195,16 @@ namespace SteamLibrary
                         {
                             type = match.Groups[2].Value;
                         }
+                        // These ones don't display in the Steam client (anymore?), but many
+                        // mods seem to have them.
+                        else if (match.Groups[1].Value == "url_info")
+                        {
+                            modInfo.links.Add(new Link("Info", match.Groups[2].Value));
+                        }
+                        else if (match.Groups[1].Value == "url_dl")
+                        {
+                            modInfo.links.Add(new Link("Download", match.Groups[2].Value));
+                        }
                     }
                 }
 

--- a/source/Plugins/SteamLibrary/ModInfo.cs
+++ b/source/Plugins/SteamLibrary/ModInfo.cs
@@ -17,12 +17,12 @@ namespace SteamLibrary
             HL2,
         }
 
-        public string name { get; private set; }
-        public GameID gameId { get; private set; }
-        public string installFolder { get; private set; }
-        public ComparableList<string> categories { get; private set; }
-        public string developer { get; private set; }
-        public ObservableCollection<Link> links { get; private set; }
+        public string Name { get; private set; }
+        public GameID GameId { get; private set; }
+        public string InstallFolder { get; private set; }
+        public ComparableList<string> Categories { get; private set; }
+        public string Developer { get; private set; }
+        public ObservableCollection<Link> Links { get; private set; }
         private readonly ModType modType;
 
         static private Dictionary<ModType, string> infoFileName = new Dictionary<ModType, string>()
@@ -39,18 +39,18 @@ namespace SteamLibrary
         {
             get
             {
-                return File.Exists(Path.Combine(installFolder, infoFileName[modType]));
+                return File.Exists(Path.Combine(InstallFolder, infoFileName[modType]));
             }
         }
 
         private ModInfo(ModType type)
         {
             modType = type;
-            name = "Unknown Mod";
-            links = new ObservableCollection<Link>();
-            gameId = new GameID();
-            developer = "Unknown";
-            categories = new ComparableList<string>();
+            Name = "Unknown Mod";
+            Links = new ObservableCollection<Link>();
+            GameId = new GameID();
+            Developer = "Unknown";
+            Categories = new ComparableList<string>();
         }
 
         static public ModInfo GetFromGameID(GameID gameID)
@@ -103,11 +103,11 @@ namespace SteamLibrary
             }
 
             ModInfo modInfo = new ModInfo(modType);
-            modInfo.installFolder = path;
+            modInfo.InstallFolder = path;
 
             if (modType == ModType.HL)
             {
-                modInfo.gameId.AppID = halfLife;
+                modInfo.GameId.AppID = halfLife;
                 PopulateModInfoFromLibList(ref modInfo, gameInfoPath);
             }
             else
@@ -115,8 +115,8 @@ namespace SteamLibrary
                 PopulateModInfoFromGameInfo(ref modInfo, gameInfoPath);
             }
 
-            modInfo.gameId.AppType = GameID.GameType.GameMod;
-            modInfo.gameId.ModID = GetModFolderCRC(dirInfo.Name);
+            modInfo.GameId.AppType = GameID.GameType.GameMod;
+            modInfo.GameId.ModID = GetModFolderCRC(dirInfo.Name);
 
             return modInfo;
         }
@@ -136,32 +136,32 @@ namespace SteamLibrary
             var gameInfo = new KeyValue();
             gameInfo.ReadFileAsText(path);
 
-            modInfo.gameId.AppID = gameInfo["FileSystem"]["SteamAppId"].AsUnsignedInteger();
-            modInfo.name = gameInfo["game"].Value;
+            modInfo.GameId.AppID = gameInfo["FileSystem"]["SteamAppId"].AsUnsignedInteger();
+            modInfo.Name = gameInfo["game"].Value;
 
             if (gameInfo["developer"] != KeyValue.Invalid)
             {
-                modInfo.developer = gameInfo["developer"].Value;
+                modInfo.Developer = gameInfo["developer"].Value;
             }
 
             if (gameInfo["manual"] != KeyValue.Invalid)
             {
-                modInfo.links.Add(new Link("Manual", gameInfo["manual"].Value));
+                modInfo.Links.Add(new Link("Manual", gameInfo["manual"].Value));
             }
 
             if (gameInfo["developer_url"] != KeyValue.Invalid)
             {
-                modInfo.links.Add(new Link("Developer URL", gameInfo["developer_url"].Value));
+                modInfo.Links.Add(new Link("Developer URL", gameInfo["developer_url"].Value));
             }
 
             if (gameInfo["type"] == KeyValue.Invalid || gameInfo["type"].Value == "singleplayer_only")
             {
-                modInfo.categories.Add("Single-Player");
+                modInfo.Categories.Add("Single-Player");
             }
 
             if (gameInfo["type"] == KeyValue.Invalid || gameInfo["type"].Value == "multiplayer_only")
             {
-                modInfo.categories.Add("Multi-Player");
+                modInfo.Categories.Add("Multi-Player");
             }
         }
 
@@ -181,15 +181,15 @@ namespace SteamLibrary
                     {
                         if (match.Groups[1].Value == "game")
                         {
-                            modInfo.name = match.Groups[2].Value;
+                            modInfo.Name = match.Groups[2].Value;
                         }
                         else if (match.Groups[1].Value == "manual")
                         {
-                            modInfo.links.Add(new Link("Manual", match.Groups[2].Value));
+                            modInfo.Links.Add(new Link("Manual", match.Groups[2].Value));
                         }
                         else if (match.Groups[1].Value == "developer_url")
                         {
-                            modInfo.links.Add(new Link("Developer URL", match.Groups[2].Value));
+                            modInfo.Links.Add(new Link("Developer URL", match.Groups[2].Value));
                         }
                         else if (match.Groups[1].Value == "type")
                         {
@@ -199,23 +199,23 @@ namespace SteamLibrary
                         // mods seem to have them.
                         else if (match.Groups[1].Value == "url_info")
                         {
-                            modInfo.links.Add(new Link("Info", match.Groups[2].Value));
+                            modInfo.Links.Add(new Link("Info", match.Groups[2].Value));
                         }
                         else if (match.Groups[1].Value == "url_dl")
                         {
-                            modInfo.links.Add(new Link("Download", match.Groups[2].Value));
+                            modInfo.Links.Add(new Link("Download", match.Groups[2].Value));
                         }
                     }
                 }
 
                 if (type == null || type == "singleplayer_only")
                 {
-                    modInfo.categories.Add("Single-Player");
+                    modInfo.Categories.Add("Single-Player");
                 }
 
                 if (type == null || type == "multiplayer_only")
                 {
-                    modInfo.categories.Add("Multi-Player");
+                    modInfo.Categories.Add("Multi-Player");
                 }
             }
         }

--- a/source/Plugins/SteamLibrary/Services/SteamServicesClient.cs
+++ b/source/Plugins/SteamLibrary/Services/SteamServicesClient.cs
@@ -24,24 +24,24 @@ namespace SteamLibrary.Services
         {
         }
 
-        public void PostSteamAppInfoData(int appId, string data)
+        public void PostSteamAppInfoData(uint appId, string data)
         {
             var content = new StringContent(data, Encoding.UTF8, "text/plain");
             httpClient.PostAsync(Endpoint + $"/api/steam/appinfo/{appId}", content).Wait();
         }
 
-        public string GetSteamAppInfoData(int appId)
+        public string GetSteamAppInfoData(uint appId)
         {
             return ExecuteGetRequest<string>($"/api/steam/appinfo/{appId}");
         }
 
-        public void PostSteamStoreData(int appId, string data)
+        public void PostSteamStoreData(uint appId, string data)
         {
             var content = new StringContent(data, Encoding.UTF8, "text/plain");
             httpClient.PostAsync(Endpoint + $"/api/steam/store/{appId}", content).Wait();
         }
 
-        public string GetSteamStoreData(int appId)
+        public string GetSteamStoreData(uint appId)
         {
             return ExecuteGetRequest<string>($"/api/steam/store/{appId}");
         }

--- a/source/Plugins/SteamLibrary/Services/WebApiClient.cs
+++ b/source/Plugins/SteamLibrary/Services/WebApiClient.cs
@@ -12,20 +12,20 @@ namespace SteamLibrary.Services
 {
     public class WebApiClient
     {
-        public static StoreAppDetailsResult ParseStoreData(int appId, string data)
+        public static StoreAppDetailsResult ParseStoreData(uint appId, string data)
         {
             var parsedData = JsonConvert.DeserializeObject<Dictionary<string, StoreAppDetailsResult>>(data);
             return parsedData[appId.ToString()];
         }
 
-        public static string GetRawStoreAppDetail(int appId)
+        public static string GetRawStoreAppDetail(uint appId)
         {
             var url = @"http://store.steampowered.com/api/appdetails?appids={0}";
             url = string.Format(url, appId);
             return HttpDownloader.DownloadString(url);
         }
 
-        public static StoreAppDetailsResult.AppDetails GetStoreAppDetail(int appId)
+        public static StoreAppDetailsResult.AppDetails GetStoreAppDetail(uint appId)
         {
             var data = GetRawStoreAppDetail(appId);
             var response = ParseStoreData(appId, data);

--- a/source/Plugins/SteamLibrary/Steam.cs
+++ b/source/Plugins/SteamLibrary/Steam.cs
@@ -136,7 +136,7 @@ namespace SteamLibrary
                         foreach (var folder in Directory.GetDirectories(Steam.ModInstallPath))
                         {
                             var modInfo = ModInfo.GetFromFolder(folder, ModInfo.ModType.HL);
-                            if (modInfo?.gameId == id)
+                            if (modInfo?.GameId == id)
                             {
                                 foundMod = true;
                                 break;
@@ -152,7 +152,7 @@ namespace SteamLibrary
                         foreach (var folder in Directory.GetDirectories(Steam.SourceModInstallPath))
                         {
                             var modInfo = ModInfo.GetFromFolder(folder, ModInfo.ModType.HL2);
-                            if (modInfo?.gameId == id)
+                            if (modInfo?.GameId == id)
                             {
                                 foundMod = true;
                                 break;

--- a/source/Plugins/SteamLibrary/Steam.cs
+++ b/source/Plugins/SteamLibrary/Steam.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using SteamKit2;
 
 namespace SteamLibrary
 {
@@ -56,15 +57,15 @@ namespace SteamLibrary
             }
         }
 
-        public static string GetWorkshopUrl(int appId)
+        public static string GetWorkshopUrl(uint appId)
         {
             return $"http://steamcommunity.com/app/{appId}/workshop/";
         }
 
-        public static GameState GetAppState(int id)
+        public static GameState GetAppState(GameID id)
         {
             var state = new GameState();
-            var rootString = @"Software\Valve\Steam\Apps\" + id.ToString();
+            var rootString = @"Software\Valve\Steam\Apps\" + id.AppID.ToString();
             var root = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Default);
             var appKey = root.OpenSubKey(rootString);
             if (appKey != null)

--- a/source/Plugins/SteamLibrary/Steam.cs
+++ b/source/Plugins/SteamLibrary/Steam.cs
@@ -42,6 +42,22 @@ namespace SteamLibrary
             }
         }
 
+        public static string SourceModInstallPath
+        {
+            get
+            {
+                using (var key = Registry.CurrentUser.OpenSubKey(@"Software\Valve\Steam"))
+                {
+                    if (key != null)
+                    {
+                        return key.GetValue("SourceModInstallPath")?.ToString().Replace('/', '\\') ?? string.Empty;
+                    }
+                }
+
+                return string.Empty;
+            }
+        }
+
         public static bool IsInstalled
         {
             get

--- a/source/Plugins/SteamLibrary/SteamGameController.cs
+++ b/source/Plugins/SteamLibrary/SteamGameController.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using SteamKit2;
 
 namespace SteamLibrary
 {
@@ -34,7 +35,7 @@ namespace SteamLibrary
         {
             ReleaseResources();
             OnStarting(this, new GameControllerEventArgs(this, 0));
-            ProcessStarter.StartUrl($"steam://run/{Game.GameId}");
+            ProcessStarter.StartUrl($"steam://rungameid/{Game.GameId}");
             StartRunningWatcher();
         }
 
@@ -58,7 +59,7 @@ namespace SteamLibrary
             await Task.Run(async () =>
             {
                 var stopWatch = Stopwatch.StartNew();
-                var id = int.Parse(Game.GameId);
+                var id = new GameID(ulong.Parse(Game.GameId));
 
                 while (true)
                 {
@@ -72,7 +73,7 @@ namespace SteamLibrary
                     {
                         if (Game.PlayAction == null)
                         {
-                            Game.PlayAction = SteamLibrary.CreatePlayTask(int.Parse(Game.GameId));
+                            Game.PlayAction = SteamLibrary.CreatePlayTask(ulong.Parse(Game.GameId));
                         }
 
                         stopWatch.Stop();
@@ -91,7 +92,7 @@ namespace SteamLibrary
             await Task.Run(async () =>
             {
                 var stopWatch = Stopwatch.StartNew();
-                var id = int.Parse(Game.GameId);
+                var id = new GameID(ulong.Parse(Game.GameId));
 
                 while (true)
                 {
@@ -119,7 +120,7 @@ namespace SteamLibrary
             await Task.Run(async () =>
             {
                 var stopWatch = Stopwatch.StartNew();
-                var id = int.Parse(Game.GameId);
+                var id = new GameID(ulong.Parse(Game.GameId));
                 var gameState = Steam.GetAppState(id);
 
                 while (true)

--- a/source/Plugins/SteamLibrary/SteamGameController.cs
+++ b/source/Plugins/SteamLibrary/SteamGameController.cs
@@ -16,9 +16,13 @@ namespace SteamLibrary
     public class SteamGameController : BaseGameController
     {
         private CancellationTokenSource watcherToken;
+        private GameID gameId;
+        private IPlayniteAPI api;
 
-        public SteamGameController(Game game) : base(game)
+        public SteamGameController(Game game, IPlayniteAPI playniteApi) : base(game)
         {
+            gameId = ulong.Parse(game.GameId);
+            api = playniteApi;
         }
 
         public override void Dispose()
@@ -41,16 +45,30 @@ namespace SteamLibrary
 
         public override void Install()
         {
-            ReleaseResources();
-            ProcessStarter.StartUrl($"steam://install/{Game.GameId}");
-            StartInstallWatcher();
+            if (gameId.IsMod)
+            {
+                api.Dialogs.ShowErrorMessage("Mods cannot be installed via Playnite.", "Error");
+            }
+            else
+            {
+                ReleaseResources();
+                ProcessStarter.StartUrl($"steam://install/{gameId.AppID}");
+                StartInstallWatcher();
+            }
         }
 
         public override void Uninstall()
         {
-            ReleaseResources();
-            ProcessStarter.StartUrl($"steam://uninstall/{Game.GameId}");
-            StartUninstallWatcher();
+            if (gameId.IsMod)
+            {
+                api.Dialogs.ShowErrorMessage("Mods cannot be uninstalled via Playnite.", "Error");
+            }
+            else
+            {
+                ReleaseResources();
+                ProcessStarter.StartUrl($"steam://uninstall/{gameId.AppID}");
+                StartUninstallWatcher();
+            }
         }
 
         public async void StartInstallWatcher()

--- a/source/Plugins/SteamLibrary/SteamGameController.cs
+++ b/source/Plugins/SteamLibrary/SteamGameController.cs
@@ -17,12 +17,10 @@ namespace SteamLibrary
     {
         private CancellationTokenSource watcherToken;
         private GameID gameId;
-        private IPlayniteAPI api;
 
-        public SteamGameController(Game game, IPlayniteAPI playniteApi) : base(game)
+        public SteamGameController(Game game) : base(game)
         {
-            gameId = ulong.Parse(game.GameId);
-            api = playniteApi;
+            gameId = game.ToSteamGameID();
         }
 
         public override void Dispose()
@@ -47,7 +45,7 @@ namespace SteamLibrary
         {
             if (gameId.IsMod)
             {
-                api.Dialogs.ShowErrorMessage("Mods cannot be installed via Playnite.", "Error");
+                throw new NotSupportedException("Installing mods is not supported.");
             }
             else
             {
@@ -61,7 +59,7 @@ namespace SteamLibrary
         {
             if (gameId.IsMod)
             {
-                api.Dialogs.ShowErrorMessage("Mods cannot be uninstalled via Playnite.", "Error");
+                throw new NotSupportedException("Uninstalling mods is not supported.");
             }
             else
             {
@@ -77,7 +75,7 @@ namespace SteamLibrary
             await Task.Run(async () =>
             {
                 var stopWatch = Stopwatch.StartNew();
-                var id = new GameID(ulong.Parse(Game.GameId));
+                var id = Game.ToSteamGameID();
 
                 while (true)
                 {
@@ -91,7 +89,7 @@ namespace SteamLibrary
                     {
                         if (Game.PlayAction == null)
                         {
-                            Game.PlayAction = SteamLibrary.CreatePlayTask(ulong.Parse(Game.GameId));
+                            Game.PlayAction = SteamLibrary.CreatePlayTask(Game.ToSteamGameID());
                         }
 
                         stopWatch.Stop();
@@ -110,7 +108,7 @@ namespace SteamLibrary
             await Task.Run(async () =>
             {
                 var stopWatch = Stopwatch.StartNew();
-                var id = new GameID(ulong.Parse(Game.GameId));
+                var id = Game.ToSteamGameID();
 
                 while (true)
                 {
@@ -138,7 +136,7 @@ namespace SteamLibrary
             await Task.Run(async () =>
             {
                 var stopWatch = Stopwatch.StartNew();
-                var id = new GameID(ulong.Parse(Game.GameId));
+                var id = Game.ToSteamGameID();
                 var gameState = Steam.GetAppState(id);
 
                 while (true)

--- a/source/Plugins/SteamLibrary/SteamLibrary.cs
+++ b/source/Plugins/SteamLibrary/SteamLibrary.cs
@@ -61,13 +61,13 @@ namespace SteamLibrary
             };
         }
 
-        internal static GameAction CreatePlayTask(int appId)
+        internal static GameAction CreatePlayTask(GameID gameId)
         {
             return new GameAction()
             {
                 Name = "Play",
                 Type = GameActionType.URL,
-                Path = @"steam://run/" + appId,
+                Path = @"steam://rungameid/" + gameId,
                 IsHandledByPlugin = true
             };
         }
@@ -90,14 +90,15 @@ namespace SteamLibrary
                 name = StringExtensions.NormalizeGameName(kv["name"].Value);
             }
 
+            var gameId = new GameID(kv["appID"].AsUnsignedInteger());
             var game = new Game()
             {
                 PluginId = Id,
                 Source = "Steam",
-                GameId = kv["appID"].Value,
+                GameId = gameId.ToString(),
                 Name = name,
                 InstallDirectory = Path.Combine((new FileInfo(path)).Directory.FullName, "common", kv["installDir"].Value),
-                PlayAction = CreatePlayTask(int.Parse(kv["appID"].Value)),
+                PlayAction = CreatePlayTask(gameId),
                 State = new GameState() { Installed = true }
             };
 

--- a/source/Plugins/SteamLibrary/SteamLibrary.cs
+++ b/source/Plugins/SteamLibrary/SteamLibrary.cs
@@ -186,7 +186,8 @@ namespace SteamLibrary
                 State = new GameState() { Installed = true },
                 Developers = new ComparableList<string>() { modInfo.Developer },
                 Links = modInfo.Links,
-                Categories = modInfo.Categories
+                Categories = modInfo.Categories,
+                Icon = modInfo.IconPath
             };
 
             return game;

--- a/source/Plugins/SteamLibrary/SteamLibrary.cs
+++ b/source/Plugins/SteamLibrary/SteamLibrary.cs
@@ -133,7 +133,7 @@ namespace SteamLibrary
             var firstPartyMods = new string[] { "bshift", "cstrike", "czero", "czeror", "dmc", "dod", "gearbox", "ricochet", "tfc", "valve"};
             var dirInfo = new DirectoryInfo(path);
 
-            foreach (var folder in dirInfo.GetDirectories().Where(a => firstPartyMods.Contains(a.Name)).Select(a => a.FullName))
+            foreach (var folder in dirInfo.GetDirectories().Where(a => !firstPartyMods.Contains(a.Name)).Select(a => a.FullName))
             {
                 try
                 {

--- a/source/Plugins/SteamLibrary/SteamLibrary.cs
+++ b/source/Plugins/SteamLibrary/SteamLibrary.cs
@@ -171,13 +171,13 @@ namespace SteamLibrary
             return games;
         }
 
-        static internal Game GetInstalledModFromFolder(string path, ModInfo.ModType modType)
+        internal Game GetInstalledModFromFolder(string path, ModInfo.ModType modType)
         {
             var modInfo = ModInfo.GetFromFolder(path, modType);
 
             var game = new Game()
             {
-                PluginId = id,
+                PluginId = Id,
                 Source = "Steam",
                 GameId = modInfo.GameId.ToString(),
                 Name = modInfo.Name,
@@ -186,7 +186,7 @@ namespace SteamLibrary
                 State = new GameState() { Installed = true },
                 Developers = new ComparableList<string>() { modInfo.Developer },
                 Links = modInfo.Links,
-                Categories = modInfo.Categories,
+                Tags = modInfo.Categories,
                 Icon = modInfo.IconPath
             };
 
@@ -486,8 +486,7 @@ namespace SteamLibrary
 
         public ILibraryClient Client { get; } = new SteamClient();
 
-        public Guid Id { get; } = id;
-        static private Guid id { get; } = Guid.Parse("CB91DFC9-B977-43BF-8E70-55F46E410FAB");
+        public Guid Id { get; } = Guid.Parse("CB91DFC9-B977-43BF-8E70-55F46E410FAB");
 
         public string Name { get; } = "Steam";
 
@@ -542,7 +541,7 @@ namespace SteamLibrary
 
         public ILibraryMetadataProvider GetMetadataDownloader()
         {
-            return new SteamMetadataProvider(servicesClient, (SteamLibrarySettings)Settings, apiClient);
+            return new SteamMetadataProvider(servicesClient, this, apiClient);
         }
 
         #endregion ILibraryPlugin

--- a/source/Plugins/SteamLibrary/SteamLibrary.cs
+++ b/source/Plugins/SteamLibrary/SteamLibrary.cs
@@ -130,12 +130,10 @@ namespace SteamLibrary
         internal List<Game> GetInstalledGoldSrcModsFromFolder(string path)
         {
             var games = new List<Game>();
-
             var firstPartyMods = new string[] { "bshift", "cstrike", "czero", "czeror", "dmc", "dod", "gearbox", "ricochet", "tfc", "valve"};
-
             var dirInfo = new DirectoryInfo(path);
 
-            foreach (var folder in dirInfo.GetDirectories().Where(a => Array.IndexOf(firstPartyMods, a.Name) == -1).Select(a => a.FullName))
+            foreach (var folder in dirInfo.GetDirectories().Where(a => firstPartyMods.Contains(a.Name)).Select(a => a.FullName))
             {
                 try
                 {
@@ -181,14 +179,14 @@ namespace SteamLibrary
             {
                 PluginId = id,
                 Source = "Steam",
-                GameId = modInfo.gameId.ToString(),
-                Name = modInfo.name,
+                GameId = modInfo.GameId.ToString(),
+                Name = modInfo.Name,
                 InstallDirectory = path,
-                PlayAction = CreatePlayTask(modInfo.gameId),
+                PlayAction = CreatePlayTask(modInfo.GameId),
                 State = new GameState() { Installed = true },
-                Developers = new ComparableList<string>() { modInfo.developer },
-                Links = modInfo.links,
-                Categories = modInfo.categories
+                Developers = new ComparableList<string>() { modInfo.Developer },
+                Links = modInfo.Links,
+                Categories = modInfo.Categories
             };
 
             return game;
@@ -218,7 +216,8 @@ namespace SteamLibrary
             }
 
             // In most cases, this will be inside the folder where Half-Life is installed.
-            if (!string.IsNullOrEmpty(Steam.ModInstallPath))
+            var modInstallPath = Steam.ModInstallPath;
+            if (!string.IsNullOrEmpty(modInstallPath) && Directory.Exists(modInstallPath))
             {
                 GetInstalledGoldSrcModsFromFolder(Steam.ModInstallPath).ForEach(a =>
                 {
@@ -230,7 +229,8 @@ namespace SteamLibrary
             }
 
             // In most cases, this will be inside the library folder where Steam is installed.
-            if (!string.IsNullOrEmpty(Steam.SourceModInstallPath))
+            var sourceModInstallPath = Steam.SourceModInstallPath;
+            if (!string.IsNullOrEmpty(sourceModInstallPath) && Directory.Exists(sourceModInstallPath))
             {
                 GetInstalledSourceModsFromFolder(Steam.SourceModInstallPath).ForEach(a =>
                 {
@@ -536,7 +536,7 @@ namespace SteamLibrary
 
         public IGameController GetGameController(Game game)
         {
-            return new SteamGameController(game, playniteApi);
+            return new SteamGameController(game);
         }
 
         public ILibraryMetadataProvider GetMetadataDownloader()

--- a/source/Plugins/SteamLibrary/SteamLibrary.csproj
+++ b/source/Plugins/SteamLibrary/SteamLibrary.csproj
@@ -90,6 +90,7 @@
       <DependentUpon>SteamLibrarySettingsView.xaml</DependentUpon>
     </Compile>
     <Compile Include="SteamMetadataProvider.cs" />
+    <Compile Include="ModInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Playnite.Common\Playnite.Common.csproj">

--- a/source/Plugins/SteamLibrary/SteamLibrary.csproj
+++ b/source/Plugins/SteamLibrary/SteamLibrary.csproj
@@ -72,6 +72,7 @@
     </Compile>
     <Compile Include="Configuration.cs" />
     <Compile Include="Environment.cs" />
+    <Compile Include="GameExtension.cs" />
     <Compile Include="Models\GetOwnedGamesResult.cs" />
     <Compile Include="Models\LocalSteamUser.cs" />
     <Compile Include="Models\ResolveVanityResult.cs" />

--- a/source/Plugins/SteamLibrary/SteamMetadataProvider.cs
+++ b/source/Plugins/SteamLibrary/SteamMetadataProvider.cs
@@ -42,7 +42,7 @@ namespace SteamLibrary
                 GameId = game.GameId
             };
 
-            var gameId = new GameID(ulong.Parse(game.GameId));
+            var gameId = game.ToSteamGameID();
             if (gameId.IsMod)
             {
                 var data = SteamLibrary.GetInstalledModFromFolder(game.InstallDirectory, ModInfo.GetModTypeOfGameID(gameId));
@@ -288,7 +288,7 @@ namespace SteamLibrary
 
         internal SteamGameMetadata UpdateGameWithMetadata(Game game)
         {
-            var appId = (new GameID(ulong.Parse(game.GameId))).AppID;
+            var appId = game.ToSteamGameID().AppID;
             var metadata = DownloadGameMetadata(appId, settings.PreferScreenshotForBackground);
             game.Name = metadata.ProductDetails?["common"]["name"]?.Value ?? game.Name;
             game.Links = new ObservableCollection<Link>()

--- a/source/Plugins/SteamLibrary/SteamMetadataProvider.cs
+++ b/source/Plugins/SteamLibrary/SteamMetadataProvider.cs
@@ -23,12 +23,12 @@ namespace SteamLibrary
     {
         private ILogger logger = LogManager.GetLogger();
         private SteamServicesClient playniteServices;
-        private SteamLibrarySettings settings;
+        private SteamLibrary library;
         private SteamApiClient apiClient;
 
-        public SteamMetadataProvider(SteamServicesClient playniteServices, SteamLibrarySettings settings, SteamApiClient apiClient)
+        public SteamMetadataProvider(SteamServicesClient playniteServices, SteamLibrary library, SteamApiClient apiClient)
         {
-            this.settings = settings;
+            this.library = library;
             this.playniteServices = playniteServices;
             this.apiClient = apiClient;
         }
@@ -45,7 +45,7 @@ namespace SteamLibrary
             var gameId = game.ToSteamGameID();
             if (gameId.IsMod)
             {
-                var data = SteamLibrary.GetInstalledModFromFolder(game.InstallDirectory, ModInfo.GetModTypeOfGameID(gameId));
+                var data = library.GetInstalledModFromFolder(game.InstallDirectory, ModInfo.GetModTypeOfGameID(gameId));
                 return new GameMetadata(data, null, null, null);
             }
             else
@@ -289,7 +289,7 @@ namespace SteamLibrary
         internal SteamGameMetadata UpdateGameWithMetadata(Game game)
         {
             var appId = game.ToSteamGameID().AppID;
-            var metadata = DownloadGameMetadata(appId, settings.PreferScreenshotForBackground);
+            var metadata = DownloadGameMetadata(appId, library.LibrarySettings.PreferScreenshotForBackground);
             game.Name = metadata.ProductDetails?["common"]["name"]?.Value ?? game.Name;
             game.Links = new ObservableCollection<Link>()
             {

--- a/source/Plugins/SteamLibrary/SteamMetadataProvider.cs
+++ b/source/Plugins/SteamLibrary/SteamMetadataProvider.cs
@@ -42,8 +42,17 @@ namespace SteamLibrary
                 GameId = game.GameId
             };
 
-            var data = UpdateGameWithMetadata(gameData);
-            return new GameMetadata(gameData, data.Icon, data.Image, data.BackgroundImage);
+            var gameId = new GameID(ulong.Parse(game.GameId));
+            if (gameId.IsMod)
+            {
+                var data = SteamLibrary.GetInstalledModFromFolder(game.InstallDirectory, ModInfo.GetModTypeOfGameID(gameId));
+                return new GameMetadata(data, null, null, null);
+            }
+            else
+            {
+                var data = UpdateGameWithMetadata(gameData);
+                return new GameMetadata(gameData, data.Icon, data.Image, data.BackgroundImage);
+            }
         }
 
         #endregion IMetadataProvider


### PR DESCRIPTION
As asked for in issue #769, this adds support for scanning/launching Source mods on Steam.

To do this, I had to change the Playnite Game ID to use a Steam Game ID instead of App ID, but there shouldn't be any backcompat issues since they have the same value for games that were already supported. (GameID is a 64-bit id, with the AppID as the lower 32 bits, and the high bits unset unless it's a mod or shortcut). There shouldn't be any effective change at all for non-mod games.

Metadata comes from the mod's gameinfo.txt, same as how Steam does it. For mods that have it populated, this provides the mod name, developer name, links (developer + manual), and categories (single-player, multi-player, or both). Icon can also be populated if Playnite can support tgas. (I couldn't find the icon image code, but I just assumed that it does not). Launching mods works as expected.

Let me know if any changes are desired. One thing I wasn't sure how to best handle was detecting installation state and uninstalling. I have a WIP change to detect installation state (making sure both the mod and the base game are installed), but not sure what to do for uninstall. The Steam UI does not allow uninstallation of mods, and I don't know if we want to just be directly deleting files from here. Also, the most that Install could do if the mod was fully uninstalled would be to just install the base game (via Steam), which would not install the mod from scratch.

I tested with a variety of Source mods I had already installed from ages ago, including The Hidden, Research and Developer, GoldenEye: Source, BattleGrounds 2, and SourceForts.