### PR TITLE
Improve Steam category import (#615)

### DIFF
--- a/source/Plugins/SteamLibrary.Tests/SteamLibraryTests.cs
+++ b/source/Plugins/SteamLibrary.Tests/SteamLibraryTests.cs
@@ -49,7 +49,10 @@ namespace SteamLibrary.Tests
             var cats = steamLib.GetCategorizedGames(user.Id);
             var game = cats.First();
             CollectionAssert.IsNotEmpty(cats);
-            CollectionAssert.IsNotEmpty(game.Categories);
+            if (!game.Hidden)
+            {
+                CollectionAssert.IsNotEmpty(game.Categories);
+            }
             Assert.IsFalse(string.IsNullOrEmpty(game.GameId));
         }
 

--- a/source/Plugins/SteamLibrary/SteamLibrary.cs
+++ b/source/Plugins/SteamLibrary/SteamLibrary.cs
@@ -440,11 +440,34 @@ namespace SteamLibrary
                     appData.Add(tag.Value);
                 }
 
+                string gameId = app.Name;
+                if (app.Name.Contains('_'))
+                {
+                    // Mods are keyed differently, "<appId>_<modId>"
+                    // Ex. 215_2287856061
+                    string[] parts = app.Name.Split('_');
+                    if (uint.TryParse(parts[0], out uint appId) && uint.TryParse(parts[1], out uint modId))
+                    {
+                        var gid = new GameID()
+                        {
+                            AppID = appId,
+                            AppType = GameID.GameType.GameMod,
+                            ModID = modId
+                        };
+                        gameId = gid;
+                    }
+                    else
+                    {
+                        // Malformed app id?
+                        continue;
+                    }
+                }
+
                 result.Add(new Game()
                 {
                     PluginId = Id,
                     Source = "Steam",
-                    GameId = app.Name,
+                    GameId = gameId,
                     Categories = new ComparableList<string>(appData),
                     Hidden = app["hidden"].AsInteger() == 1
                 });

--- a/source/Plugins/SteamLibrary/SteamLibrary.cs
+++ b/source/Plugins/SteamLibrary/SteamLibrary.cs
@@ -429,7 +429,7 @@ namespace SteamLibrary
             var apps = sharedconfig["Software"]["Valve"]["Steam"]["apps"];
             foreach (var app in apps.Children)
             {
-                if (app["tags"].Children.Count == 0)
+                if (app.Children.Count == 0)
                 {
                     continue;
                 }
@@ -445,7 +445,8 @@ namespace SteamLibrary
                     PluginId = Id,
                     Source = "Steam",
                     GameId = app.Name,
-                    Categories = new ComparableList<string>(appData)
+                    Categories = new ComparableList<string>(appData),
+                    Hidden = app["hidden"].AsInteger() == 1
                 });
             }
 
@@ -497,6 +498,7 @@ namespace SteamLibrary
                         }
 
                         dbGame.Categories = game.Categories;
+                        dbGame.Hidden = game.Hidden;
                         db.UpdateGame(dbGame);
                     }
                 }


### PR DESCRIPTION
As discussed in #615, this adds support for importing "Hidden" status for Steam games during category import. (Categories and hidden status are stored very similarly in Steam).

This change also makes category/hidden import work for Steam mods.