### PR TITLE
Fix crash when exception hit partway through metadata download

### DIFF
--- a/source/Playnite/Metadata/MetadataDownloader.cs
+++ b/source/Playnite/Metadata/MetadataDownloader.cs
@@ -39,7 +39,7 @@ namespace Playnite.Metadata
         {
             foreach (var downloader in downloaders.Values)
             {
-                downloader.Dispose();
+                downloader?.Dispose();
             }
         }
 


### PR DESCRIPTION
`downloaders` elements can have `null` values; need to null-check before calling `Dispose()`