### PR TITLE
Use HTTPS for Steam links.

### DIFF
--- a/source/Plugins/SteamLibrary/Services/WebApiClient.cs
+++ b/source/Plugins/SteamLibrary/Services/WebApiClient.cs
@@ -20,8 +20,7 @@ namespace SteamLibrary.Services
 
         public static string GetRawStoreAppDetail(uint appId)
         {
-            var url = @"http://store.steampowered.com/api/appdetails?appids={0}";
-            url = string.Format(url, appId);
+            var url = $"https://store.steampowered.com/api/appdetails?appids={appId}";
             return HttpDownloader.DownloadString(url);
         }
 

--- a/source/Plugins/SteamLibrary/Steam.cs
+++ b/source/Plugins/SteamLibrary/Steam.cs
@@ -91,7 +91,7 @@ namespace SteamLibrary
 
         public static string GetWorkshopUrl(uint appId)
         {
-            return $"http://steamcommunity.com/app/{appId}/workshop/";
+            return $"https://steamcommunity.com/app/{appId}/workshop/";
         }
 
         public static AppState GetAppState(GameID id)

--- a/source/Plugins/SteamLibrary/SteamMetadataProvider.cs
+++ b/source/Plugins/SteamLibrary/SteamMetadataProvider.cs
@@ -293,7 +293,7 @@ namespace SteamLibrary
             game.Name = metadata.ProductDetails?["common"]["name"]?.Value ?? game.Name;
             game.Links = new ObservableCollection<Link>()
             {
-                new Link("Forum", $"https://steamcommunity.com/app/{appId}/discussions"),
+                new Link("Forum", $"https://steamcommunity.com/app/{appId}"),
                 new Link("News", $"https://store.steampowered.com/news/?appids={appId}"),
                 new Link("Store", $"https://store.steampowered.com/app/{appId}"),
                 new Link("Wiki", $"https://pcgamingwiki.com/api/appid.php?appid={appId}")

--- a/source/Plugins/SteamLibrary/SteamMetadataProvider.cs
+++ b/source/Plugins/SteamLibrary/SteamMetadataProvider.cs
@@ -231,7 +231,7 @@ namespace SteamLibrary
             }
 
             // Image
-            var imageRoot = @"http://cdn.akamai.steamstatic.com/steam/apps/{0}/header.jpg";
+            var imageRoot = @"https://steamcdn-a.akamaihd.net/steam/apps/{0}/header.jpg";
             var imageUrl = string.Format(imageRoot, appId);
             byte[] imageData = null;
 
@@ -293,10 +293,10 @@ namespace SteamLibrary
             game.Name = metadata.ProductDetails?["common"]["name"]?.Value ?? game.Name;
             game.Links = new ObservableCollection<Link>()
             {
-                new Link("Forum", @"https://steamcommunity.com/app/" + appId),
-                new Link("News", @"http://store.steampowered.com/news/?appids=" + appId),
-                new Link("Store", @"http://store.steampowered.com/app/" + appId),
-                new Link("Wiki", @"http://pcgamingwiki.com/api/appid.php?appid=" + appId)
+                new Link("Forum", $"https://steamcommunity.com/app/{appId}/discussions"),
+                new Link("News", $"https://store.steampowered.com/news/?appids={appId}"),
+                new Link("Store", $"https://store.steampowered.com/app/{appId}"),
+                new Link("Wiki", $"https://pcgamingwiki.com/api/appid.php?appid={appId}")
             };
 
             if (metadata.StoreDetails?.categories?.FirstOrDefault(a => a.id == 30) != null)


### PR DESCRIPTION
Most or all of these links already get redirected to HTTPS. This way we're saving that step. ~~Also fixed forum link going to hub instead of discussion forum.~~ (see comments)