### PR TITLE
Suppress splash screen when Playnite starts at Windows startup

### DIFF
--- a/source/Playnite.Common/Programs.cs
+++ b/source/Playnite.Common/Programs.cs
@@ -52,10 +52,10 @@ namespace Playnite.Common
     {
         private static ILogger logger = LogManager.GetLogger();
 
-        public static void CreateShortcut(string executablePath, string arguments, string iconPath, string shortuctPath)
+        public static void CreateShortcut(string executablePath, string arguments, string iconPath, string shortcutPath)
         {
             var shell = new IWshRuntimeLibrary.WshShell();
-            var link = (IWshRuntimeLibrary.IWshShortcut)shell.CreateShortcut(shortuctPath);
+            var link = (IWshRuntimeLibrary.IWshShortcut)shell.CreateShortcut(shortcutPath);
             link.TargetPath = executablePath;
             link.WorkingDirectory = Path.GetDirectoryName(executablePath);
             link.Arguments = arguments;

--- a/source/Playnite.DesktopApp/ProgramEntry.cs
+++ b/source/Playnite.DesktopApp/ProgramEntry.cs
@@ -24,7 +24,7 @@ namespace Playnite.DesktopApp
             }
 
             SplashScreen splash = null;
-            if (cmdLine.Start.IsNullOrEmpty())
+            if (cmdLine.Start.IsNullOrEmpty() && !cmdLine.HideSplashScreen)
             {
                 splash = new SplashScreen("SplashScreen.png");
                 splash.Show(false);

--- a/source/Playnite.FullscreenApp/ProgramEntry.cs
+++ b/source/Playnite.FullscreenApp/ProgramEntry.cs
@@ -23,7 +23,7 @@ namespace Playnite.FullscreenApp
             }
 
             SplashScreen splash = null;
-            if (cmdLine.Start.IsNullOrEmpty())
+            if (cmdLine.Start.IsNullOrEmpty() && !cmdLine.HideSplashScreen)
             {
                 splash = new SplashScreen("SplashScreen.png");
                 splash.Show(false);

--- a/source/Playnite/App/CmdLineOptions.cs
+++ b/source/Playnite/App/CmdLineOptions.cs
@@ -24,6 +24,9 @@ namespace Playnite
         [Option("forcedefaulttheme")]
         public bool ForceDefaultTheme { get; set; }
 
+        [Option("hidesplashscreen")]
+        public bool HideSplashScreen { get; set; }
+
         public override string ToString()
         {
             return Parser.Default.FormatCommandLine(this);

--- a/source/Playnite/Settings/PlayniteSettings.cs
+++ b/source/Playnite/Settings/PlayniteSettings.cs
@@ -1351,7 +1351,13 @@ namespace Playnite
             if (runOnBootup)
             {
                 FileSystem.DeleteFile(shortcutPath);
-                Programs.CreateShortcut(PlaynitePaths.DesktopExecutablePath, "--hidesplashscreen", "", shortcutPath);
+
+                var hideSplashScreenOption = new CmdLineOptions()
+                {
+                    HideSplashScreen = true
+                };
+
+                Programs.CreateShortcut(PlaynitePaths.DesktopExecutablePath, hideSplashScreenOption.ToString(), "", shortcutPath);
             }
             else
             {

--- a/source/Playnite/Settings/PlayniteSettings.cs
+++ b/source/Playnite/Settings/PlayniteSettings.cs
@@ -1351,7 +1351,7 @@ namespace Playnite
             if (runOnBootup)
             {
                 FileSystem.DeleteFile(shortcutPath);
-                Programs.CreateShortcut(PlaynitePaths.DesktopExecutablePath, "", "", shortcutPath);
+                Programs.CreateShortcut(PlaynitePaths.DesktopExecutablePath, "--hidesplashscreen", "", shortcutPath);
             }
             else
             {


### PR DESCRIPTION
For #1285 

Added a new startup argument named 'hidesplashscreen' which suppresses the splash screen when Playnite starts.  This parameter is added to the Playnite.lnk file which is generated when a user selects to start Playnite at windows startup (via Options...), thereby preventing the splash screen from appearing at Windows startup but retains the splash screen if Playnite is started manually.