### PR TITLE
Rework background update notifications (devel rebase)

### DIFF
--- a/source/Playnite.DesktopApp/DesktopApplication.cs
+++ b/source/Playnite.DesktopApp/DesktopApplication.cs
@@ -235,7 +235,14 @@ namespace Playnite.DesktopApp
         {
             var icon = new Icon(ThemeFile.GetFilePath("Images/applogo.ico", ThemeManager.DefaultTheme,
                 ThemeManager.CurrentTheme));
-            trayIcon.ShowBalloonTip(title, body, icon, true);
+            if (AppSettings.EnableTray)
+            {
+                trayIcon.ShowBalloonTip(title, body, icon, true);
+            }
+            else
+            {
+                WindowsNotifyIconManager.Notify(icon, title, body);
+            }
 
         }
     }

--- a/source/Playnite.DesktopApp/DesktopApplication.cs
+++ b/source/Playnite.DesktopApp/DesktopApplication.cs
@@ -230,5 +230,13 @@ namespace Playnite.DesktopApp
 
             return isFirstStart;
         }
+
+        public override void NotifyInWindows(string title, string body)
+        {
+            var icon = new Icon(ThemeFile.GetFilePath("Images/applogo.ico", ThemeManager.DefaultTheme,
+                ThemeManager.CurrentTheme));
+            trayIcon.ShowBalloonTip(title, body, icon, true);
+
+        }
     }
 }

--- a/source/Playnite/App/PlayniteApplication.cs
+++ b/source/Playnite/App/PlayniteApplication.cs
@@ -2,12 +2,10 @@
 using Playnite.Input;
 using Playnite.SDK;
 using Playnite.Plugins;
-using Playnite.Settings;
 using Playnite.ViewModels;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
@@ -15,8 +13,6 @@ using System.Diagnostics;
 using Playnite.Database;
 using Playnite.API;
 using TheArtOfDev.HtmlRenderer;
-using Playnite.SDK.Models;
-using Playnite.WebView;
 using Playnite.Services;
 using System.Windows.Input;
 using System.Windows.Interop;
@@ -140,6 +136,8 @@ namespace Playnite
         public abstract void Restore();
 
         public abstract void Minimize();
+
+        public abstract void NotifyInWindows(string title, string body);
 
         private void Application_SessionEnding(object sender, SessionEndingCancelEventArgs e)
         {
@@ -442,15 +440,17 @@ namespace Playnite
                     {
                         if (updater.IsUpdateAvailable)
                         {
-                            CurrentNative.Dispatcher.Invoke(() =>
+                            var updateTitle = ResourceProvider.GetString("LOCUpdaterWindowTitle");
+                            var updateBody = ResourceProvider.GetString("LOCUpdateIsAvailableNotificationBody");
+                            if (!Current.IsActive)
                             {
-                                var model = new UpdateViewModel(
-                                    updater,
-                                    new UpdateWindowFactory(),
-                                    new ResourceProvider(),
-                                    Dialogs);
-                                model.OpenView();
-                            });
+                                NotifyInWindows(updateTitle, updateBody);
+                            }
+                            else
+                            {
+                                Api.Notifications.Add(new NotificationMessage("UpdateAvailable", updateBody,
+                                    NotificationType.Info, null));
+                            }
                         }
                     }
                     catch (Exception exc)

--- a/source/Playnite/App/PlayniteApplication.cs
+++ b/source/Playnite/App/PlayniteApplication.cs
@@ -446,11 +446,9 @@ namespace Playnite
                             {
                                 NotifyInWindows(updateTitle, updateBody);
                             }
-                            else
-                            {
-                                Api.Notifications.Add(new NotificationMessage("UpdateAvailable", updateBody,
-                                    NotificationType.Info, null));
-                            }
+
+                            Api.Notifications.Add(new NotificationMessage("UpdateAvailable", updateBody,
+                                NotificationType.Info, null));
                         }
                     }
                     catch (Exception exc)

--- a/source/Playnite/Localization/LocSource.xaml
+++ b/source/Playnite/Localization/LocSource.xaml
@@ -579,6 +579,7 @@ You can try these to fix the issue:
     <sys:String x:Key="LOCGeneralUpdateFailMessage">Failed to download and install update.</sys:String>
     <sys:String x:Key="LOCUpdateProgressCancelAsk">Background task is currently running, do you want to cancel it and proceed with update installation?</sys:String>
     <sys:String x:Key="LOCBackgroundProgressCancelAskExit">Background task is currently running, do you want to cancel it and close Playnite?</sys:String>
+    <sys:String x:Key="LOCUpdateIsAvailableNotificationBody">A new update is available for Playnite</sys:String>
 
     <sys:String x:Key="LOCThemeTestReloadList">Reload theme list</sys:String>
     <sys:String x:Key="LOCThemeTestApplySkin">Apply selected theme</sys:String>

--- a/source/Playnite/Playnite.csproj
+++ b/source/Playnite/Playnite.csproj
@@ -342,6 +342,7 @@
     <Compile Include="WebView\OffscreenWebView.cs" />
     <Compile Include="WebView\WebView.cs" />
     <Compile Include="WebView\WebViewFactory.cs" />
+    <Compile Include="WindowsNotifyIconManager.cs" />
     <Compile Include="Windows\CrashHandlerWindowFactory.cs" />
     <Compile Include="Windows\WebViewWindow.xaml.cs">
       <DependentUpon>WebViewWindow.xaml</DependentUpon>

--- a/source/Playnite/ViewModels/UpdateViewModel.cs
+++ b/source/Playnite/ViewModels/UpdateViewModel.cs
@@ -2,10 +2,7 @@
 using Playnite.Commands;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 using System.Windows;
 using Playnite.Windows;
 

--- a/source/Playnite/WindowsNotifyIconManager.cs
+++ b/source/Playnite/WindowsNotifyIconManager.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace Playnite
+{
+    public static class WindowsNotifyIconManager
+    {
+        public static void Notify(Icon icon, string title, string body, Action clickAction = null)
+        {
+            var notifyIcon = new NotifyIcon
+            {
+                Icon = icon,
+                BalloonTipTitle = title,
+                BalloonTipText = body,
+                Visible = true
+            };
+            notifyIcon.BalloonTipClicked += (o, ea) => { clickAction?.Invoke(); notifyIcon.Dispose(); };
+            notifyIcon.BalloonTipClosed += (o, ea) => { notifyIcon.Dispose(); };
+
+            notifyIcon.ShowBalloonTip(0); // Windows Vista and up timeout is 5sec by default, only Windows Accessibility Settings can override this
+        }
+    }
+}


### PR DESCRIPTION
Fixes #995 

So while working on this, I've noticed a minor annoyance with `NotifyIcon`, and that's if you don't `Dispose()` of it, the notification icon stays in the tray bar forever (or until you close Playnite). However, once I've hooked `Dispose()` to the notification close event, it would not stay in the W10 notification bar after a couple of seconds (so the notification would be utterly pointless while the person is let's say gaming in the background)

Therefore I've tried delving a little into `ToastNotification`, but quickly realized utilizing the API while the project doesn't target W10 specifically or is not a UWP app; becomes a real pain in the ass.

Finally, while traversing through the project, I've noticed that the `TaskBarIcon` class utilized for the tray operations of Playnite does provide the same balloon tip functionality without the above mentioned drawbacks. Well, except for one - hooking a custom click event into it doesn't seem so simple, so it can no longer be hooked into restoring the main window of Playnite upon clicking the notification.