### PR TITLE
Create desktop shortcuts when desktop folder is not in default location.

### DIFF
--- a/source/PlayniteUI/GamesEditor.cs
+++ b/source/PlayniteUI/GamesEditor.cs
@@ -337,7 +337,7 @@ namespace PlayniteUI
         {
             try
             {
-                var path = Environment.ExpandEnvironmentVariables(Path.Combine("%userprofile%", "Desktop", Paths.GetSafeFilename(game.Name) + ".lnk"));
+                var path = Environment.ExpandEnvironmentVariables(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory), Paths.GetSafeFilename(game.Name) + ".lnk"));
                 string icon = string.Empty;
 
                 if (!string.IsNullOrEmpty(game.Icon) && Path.GetExtension(game.Icon) == ".ico")


### PR DESCRIPTION
When the desktop is located on a different folder and/or drive, Playnite fails to create a shortcut. 

This fixes that by changing from an effectively hardcoded path to dynamically pulling the desktop path when creating a shortcut.