### PR TITLE
Add Achievement links to Steam Games

### DIFF
--- a/source/Plugins/SteamLibrary/Steam.cs
+++ b/source/Plugins/SteamLibrary/Steam.cs
@@ -99,7 +99,7 @@ namespace SteamLibrary
 
         public static string GetAchievementsUrl(uint appId)
         {
-            return $"steam://openurl/https://steamcommunity.com/stats/{appId}/achievements";
+            return $"https://steamcommunity.com/stats/{appId}/achievements";
         }
 
         public static AppState GetAppState(GameID id)

--- a/source/Plugins/SteamLibrary/Steam.cs
+++ b/source/Plugins/SteamLibrary/Steam.cs
@@ -97,6 +97,11 @@ namespace SteamLibrary
             return $"https://steamcommunity.com/app/{appId}/workshop/";
         }
 
+        public static string GetAchievementsUrl(uint appId)
+        {
+            return $"steam://openurl/https://steamcommunity.com/stats/{appId}/achievements";
+        }
+
         public static AppState GetAppState(GameID id)
         {
             var state = new AppState();

--- a/source/Plugins/SteamLibrary/SteamMetadataProvider.cs
+++ b/source/Plugins/SteamLibrary/SteamMetadataProvider.cs
@@ -311,6 +311,11 @@ namespace SteamLibrary
                 BackgroundImage = downloadedMetadata.BackgroundImage
             };
 
+            if (downloadedMetadata.StoreDetails?.categories?.FirstOrDefault(a => a.id == 22) != null)
+            {
+                gameInfo.Links.Add(new Link("Achievements", Steam.GetAchievementsUrl(appId)));
+            }
+
             if (downloadedMetadata.StoreDetails?.categories?.FirstOrDefault(a => a.id == 30) != null)
             {
                 gameInfo.Links.Add(new Link("Workshop", Steam.GetWorkshopUrl(appId)));


### PR DESCRIPTION
The link opens in the Steam client, that way there won't be problems in case you are not logged in on Steam in the web browser. I figured this can be a solution until there's native achievement support in Playnite