### PR TITLE
Add Flash Projector as an Adobe Flash emulator

### DIFF
--- a/source/Playnite/Emulators/Definitions.yaml
+++ b/source/Playnite/Emulators/Definitions.yaml
@@ -1493,3 +1493,12 @@
       ImageExtensions: [bin, cue, iso, zip, 7z]
       RequiredFiles: ['cores\yabause_libretro.dll']
       ExecutableLookup: ^retroarch\.exe$
+
+- Name: Flash Player Projector
+  Website: 'https://www.adobe.com/support/flashplayer/debug_downloads.html'
+  Profiles:
+    - Name: Default
+      DefaultArguments: '"{ImagePath}"'
+      Platforms: [Adobe Flash]
+      ImageExtensions: [swf]
+      ExecutableLookup: ^flashplayer_\d+_sa\.exe$


### PR DESCRIPTION
Allow playing Flash games in Playnite by using the Flash Player projector as an "emulator" for Adobe Flash. A new platform "Adobe Flash" is used for .swf files. Support for other Flash players could use this same platform.

I'm not too familiar with other Flash players, it may make sense to add some other players. Browsers don't really work, Chrome likes to download a local .swf file instead of opening it.

The only real issue with the Flash Player projector is that it has no built in full screen button, but some games have an internal button for that.