### PR TITLE
Improve UI interactions in game edit and category windows

### DIFF
--- a/source/PlayniteUI/ViewModels/CategoryConfigViewModel.cs
+++ b/source/PlayniteUI/ViewModels/CategoryConfigViewModel.cs
@@ -13,22 +13,25 @@ namespace PlayniteUI.ViewModels
 {
     public class CategoryConfigViewModel : ObservableObject
     {
-        public class Category
+        public class Category : ObservableObject
         {
+            private bool? enabled;
             public bool? Enabled
             {
-                get; set;
+                get
+                {
+                    return enabled;
+                }
+
+                set
+                {
+                    enabled = value;
+                    OnPropertyChanged();
+                }
             }
 
-            public string Name
-            {
-                get; set;
-            }
-
-            public Category()
-            {
-
-            }
+            public string Name { get; }
+            // No setter: if the name of a Category changes, Categories could have duplicates
 
             public Category(string name, bool enabled)
             {
@@ -86,6 +89,7 @@ namespace PlayniteUI.ViewModels
             get => new RelayCommand<string>((category) =>
             {
                 AddCategory(category);
+                NewTextCat = String.Empty;
             });
         }
 
@@ -134,7 +138,15 @@ namespace PlayniteUI.ViewModels
         {
             if (!string.IsNullOrEmpty(category))
             {
-                Categories.Add(new Category(category, true));
+                Category existing = Categories.Where(a => a.Name.Equals(category, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
+                if (existing != null)
+                {
+                    existing.Enabled = true;
+                }
+                else
+                {
+                    Categories.Add(new Category(category, true));
+                }
             }
         }
 
@@ -282,6 +294,21 @@ namespace PlayniteUI.ViewModels
             }
 
             return categories;
+        }
+
+        private string newTextCat;
+        public string NewTextCat
+        {
+            get
+            {
+                return newTextCat;
+            }
+
+            set
+            {
+                newTextCat = value;
+                OnPropertyChanged();
+            }
         }
     }
 }

--- a/source/PlayniteUI/Windows/CategoryConfigWindow.xaml
+++ b/source/PlayniteUI/Windows/CategoryConfigWindow.xaml
@@ -21,9 +21,22 @@
         <Border DockPanel.Dock="Bottom" BorderThickness="0,1,0,0" BorderBrush="{StaticResource NormalBorderBrush}">
             <DockPanel LastChildFill="False" Margin="5">
                 <Button Name="ButtonCancel" Content="{DynamicResource LOCCancelLabel}"  Style="{StaticResource BottomButton}"
-                        DockPanel.Dock="Right" IsCancel="True" Command="{Binding CloseCommand}"/>
-                <Button Name="ButtonOK" Content="{DynamicResource LOCCategorySetButton}" Style="{StaticResource BottomButton}"
-                        DockPanel.Dock="Right" Command="{Binding SetCategoriesCommand}"/>
+                        DockPanel.Dock="Right" IsCancel="True" Command="{Binding CloseCommand}" />
+                <Button Name="ButtonOK" Content="{DynamicResource LOCCategorySetButton}"
+                        DockPanel.Dock="Right" Command="{Binding SetCategoriesCommand}">
+                    <Button.Style>
+                        <Style TargetType="{x:Type Button}" BasedOn="{StaticResource BottomButton}">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding ElementName=TextNewCat, Path=IsFocused}" Value="True">
+                                    <Setter Property="IsDefault"  Value="False"/>
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding ElementName=TextNewCat, Path=IsFocused}" Value="False">
+                                    <Setter Property="IsDefault"  Value="True"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Button.Style>
+                </Button>
             </DockPanel>
         </Border>
 
@@ -32,8 +45,9 @@
             <DockPanel>
                 <Button Name="ButtonAddCat" Content="{DynamicResource LOCCategoryAddCatButton}"
                         DockPanel.Dock="Left" Padding="10,5,10,5"
-                        Command="{Binding AddCategoryCommand}" CommandParameter="{Binding Text, ElementName=TextNewCat}"/>
-                <TextBox Name="TextNewCat" DockPanel.Dock="Left" Margin="10,0,0,0" VerticalAlignment="Center"/>
+                        Command="{Binding AddCategoryCommand}" CommandParameter="{Binding Text, ElementName=TextNewCat}"
+                        IsDefault="{Binding IsFocused, ElementName=TextNewCat}" />
+                <TextBox Name="TextNewCat" Text="{Binding NewTextCat}" DockPanel.Dock="Left" Margin="10,0,0,0" VerticalAlignment="Center"/>
             </DockPanel>
         </Border>
 

--- a/source/PlayniteUI/Windows/GameEditWindow.xaml
+++ b/source/PlayniteUI/Windows/GameEditWindow.xaml
@@ -703,7 +703,7 @@
                 <Button TabIndex="3" Name="ButtonCancel" Content="{DynamicResource LOCCancelLabel}" DockPanel.Dock="Right" IsCancel="True"
                         Style="{StaticResource BottomButton}"
                         Command="{Binding CancelCommand}"/>
-                <Button TabIndex="2" Name="ButtonOK" Content="{DynamicResource LOCSaveLabel}" DockPanel.Dock="Right"
+                <Button TabIndex="2" Name="ButtonOK" Content="{DynamicResource LOCSaveLabel}" DockPanel.Dock="Right" IsDefault="True"
                         Style="{StaticResource BottomButton}"
                         Command="{Binding ConfirmCommand}"/>
             </DockPanel>


### PR DESCRIPTION
Game edit window changes:

* Set default button in `GameEditWindow` to `ButtonOK`

Category config window changes:

*  Conditionally set default button in `CategoryConfigWindow`. If `NewTestCat` is not focused, use `ButtonOK` as default. If   `NewTestCat` is not focused, use `ButtonAddCat` as default.
*  Clear `NewTestCat` on `AddCategory()`. I had to add a property for   `NewTextCat` in `CategoryConfigViewModel` to do this, I'm not sure   if that's the cleanest way.
*  Don't add the `Category` to `Categories` if it already exists and is   enabled. This fixes a bug that you could have duplicate categories   listed.
*  If the category does already exist but is not enabled, enable it. I   had to make `Category` an `ObservableObject` for this to work, it   needed to be able to notify that it had been updated.
*  Removed default constructor for `Category` and setter for `Name`.   This prevents changing the `Name` of a `Category`, ensuring there   are never duplicates in `Categories`.

Now you can quickly create categories by typing in their name and pressing enter. If the text box is not focused, the OK button of the categories window will be submitted instead.

(This is the first time I've written C# and XAML since almost 8 years ago. Please let me know if I wrote any horribly unidiomatic code or anything.)