### PR TITLE
Include free games from Steam owned games API when not using PlayniteServices

### DIFF
--- a/source/Plugins/SteamLibrary/SteamLibrary.cs
+++ b/source/Plugins/SteamLibrary/SteamLibrary.cs
@@ -342,7 +342,7 @@ namespace SteamLibrary
         internal List<Game> GetLibraryGames(string userName, string apiKey)
         {
             var userNameUrl = @"https://api.steampowered.com/ISteamUser/ResolveVanityURL/v0001/?key={0}&vanityurl={1}";
-            var libraryUrl = @"https://api.steampowered.com/IPlayerService/GetOwnedGames/v0001/?key={0}&include_appinfo=1&format=json&steamid={1}";
+            var libraryUrl = @"https://api.steampowered.com/IPlayerService/GetOwnedGames/v0001/?key={0}&include_appinfo=1&include_played_free_games=1&format=json&steamid={1}";
 
             ulong userId = 0;
             if (!ulong.TryParse(userName, out userId))


### PR DESCRIPTION
In the SteamLibrary plugin, when querying the Steam GetOwnedGames web api directly, the include_played_free_games parameter isn't passed, so free games that have been played, such as Dota 2 or Team Fortress 2, will never be returned in the results.

PlayniteServices does pass this.