### PR TITLE
Modify Loc Strings related to playtime sync

### DIFF
--- a/source/Playnite/Localization/LocSource.xaml
+++ b/source/Playnite/Localization/LocSource.xaml
@@ -372,8 +372,8 @@ New database location will only be used after application is restarted.</sys:Str
     <sys:String x:Key="LOCSteamBackgroundSourceScreenshot">Store Screenshot</sys:String>
     <sys:String x:Key="LOCSteamBackgroundSourceStore">Store Background</sys:String>
     <sys:String x:Key="LOCBackgroundImageScreenOptionTooltip" xml:space="preserve">Doesn't apply retrospectively to existing games without re-downloading metadata.</sys:String>
-    <sys:String x:Key="LOCSettingsForceDownloadPlaynite">Force sync play time</sys:String>
-    <sys:String x:Key="LOCSettingsForceDownloadPlayniteTooltip">Always download recorded play time from remote library during library sync, ignoring time recorded by Playnite.</sys:String>
+    <sys:String x:Key="LOCSettingsForceDownloadPlaynite">Force sync Play Time for supported libraries</sys:String>
+    <sys:String x:Key="LOCSettingsForceDownloadPlayniteTooltip">Always download recorded Play Time from remote library during library sync, ignoring time recorded by Playnite. GOG, Origin and Steam libraries are supported when the user is authenticated.</sys:String>
     <sys:String x:Key="LOCSettingsXInputInDesktopMode">Enable controller support in Desktop mode</sys:String>
     <sys:String x:Key="LOCSettingsXInputGuideOpensFullscreen">Guide button opens Fullscreen mode</sys:String>
     <sys:String x:Key="LOCSettingsDefaultMetadataDescription">Configure settings used when metadata are being downloaded automatically after new games are imported.</sys:String>
@@ -694,7 +694,7 @@ You can try these to fix the issue:
     <sys:String x:Key="LOCMetadownloadSingleGameTip">Tip: You can use more advanced metadata download process while editing single game via "Edit" menu option.</sys:String>
     <sys:String x:Key="LOCProgreessAvailabilityMessage">Not available when some action is in progress.</sys:String>
     <sys:String x:Key="LOCDescriptionHTMLSupportTooltip">Description text is HTML syntax sensitive</sys:String>
-    <sys:String x:Key="LOCDescriptionPlaytimeSeconds">Playtime is tracked and stored in seconds.</sys:String>
+    <sys:String x:Key="LOCDescriptionPlaytimeSeconds">Play Time is tracked and stored in seconds.</sys:String>
     <sys:String x:Key="LOCDescriptionScoreValues">Values from 0 to 100 or empty for no score.</sys:String>
     <sys:String x:Key="LOCPatreonDevelopMessage">Playnite's development is supported by these patrons:</sys:String>
     <sys:String x:Key="LOCAboutContributorsMessage">Code, localization and other contributors in no particular order:</sys:String>

--- a/source/Playnite/Localization/LocSource.xaml
+++ b/source/Playnite/Localization/LocSource.xaml
@@ -373,7 +373,7 @@ New database location will only be used after application is restarted.</sys:Str
     <sys:String x:Key="LOCSteamBackgroundSourceStore">Store Background</sys:String>
     <sys:String x:Key="LOCBackgroundImageScreenOptionTooltip" xml:space="preserve">Doesn't apply retrospectively to existing games without re-downloading metadata.</sys:String>
     <sys:String x:Key="LOCSettingsForceDownloadPlaynite">Prioritize play time for supported libraries</sys:String>
-    <sys:String x:Key="LOCSettingsForceDownloadPlayniteTooltip">Always download recorded play time from remote library during library sync, ignoring time recorded by Playnite. GOG, Origin and Steam libraries are supported when the user is authenticated.</sys:String>
+    <sys:String x:Key="LOCSettingsForceDownloadPlayniteTooltip">Always download recorded play time from remote library during library sync, ignoring time recorded by Playnite.</sys:String>
     <sys:String x:Key="LOCSettingsXInputInDesktopMode">Enable controller support in Desktop mode</sys:String>
     <sys:String x:Key="LOCSettingsXInputGuideOpensFullscreen">Guide button opens Fullscreen mode</sys:String>
     <sys:String x:Key="LOCSettingsDefaultMetadataDescription">Configure settings used when metadata are being downloaded automatically after new games are imported.</sys:String>

--- a/source/Playnite/Localization/LocSource.xaml
+++ b/source/Playnite/Localization/LocSource.xaml
@@ -363,7 +363,7 @@ Any currently active tasks (metadata downloads) will be canceled.</sys:String>
     <sys:String x:Key="LOCSettingsDBPathNotification" xml:space="preserve">Playnite doesn't move library files automatically, you must move/copy them before the location is changed. If no library is present in target location, new one will be created.
 
 New database location will only be used after application is restarted.</sys:String>
