### PR TITLE
Import LastPlayed information from Steam

### DIFF
--- a/source/Playnite/Localization/LocSource.xaml
+++ b/source/Playnite/Localization/LocSource.xaml
@@ -276,8 +276,9 @@ Prefer data from official Store and where not available use IGBD.com database.</
     <sys:String x:Key="LOCSettingsWhatsSteamName">What's my account name?</sys:String>
     <sys:String x:Key="LOCSettingsLoginStatus">Login status:</sys:String>    
     <sys:String x:Key="LOCSettingsWindowTitle">Playnite Settings</sys:String>
-    <sys:String x:Key="LOCSettingsSteamImportCategories">Import Steam Categories:</sys:String>
-    <sys:String x:Key="LOCSettingsSteamImportCatFrom">from account:</sys:String>
+    <sys:String x:Key="LOCSettingsSteamImportMetadata">Import metadata from Steam account:</sys:String>
+    <sys:String x:Key="LOCImportSteamCategoriesLabel">Import Steam Categories</sys:String>
+    <sys:String x:Key="LOCImportSteamLastActivityLabel">Import Steam Last Played</sys:String>
     <sys:String x:Key="LOCSettingsClearWebCache">Clear web cache</sys:String>
     <sys:String x:Key="LOCSettingsClearWebCacheTooltip">May solve issues encountered while linking accounts.</sys:String>
     <sys:String x:Key="LOCSettingsShowTray">Show Tray Icon *</sys:String>
@@ -292,6 +293,9 @@ Prefer data from official Store and where not available use IGBD.com database.</
     <sys:String x:Key="LOCSettingsSteamCatImportErrorAccount">Cannot import categories, account for import is not selected.</sys:String>
     <sys:String x:Key="LOCSettingsSteamCatImportErrorDb">Cannot import categories, database is not opened.</sys:String>
     <sys:String x:Key="LOCSettingsSteamCatImportError">Failed to import Steam categories: {0}</sys:String>
+    <sys:String x:Key="LOCSettingsSteamLastActivityImportErrorAccount">Cannot import last played information, account for import is not selected.</sys:String>
+    <sys:String x:Key="LOCSettingsSteamLastActivityImportErrorDb">Cannot import last played information, database is not opened.</sys:String>
+    <sys:String x:Key="LOCSettingsSteamLastActivityImportError">Failed to import Steam last played information: {0}</sys:String>
     <sys:String x:Key="LOCSettingsClearCacheWarn">This will log you out of all linked services. Application restart is required, do you want to proceed?</sys:String>
     <sys:String x:Key="LOCSettingsClearCacheTitle">Clear Cache?</sys:String>
     <sys:String x:Key="LOCSettingsApiKeyTooltip">API Key is required for Steam private accounts</sys:String>

--- a/source/Plugins/SteamLibrary.Tests/SteamLibraryTests.cs
+++ b/source/Plugins/SteamLibrary.Tests/SteamLibraryTests.cs
@@ -56,6 +56,18 @@ namespace SteamLibrary.Tests
         }
 
         [Test]
+        public void GetGamesLastActivityTest()
+        {
+            var steamLib = CreateLibrary();
+            var user = steamLib.GetSteamUsers().First(a => a.Recent);
+            var lastActivity = steamLib.GetGamesLastActivity(user.Id);
+            var game = lastActivity.First();
+            CollectionAssert.IsNotEmpty(lastActivity);
+            Assert.IsNotNull(game.LastActivity);
+            Assert.IsFalse(string.IsNullOrEmpty(game.GameId));
+        }
+
+        [Test]
         public void GetSteamUsersTest()
         {
             var steamLib = CreateLibrary();

--- a/source/Plugins/SteamLibrary.Tests/SteamLibraryTests.cs
+++ b/source/Plugins/SteamLibrary.Tests/SteamLibraryTests.cs
@@ -61,10 +61,10 @@ namespace SteamLibrary.Tests
             var steamLib = CreateLibrary();
             var user = steamLib.GetSteamUsers().First(a => a.Recent);
             var lastActivity = steamLib.GetGamesLastActivity(user.Id);
-            var game = lastActivity.First();
+            var kvp = lastActivity.First();
             CollectionAssert.IsNotEmpty(lastActivity);
-            Assert.IsNotNull(game.LastActivity);
-            Assert.IsFalse(string.IsNullOrEmpty(game.GameId));
+            Assert.IsNotNull(kvp.Value);
+            Assert.IsFalse(string.IsNullOrEmpty(kvp.Key));
         }
 
         [Test]

