### PR TITLE
Update ScummVMImporter to use the refactored Game api

### DIFF
--- a/scripts/Extensions/ScummVMImporter/ScummVMImporter.ps1
+++ b/scripts/Extensions/ScummVMImporter/ScummVMImporter.ps1
@@ -53,7 +53,7 @@ function global:ImportScummVMGames()
         {
             $game = New-Object "Playnite.SDK.Models.Game" ($config[$key].description -replace "\(.*\)")
             $game.InstallDirectory = $config[$key].path
-            $game.State.Installed = $true
+            $game.IsInstalled = $true
 
             $playTask = New-Object "Playnite.SDK.Models.GameAction"
             $playTask.Type = "Emulator"

--- a/scripts/Extensions/ScummVMImporter/extension.yaml
+++ b/scripts/Extensions/ScummVMImporter/extension.yaml
@@ -1,6 +1,6 @@
 ﻿Name: Library Exporter
 Author: Josef Nemec
-Version: 1.0
+Version: 1.0.1
 Module: ScummVMImporter.ps1
 Type: Script
 Functions: 


### PR DESCRIPTION
The `State` property no longer exists on Game objects as of 3371c606. Change the extension to use the new `IsInstalled` setter.