### PR TITLE
Add FinalBurn Neo profile to RetroArch emulator definition

### DIFF
--- a/source/Playnite/Emulators/Definitions.yaml
+++ b/source/Playnite/Emulators/Definitions.yaml
@@ -870,6 +870,13 @@
       RequiredFiles: ['cores\fbalpha_libretro.dll']
       ExecutableLookup: ^retroarch\.exe$
 
+    - Name: FinalBurn Neo
+      DefaultArguments: '-L ".\cores\fbneo_libretro.dll" "{ImagePath}"'
+      Platforms: [Various]
+      ImageExtensions: [iso, zip, 7z]
+      RequiredFiles: ['cores\fbneo_libretro.dll']
+      ExecutableLookup: ^retroarch\.exe$
+
     - Name: FCEUmm
       DefaultArguments: '-L ".\cores\fceumm_libretro.dll" "{ImagePath}"'
       Platforms: [Nintendo Entertainment System, Nintendo Family Computer Disk System]


### PR DESCRIPTION
Originally had the profile name as "FB Neo" to better match the related cores, but then I realized RetroArch's Online Updater calls it "FinalBurn Neo" so I matched that instead.

Didn't place it in the list alphabetically since I wanted to keep it by the other FB/FinalBurn cores.