--- a/source/Plugins/SteamLibrary/SteamLibrary.cs
+++ b/source/Plugins/SteamLibrary/SteamLibrary.cs
@@ -498,15 +498,15 @@ namespace SteamLibrary
 
         public void ImportSteamLastActivity(ulong accountId)
         {
-            var dialogs = playniteApi.Dialogs;
-            var resources = playniteApi.Resources;
-            var db = playniteApi.Database;
+            var dialogs = PlayniteApi.Dialogs;
+            var resources = PlayniteApi.Resources;
+            var db = PlayniteApi.Database;
 
             if (accountId == 0)
             {
                 dialogs.ShowMessage(
-                    resources.FindString("LOCSettingsSteamLastActivityImportErrorAccount"),
-                    resources.FindString("LOCImportError"),
+                    resources.GetString("LOCSettingsSteamLastActivityImportErrorAccount"),
+                    resources.GetString("LOCImportError"),
                     MessageBoxButton.OK, MessageBoxImage.Error);
                 return;
             }
@@ -514,8 +514,8 @@ namespace SteamLibrary
             if (!db.IsOpen)
             {
                 dialogs.ShowMessage(
-                    resources.FindString("LOCSettingsSteamLastActivityImportErrorDb"),
-                    resources.FindString("LOCImportError"),
+                    resources.GetString("LOCSettingsSteamLastActivityImportErrorDb"),
+                    resources.GetString("LOCImportError"),
                     MessageBoxButton.OK, MessageBoxImage.Error);
                 return;
             }
@@ -526,7 +526,7 @@ namespace SteamLibrary
                 {
                     foreach (var kvp in GetGamesLastActivity(accountId))
                     {
-                        var dbGame = db.GetGames().FirstOrDefault(a => a.PluginId == Id && a.GameId == kvp.Key);
+                        var dbGame = db.Games.FirstOrDefault(a => a.PluginId == Id && a.GameId == kvp.Key);
                         if (dbGame == null)
                         {
                             continue;
@@ -537,18 +537,17 @@ namespace SteamLibrary
                             continue;
                         }
                         dbGame.LastActivity = kvp.Value;
-                        db.UpdateGame(dbGame);
                     }
                 }
 
-                dialogs.ShowMessage(resources.FindString("LOCImportCompleted"));
+                dialogs.ShowMessage(resources.GetString("LOCImportCompleted"));
             }
             catch (Exception exc) when (!Environment.IsDebugBuild)
             {
                 logger.Error(exc, "Failed to import Steam last activity.");
                 dialogs.ShowMessage(
-                    resources.FindString("LOCSettingsSteamLastActivityImportError"),
-                    resources.FindString("LOCImportError"),
+                    resources.GetString("LOCSettingsSteamLastActivityImportError"),
+                    resources.GetString("LOCImportError"),
                     MessageBoxButton.OK, MessageBoxImage.Error);
             }
         }

--- a/source/Plugins/SteamLibrary/SteamLibrarySettings.cs
+++ b/source/Plugins/SteamLibrary/SteamLibrarySettings.cs
@@ -67,6 +67,15 @@ namespace SteamLibrary
             });
         }
 
+        [JsonIgnore]
+        public RelayCommand<LocalSteamUser> ImportSteamLastActivityCommand
+        {
+            get => new RelayCommand<LocalSteamUser>((a) =>
+            {
+                ImportSteamLastActivity(a);
+            });
+        }
+
         public SteamLibrarySettings()
         {
         }
@@ -121,6 +130,12 @@ namespace SteamLibrary
         {
             var accId = user == null ? 0 : user.Id;
             library.ImportSteamCategories(accId);
+        }
+
+        public void ImportSteamLastActivity(LocalSteamUser user)
+        {
+            var accId = user == null ? 0 : user.Id;
+            library.ImportSteamLastActivity(accId);
         }
     }
 }

--- a/source/Plugins/SteamLibrary/SteamLibrarySettingsView.xaml
+++ b/source/Plugins/SteamLibrary/SteamLibrarySettingsView.xaml
@@ -112,21 +112,27 @@
             <TextBlock Text="{DynamicResource LOCSteamBackgroundSource}"
                        VerticalAlignment="Center"/>
             <ContentControl Content="{StaticResource BackgroundSourceBox}" Margin="10,0,0,0" />
