### PR TITLE
Rework background update notifications

### DIFF
--- a/source/PlayniteUI/App.xaml.cs
+++ b/source/PlayniteUI/App.xaml.cs
@@ -352,7 +352,7 @@ namespace PlayniteUI
             // Update and stats
             if (!PlayniteEnvironment.InOfflineMode)
             {
-                CheckUpdate();
+                NotifyIfUpdateIsAvailableDelayed();
                 SendUsageData();
             }
 
@@ -435,7 +435,7 @@ namespace PlayniteUI
             }
         }
 
-        private async void CheckUpdate()
+        private async void NotifyIfUpdateIsAvailableDelayed()
         {
             await Task.Delay(Playnite.Timer.SecondsToMilliseconds(10));
             if (GlobalTaskHandler.IsActive)
@@ -453,11 +453,16 @@ namespace PlayniteUI
                     {
                         if (updater.IsUpdateAvailable)
                         {
-                            Dispatcher.Invoke(() =>
+                            if (!CurrentApp.IsActive)
                             {
-                                var model = new UpdateViewModel(updater, UpdateWindowFactory.Instance, new DefaultResourceProvider(), dialogs);
-                                model.OpenView();
-                            });
+                                UpdateViewModel.NotifyInWindows();
+                            }
+                            else
+                            {
+                                Api.Notifications.Add(new NotificationMessage("UpdateAvailable",
+                                    DefaultResourceProvider.FindString("LOCUpdateIsAvailableNotificationBody"),
+                                    NotificationType.Info, null));
+                            }
                         }
                     }
                     catch (Exception exc)

--- a/source/PlayniteUI/Localization/english.xaml
+++ b/source/PlayniteUI/Localization/english.xaml
@@ -533,6 +533,7 @@ You can try these to fix the issue:
     <sys:String x:Key="LOCGeneralUpdateFailMessage">Failed to download and install update.</sys:String>
     <sys:String x:Key="LOCUpdateProgressCancelAsk">Background task is currently running, do you want to cancel it and proceed with update installation?</sys:String>
     <sys:String x:Key="LOCBackgroundProgressCancelAskExit">Background task is currently running, do you want to cancel it and close Playnite?</sys:String>
+    <sys:String x:Key="LOCUpdateIsAvailableNotificationBody">A new update is available for Playnite</sys:String>
 
     <sys:String x:Key="LOCThemeTestReloadList">Reload theme list</sys:String>
     <sys:String x:Key="LOCThemeTestApplySkin">Apply selected theme</sys:String>

--- a/source/PlayniteUI/ViewModels/UpdateViewModel.cs
+++ b/source/PlayniteUI/ViewModels/UpdateViewModel.cs
@@ -4,11 +4,10 @@ using Playnite.SDK;
 using PlayniteUI.Commands;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.Drawing;
 using System.Threading;
-using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Forms;
 
 namespace PlayniteUI.ViewModels
 {
@@ -150,6 +149,25 @@ namespace PlayniteUI.ViewModels
                 window.Close();
                 return;
             }
+        }
+
+        public static void NotifyInWindows()
+        {
+            var notifyIcon = new NotifyIcon
+            {
+                Visible = true,
+                Icon = Icon.ExtractAssociatedIcon(@"PlayniteUI.exe"),
+                BalloonTipTitle = DefaultResourceProvider.FindString("LOCUpdaterWindowTitle"),
+                BalloonTipText = DefaultResourceProvider.FindString("LOCUpdateIsAvailableNotificationBody")
+            };
+            notifyIcon.BalloonTipClicked += RestoreMainWindow;
+
+            notifyIcon.ShowBalloonTip(5000);
+        }
+
+        private static void RestoreMainWindow(object a, EventArgs e)
+        {
+            App.CurrentApp.MainViewWindow.RestoreWindow();
         }
     }
 }


### PR DESCRIPTION
Fixes #995

The background update check now shows a notification in Playnite if Playnite is active, otherwise a balloon tip/w10 notification pops up in the background.

One thing that could perhaps improve this is binding the action of opening the update window simply by clicking the notification? I've noticed that there's an `InvokeAction` property in the `NotificationMessage` class. However, it does not seem to be utilized anywhere as of right now and every constructor call just passes in the null parameter.