### PR TITLE
Replaces %CDN_HOST_MEDIA_SSL% for Steam games

### DIFF
--- a/source/Plugins/SteamLibrary/SteamMetadataProvider.cs
+++ b/source/Plugins/SteamLibrary/SteamMetadataProvider.cs
@@ -279,6 +279,11 @@ namespace SteamLibrary
             return metadata;
         }
 
+        internal string ParseDescription(string description)
+        {
+            return description.Replace("%CDN_HOST_MEDIA_SSL%", "steamcdn-a.akamaihd.net");
+        }
+
         internal GameMetadata GetGameMetadata(GameID gameId)
         {
             var appId = gameId.AppID;
@@ -312,7 +317,7 @@ namespace SteamLibrary
 
             if (downloadedMetadata.StoreDetails != null)
             {
-                gameInfo.Description = downloadedMetadata.StoreDetails.detailed_description;
+                gameInfo.Description = ParseDescription(downloadedMetadata.StoreDetails.detailed_description);
                 var cultInfo = new CultureInfo("en-US", false).TextInfo;
                 gameInfo.ReleaseDate = downloadedMetadata.StoreDetails.release_date.date;
                 gameInfo.CriticScore = downloadedMetadata.StoreDetails.metacritic?.score;


### PR DESCRIPTION
Adds a converter to automatically replace %CDN_HOST_MEDIA_SSL% with
steamcdn-a.akamaihd.net.

Affects Hollow Knight metadata import.

Fixes #1205.

Screenshot after fix:
![FixScreenshot](https://user-images.githubusercontent.com/2625852/61393451-d5049c80-a875-11e9-92fd-4d4ea57adfa3.png)