-        </StackPanel>       
+        </StackPanel>
 
-        <TextBlock Text="{DynamicResource LOCSettingsSteamImportCategories}"
-                   DockPanel.Dock="Top" Margin="0,25,5,5"
-                   Visibility="{Binding ShowCategoryImport, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-        <StackPanel DockPanel.Dock="Top" Margin="20,10,5,5" Orientation="Horizontal"
+
+        <StackPanel DockPanel.Dock="Top" Margin="0,25,5,5" Orientation="Horizontal"
                     Visibility="{Binding ShowCategoryImport, Converter={StaticResource BooleanToVisibilityConverter}}">
-            <Button Content="{DynamicResource LOCImportLabel}" Name="ButtonImportSteamCategories"
-                    Command="{Binding ImportSteamCategoriesCommand}"
-                    CommandParameter="{Binding SelectedItem, ElementName=ComboSteamCatImport}"/>
-            <TextBlock Text="{DynamicResource LOCSettingsSteamImportCatFrom}" VerticalAlignment="Center" Margin="10,0,0,0"/>
+            <TextBlock Text="{DynamicResource LOCSettingsSteamImportMetadata}"
+                   VerticalAlignment="Center"
+                   Visibility="{Binding ShowCategoryImport, Converter={StaticResource BooleanToVisibilityConverter}}"/>
             <ComboBox IsReadOnly="True" Margin="10,0,0,0"
-                      Name="ComboSteamCatImport"
+                      Name="ComboSteamMetadataImport"
                       DisplayMemberPath="AccountName" SelectedValuePath="Id" SelectedIndex="0"
                       ItemsSource="{Binding SteamUsers}" />
+        </StackPanel>
+        <StackPanel DockPanel.Dock="Top" Margin="40,10,5,5" Orientation="Horizontal"
+                    Visibility="{Binding ShowCategoryImport, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <Button Content="{DynamicResource LOCImportSteamCategoriesLabel}" Name="ButtonImportSteamCategories"
+                     Margin="0,0,10,0" Command="{Binding ImportSteamCategoriesCommand}"
+                    CommandParameter="{Binding SelectedItem, ElementName=ComboSteamMetadataImport}"/>
+            <Button Content="{DynamicResource LOCImportSteamLastActivityLabel}" Name="ButtonImportSteamLastActivity"
+                        Command="{Binding ImportSteamLastActivityCommand}"
+                        CommandParameter="{Binding SelectedItem, ElementName=ComboSteamMetadataImport}"/>
         </StackPanel>
     </StackPanel>
 </UserControl>


### PR DESCRIPTION
LastActivity data is imported from \steam\userdata\{steam_id}\config\localconfig.vdf

A button has been added to `SteamLibrarySettings` to trigger import. Updating a game's `LastActivity` if it skipped if is Playnite's value is newer than Steam's data.

I named things "LastActivity" throughout the code even though the Steam and the Playnite UI says "Last Played" usually. It seemed to match the code better, let me know if it's confusing.

I'm not sure if I have any Steam mods in my account, I couldn't test whether `localconfig.vdf` has underscores in AppIds like `sharedconfig.vdf`.

I added a `GetGamesLastActivityTest()`,  but I don't know how to actually get tests to run in Visual Studio. Could you please help?

I introduced multiple new localization strings. I added them to `english.xaml`, I'm not sure that needs to be done though?

`LastActivity` is now imported during `GetLibraryGames(...)` too. One caveat though: if a public library is being imported but `settings.IdSource == SteamIdSource.Name`, we won't have an API key, so we can't convert the `AccountName` to an `AccountId`. In that case I just skip it. Also if during import there are any errors accessing `localconfig.vdf`, I just log and ignore it. (It's possible a user is importing a library by username and they have never logged into that Steam account locally.) Errors are shown when manually clicking the import button though.

If "Force sync play time" is set, `LastActivity` will be updated every import. (I wonder though, should we [only update `LastActivity` if it is older than the current value](https://github.com/JosefNemec/Playnite/blob/master/source/Playnite/Database/GameLibrary.cs#L127)? And maybe only update `Playtime` if it is lesser too? Someone may have played the game in Playnite without launching Steam and the times could be out of sync.)