### PR TITLE
Fix attempted fetching of non-existent Steam icons.

### DIFF
--- a/source/Plugins/SteamLibrary/SteamMetadataProvider.cs
+++ b/source/Plugins/SteamLibrary/SteamMetadataProvider.cs
@@ -201,14 +201,14 @@ namespace SteamLibrary
                 var iconRoot = @"https://steamcdn-a.akamaihd.net/steamcommunity/public/images/apps/{0}/{1}.ico";
                 var icon = productInfo["common"]["clienticon"];
                 var iconUrl = string.Empty;
-                if (icon.Name != null)
+                if (!string.IsNullOrEmpty(icon.Value))
                 {
                     iconUrl = string.Format(iconRoot, appId, icon.Value);
                 }
                 else
                 {
                     var newIcon = productInfo["common"]["icon"];
-                    if (newIcon.Name != null)
+                    if (!string.IsNullOrEmpty(newIcon.Value))
                     {
                         iconRoot = @"https://steamcdn-a.akamaihd.net/steamcommunity/public/images/apps/{0}/{1}.jpg";
                         iconUrl = string.Format(iconRoot, appId, newIcon.Value);
@@ -247,7 +247,7 @@ namespace SteamLibrary
                     {
                         imageRoot = @"https://steamcdn-a.akamaihd.net/steamcommunity/public/images/apps/{0}/{1}.jpg";
                         var image = productInfo["common"]["logo"];
-                        if (image.Name != null)
+                        if (!string.IsNullOrEmpty(image.Value))
                         {
                             imageUrl = string.Format(imageRoot, appId, image.Value);
                             imageData = HttpDownloader.DownloadData(imageUrl);


### PR DESCRIPTION
For some apps, Steam has the icon, clienticon, or logo fields defined in the appinfo, but with an empty value (""). This causes Playnite to try to download an image that will never exist, and throw an exception internally. App id 215, Source SDK Base 2006 is an example of this.

Ex. "https://steamcdn-a.akamaihd.net/steamcommunity/public/images/apps/215/.jpg"