### PR TITLE
Add option to show grouped items count (#989)

### DIFF
--- a/source/Playnite/Settings/PlayniteSettings.cs
+++ b/source/Playnite/Settings/PlayniteSettings.cs
@@ -265,6 +265,21 @@ namespace Playnite.Settings
             }
         }
 
+        private bool showGroupCount = false;
+        public bool ShowGroupCount
+        {
+            get
+            {
+                return showGroupCount;
+            }
+
+            set
+            {
+                showGroupCount = value;
+                OnPropertyChanged();
+            }
+        }
+
         private bool startInFullscreen = false;
         public bool StartInFullscreen
         {

--- a/source/PlayniteUI/Controls/GamesGridView.xaml
+++ b/source/PlayniteUI/Controls/GamesGridView.xaml
@@ -94,9 +94,16 @@
                         <Setter Property="Template">
                             <Setter.Value>
                                 <ControlTemplate>
-                                    <Expander Header="{Binding Mode=OneWay}" IsExpanded="True"
+                                    <Expander IsExpanded="True"
                                               pui:ExpanderBehaviors.SaveState="True"
                                               pui:ExpanderBehaviors.SaveStateId="{Binding Name, Mode=OneWay}">
+                                        <Expander.Header>
+                                            <StackPanel Orientation="Horizontal">
+                                                <TextBlock Text="{Binding Name}" VerticalAlignment="Center" HorizontalAlignment="Center" Style="{DynamicResource BaseTextBlockStyle}" TextAlignment="Center" Margin="0 0 5 0"/>
+                                                <TextBlock Text="{Binding Items.Count, Mode=OneWay, StringFormat=({0})}" VerticalAlignment="Center" HorizontalAlignment="Center" Style="{DynamicResource BaseTextBlockStyle}" TextAlignment="Center"
+                                                                       Visibility="{Binding Path=AppSettings.ShowGroupCount, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                                            </StackPanel>
+                                        </Expander.Header>
                                         <ItemsPresenter />
                                     </Expander>
                                 </ControlTemplate>

--- a/source/PlayniteUI/Localization/english.xaml
+++ b/source/PlayniteUI/Localization/english.xaml
@@ -237,7 +237,7 @@ Prefer data from official Store and where not available use IGBD.com database.</
     <sys:String x:Key="LOCSettingsShowNameEmptyCover">Display game name when cover art is missing</sys:String>
     <sys:String x:Key="LOCSettingsShowNamesUnderCover">Show game names on cover view</sys:String>
     <sys:String x:Key="LOCSettingsShowIconList">Show game icons on List view</sys:String>
-    <sys:String x:Key="LOCSettingsShowGroupCount">Show number of items in groups on list view</sys:String>
+    <sys:String x:Key="LOCSettingsShowGroupCount">Show number of items in List view</sys:String>
     <sys:String x:Key="LOCSettingsDisableAcceleration">Disable hardware acceleration (requires restart)</sys:String>
     <sys:String x:Key="LOCSettingsDisableAccelerationTooltip">Use when experiencing stuttering or similar UI issues</sys:String>
     <sys:String x:Key="LOCSettingsDisableDpiAwareness">Disable DPI Scaling (requires restart)</sys:String>

--- a/source/PlayniteUI/Localization/english.xaml
+++ b/source/PlayniteUI/Localization/english.xaml
@@ -237,6 +237,7 @@ Prefer data from official Store and where not available use IGBD.com database.</
     <sys:String x:Key="LOCSettingsShowNameEmptyCover">Display game name when cover art is missing</sys:String>
     <sys:String x:Key="LOCSettingsShowNamesUnderCover">Show game names on cover view</sys:String>
     <sys:String x:Key="LOCSettingsShowIconList">Show game icons on List view</sys:String>
+    <sys:String x:Key="LOCSettingsShowGroupCount">Show number of items in groups on list view</sys:String>
     <sys:String x:Key="LOCSettingsDisableAcceleration">Disable hardware acceleration (requires restart)</sys:String>
     <sys:String x:Key="LOCSettingsDisableAccelerationTooltip">Use when experiencing stuttering or similar UI issues</sys:String>
     <sys:String x:Key="LOCSettingsDisableDpiAwareness">Disable DPI Scaling (requires restart)</sys:String>

--- a/source/PlayniteUI/Localization/english.xaml
+++ b/source/PlayniteUI/Localization/english.xaml
@@ -237,7 +237,7 @@ Prefer data from official Store and where not available use IGBD.com database.</
     <sys:String x:Key="LOCSettingsShowNameEmptyCover">Display game name when cover art is missing</sys:String>
     <sys:String x:Key="LOCSettingsShowNamesUnderCover">Show game names on cover view</sys:String>
     <sys:String x:Key="LOCSettingsShowIconList">Show game icons on List view</sys:String>
-    <sys:String x:Key="LOCSettingsShowGroupCount">Show number of items in List view</sys:String>
+    <sys:String x:Key="LOCSettingsShowGroupCount">Show item count on group descriptions</sys:String>
     <sys:String x:Key="LOCSettingsDisableAcceleration">Disable hardware acceleration (requires restart)</sys:String>
     <sys:String x:Key="LOCSettingsDisableAccelerationTooltip">Use when experiencing stuttering or similar UI issues</sys:String>
     <sys:String x:Key="LOCSettingsDisableDpiAwareness">Disable DPI Scaling (requires restart)</sys:String>

--- a/source/PlayniteUI/Localization/french.xaml
+++ b/source/PlayniteUI/Localization/french.xaml
@@ -232,7 +232,7 @@ Préférer les données des boutiques officielles et, lorsqu'elles ne sont pas d
     <sys:String x:Key="LOCSettingsShowNameEmptyCover">Afficher le nom des jeux à la place des jaquettes manquantes</sys:String>
     <sys:String x:Key="LOCSettingsShowNamesUnderCover">Afficher le nom des jeux dans la vue en grille</sys:String>
     <sys:String x:Key="LOCSettingsShowIconList">Afficher les icônes des jeux dans la vue en liste</sys:String>
-    <sys:String x:Key="LOCSettingsShowGroupCount">Afficher le nombre d'items des groupes dans la vue en liste</sys:String>
+    <sys:String x:Key="LOCSettingsShowGroupCount">Afficher le nombre d'items dans la vue en liste</sys:String>
     <sys:String x:Key="LOCSettingsDisableAcceleration">Désactiver l'accélération matérielle (redémarrage nécessaire)</sys:String>
     <sys:String x:Key="LOCSettingsDisableAccelerationTooltip">Cocher cette option en cas de ralentissement ou de malfonctionnement de l'interface.</sys:String>
     <sys:String x:Key="LOCSettingsDisableDpiAwareness">Désactiver la mise à l'échelle (redémarrage nécessaire)</sys:String>

--- a/source/PlayniteUI/Localization/french.xaml
+++ b/source/PlayniteUI/Localization/french.xaml
@@ -232,6 +232,7 @@ Préférer les données des boutiques officielles et, lorsqu'elles ne sont pas d
     <sys:String x:Key="LOCSettingsShowNameEmptyCover">Afficher le nom des jeux à la place des jaquettes manquantes</sys:String>
     <sys:String x:Key="LOCSettingsShowNamesUnderCover">Afficher le nom des jeux dans la vue en grille</sys:String>
     <sys:String x:Key="LOCSettingsShowIconList">Afficher les icônes des jeux dans la vue en liste</sys:String>
+    <sys:String x:Key="LOCSettingsShowGroupCount">Afficher le nombre d'items des groupes dans la vue en liste</sys:String>
     <sys:String x:Key="LOCSettingsDisableAcceleration">Désactiver l'accélération matérielle (redémarrage nécessaire)</sys:String>
     <sys:String x:Key="LOCSettingsDisableAccelerationTooltip">Cocher cette option en cas de ralentissement ou de malfonctionnement de l'interface.</sys:String>
     <sys:String x:Key="LOCSettingsDisableDpiAwareness">Désactiver la mise à l'échelle (redémarrage nécessaire)</sys:String>

--- a/source/PlayniteUI/Localization/french.xaml
+++ b/source/PlayniteUI/Localization/french.xaml
@@ -232,7 +232,7 @@ Préférer les données des boutiques officielles et, lorsqu'elles ne sont pas d
     <sys:String x:Key="LOCSettingsShowNameEmptyCover">Afficher le nom des jeux à la place des jaquettes manquantes</sys:String>
     <sys:String x:Key="LOCSettingsShowNamesUnderCover">Afficher le nom des jeux dans la vue en grille</sys:String>
     <sys:String x:Key="LOCSettingsShowIconList">Afficher les icônes des jeux dans la vue en liste</sys:String>
-    <sys:String x:Key="LOCSettingsShowGroupCount">Afficher le nombre d'items dans la vue en liste</sys:String>
+    <sys:String x:Key="LOCSettingsShowGroupCount">Afficher le nombre d'items dans la description des groupes</sys:String>
     <sys:String x:Key="LOCSettingsDisableAcceleration">Désactiver l'accélération matérielle (redémarrage nécessaire)</sys:String>
     <sys:String x:Key="LOCSettingsDisableAccelerationTooltip">Cocher cette option en cas de ralentissement ou de malfonctionnement de l'interface.</sys:String>
     <sys:String x:Key="LOCSettingsDisableDpiAwareness">Désactiver la mise à l'échelle (redémarrage nécessaire)</sys:String>

--- a/source/PlayniteUI/Skins/Classic/Classic.xaml
+++ b/source/PlayniteUI/Skins/Classic/Classic.xaml
@@ -3049,9 +3049,16 @@
                                                     <Setter Property="Template">
                                                         <Setter.Value>
                                                             <ControlTemplate>
-                                                                <Expander Header="{Binding Mode=OneWay}" BorderThickness="0" IsExpanded="True"                                                                          
+                                                                <Expander BorderThickness="0" IsExpanded="True"                                                                          
                                                                           pui:ExpanderBehaviors.SaveState="True"
                                                                           pui:ExpanderBehaviors.SaveStateId="{Binding Name, Mode=OneWay}">
+                                                                    <Expander.Header>
+                                                                        <StackPanel Orientation="Horizontal">
+                                                                            <TextBlock Text="{Binding Name}" VerticalAlignment="Center" HorizontalAlignment="Center" Style="{DynamicResource BaseTextBlockStyle}" TextAlignment="Center" Margin="0 0 5 0"/>
+                                                                            <TextBlock Text="{Binding Items.Count, Mode=OneWay, StringFormat=({0})}" VerticalAlignment="Center" HorizontalAlignment="Center" Style="{DynamicResource BaseTextBlockStyle}" TextAlignment="Center"
+                                                                                       Visibility="{Binding Path=Data.AppSettings.ShowGroupCount, Source={StaticResource Proxy}, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                                                                        </StackPanel>
+                                                                    </Expander.Header>
                                                                     <ItemsPresenter />
                                                                 </Expander>
                                                             </ControlTemplate>

--- a/source/PlayniteUI/Skins/Modern/Modern.xaml
+++ b/source/PlayniteUI/Skins/Modern/Modern.xaml
@@ -2691,9 +2691,16 @@
                                     <Setter Property="Template">
                                         <Setter.Value>
                                             <ControlTemplate>
-                                                <Expander Header="{Binding Mode=OneWay}" BorderThickness="0" IsExpanded="True"
+                                                <Expander BorderThickness="0" IsExpanded="True"
                                                           pui:ExpanderBehaviors.SaveState="True"
                                                           pui:ExpanderBehaviors.SaveStateId="{Binding Name, Mode=OneWay}">
+                                                    <Expander.Header>
+                                                        <StackPanel Orientation="Horizontal">
+                                                            <TextBlock Text="{Binding Name}" VerticalAlignment="Center" HorizontalAlignment="Center" Style="{DynamicResource BaseTextBlockStyle}" TextAlignment="Center" Margin="0 0 5 0"/>
+                                                            <TextBlock Text="{Binding Items.Count, Mode=OneWay, StringFormat=({0})}" VerticalAlignment="Center" HorizontalAlignment="Center" Style="{DynamicResource BaseTextBlockStyle}" TextAlignment="Center"
+                                                                       Visibility="{Binding Path=Data.AppSettings.ShowGroupCount, Source={StaticResource Proxy}, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                                                        </StackPanel>
+                                                    </Expander.Header>
                                                     <ItemsPresenter />
                                                 </Expander>
                                             </ControlTemplate>

--- a/source/PlayniteUI/Windows/SettingsWindow.xaml
+++ b/source/PlayniteUI/Windows/SettingsWindow.xaml
@@ -274,7 +274,9 @@
                                 <CheckBox Content="{DynamicResource LOCSettingsShowNamesUnderCover}" Margin="0,15,0,0"
                                   Name="CheckNameUnderCover" IsChecked="{Binding Settings.ShowNamesUnderCovers}"/>
                                 <CheckBox Content="{DynamicResource LOCSettingsShowIconList}" Margin="0,15,0,0"
-                                  Name="CheckShowIcons" IsChecked="{Binding Settings.ShowIconsOnList}"/>                       
+                                  Name="CheckShowIcons" IsChecked="{Binding Settings.ShowIconsOnList}"/>
+                                <CheckBox Content="{DynamicResource LOCSettingsShowGroupCount}" Margin="0,15,0,0"
+                                  Name="CheckShowGroupCount" IsChecked="{Binding Settings.ShowGroupCount}"/>
                                 <CheckBox Content="{DynamicResource LOCSettingsShowSteamFriendsButton}" Margin="0,15,0,0"
                                   Name="CheckShowSteamFriends" IsChecked="{Binding Settings.ShowSteamFriendsButton}"/>
                                 <CheckBox Content="{DynamicResource LOCSettingsShowBackgroundImage}" Margin="0,15,0,0"


### PR DESCRIPTION
This is a PR for the issue #989 . It adds an option in the appearance settings to show the item count next to the group name in list or grid view.

This is my first time contributing on github and my first time working in .net (I usually work in java). I'm sorry if I made stupid mistakes.

I was not sure from what branch to branch from. At first I tried with devel but I could not get the application running (xaml parsing error) so I branched from master.

Also, I added a new language string in English and French. I'm not sure what to do with the other languages.

Thanks
JF