-    <sys:String x:Key="LOCSettingsClosePlaytimeNotif">Gameplay time will not be recorded if "Close" action is set.</sys:String>
+    <sys:String x:Key="LOCSettingsClosePlaytimeNotif">Play time will not be recorded if "Close" action is set.</sys:String>
     <sys:String x:Key="LOCSettingsFullscreenRows">Number of rows</sys:String>
     <sys:String x:Key="LOCSettingsFullscreenColumns">Number of columns</sys:String>
     <sys:String x:Key="LOCSettingsFullscreenRowDetails">Number of detail view rows</sys:String>
@@ -372,8 +372,8 @@ New database location will only be used after application is restarted.</sys:Str
     <sys:String x:Key="LOCSteamBackgroundSourceScreenshot">Store Screenshot</sys:String>
     <sys:String x:Key="LOCSteamBackgroundSourceStore">Store Background</sys:String>
     <sys:String x:Key="LOCBackgroundImageScreenOptionTooltip" xml:space="preserve">Doesn't apply retrospectively to existing games without re-downloading metadata.</sys:String>
-    <sys:String x:Key="LOCSettingsForceDownloadPlaynite">Force sync Play Time for supported libraries</sys:String>
-    <sys:String x:Key="LOCSettingsForceDownloadPlayniteTooltip">Always download recorded Play Time from remote library during library sync, ignoring time recorded by Playnite. GOG, Origin and Steam libraries are supported when the user is authenticated.</sys:String>
+    <sys:String x:Key="LOCSettingsForceDownloadPlaynite">Prioritize play time for supported libraries</sys:String>
+    <sys:String x:Key="LOCSettingsForceDownloadPlayniteTooltip">Always download recorded play time from remote library during library sync, ignoring time recorded by Playnite. GOG, Origin and Steam libraries are supported when the user is authenticated.</sys:String>
     <sys:String x:Key="LOCSettingsXInputInDesktopMode">Enable controller support in Desktop mode</sys:String>
     <sys:String x:Key="LOCSettingsXInputGuideOpensFullscreen">Guide button opens Fullscreen mode</sys:String>
     <sys:String x:Key="LOCSettingsDefaultMetadataDescription">Configure settings used when metadata are being downloaded automatically after new games are imported.</sys:String>
@@ -694,7 +694,7 @@ You can try these to fix the issue:
     <sys:String x:Key="LOCMetadownloadSingleGameTip">Tip: You can use more advanced metadata download process while editing single game via "Edit" menu option.</sys:String>
     <sys:String x:Key="LOCProgreessAvailabilityMessage">Not available when some action is in progress.</sys:String>
     <sys:String x:Key="LOCDescriptionHTMLSupportTooltip">Description text is HTML syntax sensitive</sys:String>
-    <sys:String x:Key="LOCDescriptionPlaytimeSeconds">Play Time is tracked and stored in seconds.</sys:String>
+    <sys:String x:Key="LOCDescriptionPlaytimeSeconds">Play time is tracked and stored in seconds.</sys:String>
     <sys:String x:Key="LOCDescriptionScoreValues">Values from 0 to 100 or empty for no score.</sys:String>
     <sys:String x:Key="LOCPatreonDevelopMessage">Playnite's development is supported by these patrons:</sys:String>
     <sys:String x:Key="LOCAboutContributorsMessage">Code, localization and other contributors in no particular order:</sys:String>


### PR DESCRIPTION
I propose modifying three strings to be more clear:

1. `Force sync play time` -> `Force sync Play Time for supported libraries` (Makes it clear that not every library is supported)
2. `Always download recorded play time from remote library during library sync, ignoring time recorded by Playnite.` -> 
`Always download recorded Play Time from remote library during library sync, ignoring time recorded by Playnite. GOG, Origin and Steam libraries are supported when the user is authenticated.` (To specify exactly what libraries are supported and to explain that the user must be currently authenticated in each respective library for Playtime Sync to work.
3. `Playtime is tracked and stored in seconds.` -> `Play Time is tracked and stored in seconds.` (For consistency since the other strings have a space between `Play` and `Time`. I also capitalized the first letter of each word.

Just as another suggeston, I was thinking that the terms `Play Time` and `Time Played` in the different strings could be unified using one of the two, since they have the same meaning. If this was the case, I'm more inclined to use `Time Played`

I propose this because I've seen confusion on which libraries can sync playtime and some playtime sync problems that have been reported were because the user was not authenticated, as seen in #1481 and on discord different times. It should also be mentioned that the GOG sync is currently not working as mentioned in #1474