### PR TITLE
#1349 - Option to add description to crash dialog

### DIFF
--- a/source/Playnite.DesktopApp/Windows/CrashHandlerWindow.xaml
+++ b/source/Playnite.DesktopApp/Windows/CrashHandlerWindow.xaml
@@ -29,7 +29,7 @@
                    TextWrapping="Wrap" Foreground="{StaticResource TextBrush}" />
         <Label Content="{DynamicResource LOCCrashUserActionsDescription}" DockPanel.Dock="Top"
                Margin="10,10,10,0" FontSize="12"/>
-        <TextBox Name="TextBoxDescription" Text="{Binding Description}" Margin="10,10,10,10"
+        <TextBox Name="TextBoxDescription" Text="{Binding Description}" Margin="10,10,10,10" MinLines="3"
                  TextWrapping="Wrap" AcceptsReturn="True" AcceptsTab="True" SpellCheck.IsEnabled="True"/>
     </DockPanel>
 </controls:WindowBase>

--- a/source/Playnite.DesktopApp/Windows/CrashHandlerWindow.xaml
+++ b/source/Playnite.DesktopApp/Windows/CrashHandlerWindow.xaml
@@ -24,8 +24,12 @@
                     Command="{Binding ReportIssueCommand}"/>
         </DockPanel>
         <TextBlock Text="{DynamicResource LOCCrashDescription}"
-                   Margin="10,10,10,20"
+                   Margin="10,10,10,10"
                    VerticalAlignment="Center" DockPanel.Dock="Top" 
                    TextWrapping="Wrap" Foreground="{StaticResource TextBrush}" />
+        <Label Content="{DynamicResource LOCCrashUserActionsDescription}" DockPanel.Dock="Top"
+               Margin="10,10,10,0" FontSize="12"/>
+        <TextBox Name="TextBoxDescription" Text="{Binding Description}" Margin="10,10,10,10"
+                 TextWrapping="Wrap" AcceptsReturn="True" AcceptsTab="True" SpellCheck.IsEnabled="True"/>
     </DockPanel>
 </controls:WindowBase>

--- a/source/Playnite/Diagnostic.cs
+++ b/source/Playnite/Diagnostic.cs
@@ -1,26 +1,19 @@
-﻿using System;
+﻿using Playnite.Common;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.IO;
 using System.IO.Compression;
-using System.Diagnostics;
-using Newtonsoft.Json;
-using Playnite.Common;
-using Playnite.Settings;
 
 namespace Playnite
 {
     public static class Diagnostic
     {
-        public static void CreateDiagPackage(string path)
+        public static void CreateDiagPackage(string path, string userActionsDescription)
         {
             var diagTemp = Path.Combine(PlaynitePaths.TempPath, "diag");
             FileSystem.CreateDirectory(diagTemp, true);
-            FileSystem.DeleteFile(path);    
-            
-            ZipFile.CreateFromDirectory(diagTemp, path);            
+            FileSystem.DeleteFile(path);
+
+            ZipFile.CreateFromDirectory(diagTemp, path);
             using (FileStream zipToOpen = new FileStream(path, FileMode.Open))
             {
                 using (ZipArchive archive = new ZipArchive(zipToOpen, ZipArchiveMode.Update))
@@ -77,6 +70,14 @@ namespace Playnite
 
                     File.WriteAllText(playnitePath, Serialization.ToYaml(playniteInfo));
                     archive.CreateEntryFromFile(playnitePath, Path.GetFileName(playnitePath));
+
+                    // User actions description
+                    if (!string.IsNullOrWhiteSpace(userActionsDescription))
+                    {
+                        var descriptionPath = Path.Combine(diagTemp, "userActions.txt");
+                        File.WriteAllText(descriptionPath, userActionsDescription);
+                        archive.CreateEntryFromFile(descriptionPath, Path.GetFileName(descriptionPath));
+                    }
                 }
             }
 

--- a/source/Playnite/Localization/LocSource.xaml
+++ b/source/Playnite/Localization/LocSource.xaml
@@ -38,9 +38,9 @@ Indeterminate - No changes (when editing multiple games)</sys:String>
     <sys:String x:Key="LOCCrashWindowTitle">Oh no, something bad happened…</sys:String>
     <sys:String x:Key="LOCCrashDescription" xml:space="preserve">An unrecoverable error occurred.
         
-If you want to help us fix this issue, please briefly describe actions taken before the crash and then create a diagnostics package. If you are online, the package will get uploaded to the Playnite API.
+If you want to help us fix this issue, please briefly describe actions taken before the crash and then create a diagnostics package. If you are online, the package will get uploaded to the Playnite server for analysis.
 
-Alternatively, you can use the 'Report Crash' button to create a new issue on GitHub.
+Alternatively, you can use the 'Report Crash' button to create a new issue on GitHub and report the crash manually.
 
 Thank you for your help.</sys:String>
     <sys:String x:Key="LOCCrashDescriptionFullscreen" xml:space="preserve">Unrecoverable error occurred.

--- a/source/Playnite/Localization/LocSource.xaml
+++ b/source/Playnite/Localization/LocSource.xaml
@@ -38,13 +38,14 @@ Indeterminate - No changes (when editing multiple games)</sys:String>
     <sys:String x:Key="LOCCrashWindowTitle">Oh no, something bad happened…</sys:String>
     <sys:String x:Key="LOCCrashDescription" xml:space="preserve">Unrecoverable error occurred.
         
-If you want to help us fix this issue, please create diagnostics package and use 'Report Crash' button to let us know what happened. Thank you.</sys:String>
+If you want to help us fix this issue, please briefly describe actions taken before the crash, create a diagnostics package, and use the 'Report Crash' button to let us know what happened. Thank you.</sys:String>
     <sys:String x:Key="LOCCrashDescriptionFullscreen" xml:space="preserve">Unrecoverable error occurred.
         
 If you want to help us fix this issue, please send diagnostic information. Thank you.</sys:String>
     <sys:String x:Key="LOCCrashReportIssue">Report Crash</sys:String>
     <sys:String x:Key="LOCCrashRestartPlaynite">Restart Playnite</sys:String>
     <sys:String x:Key="LOCCrashClosePlaynite">Exit Playnite</sys:String>
+    <sys:String x:Key="LOCCrashUserActionsDescription">Actions taken before the crash:</sys:String>
 
     <sys:String x:Key="LOCLibraryManager">Library Manager</sys:String>
     <sys:String x:Key="LOCGameRemoveAskTitle">Remove Game(s)?</sys:String>

--- a/source/Playnite/Localization/LocSource.xaml
+++ b/source/Playnite/Localization/LocSource.xaml
@@ -36,16 +36,20 @@ Indeterminate - No changes (when editing multiple games)</sys:String>
     <sys:String x:Key="LOCNoPlatform">No Platform</sys:String>
 
     <sys:String x:Key="LOCCrashWindowTitle">Oh no, something bad happened…</sys:String>
-    <sys:String x:Key="LOCCrashDescription" xml:space="preserve">Unrecoverable error occurred.
+    <sys:String x:Key="LOCCrashDescription" xml:space="preserve">An unrecoverable error occurred.
         
-If you want to help us fix this issue, please briefly describe actions taken before the crash, create a diagnostics package, and use the 'Report Crash' button to let us know what happened. Thank you.</sys:String>
+If you want to help us fix this issue, please briefly describe actions taken before the crash and then create a diagnostics package. If you are online, the package will get uploaded to the Playnite API.
+
+Alternatively, you can use the 'Report Crash' button to create a new issue on GitHub.
+
+Thank you for your help.</sys:String>
     <sys:String x:Key="LOCCrashDescriptionFullscreen" xml:space="preserve">Unrecoverable error occurred.
         
 If you want to help us fix this issue, please send diagnostic information. Thank you.</sys:String>
     <sys:String x:Key="LOCCrashReportIssue">Report Crash</sys:String>
     <sys:String x:Key="LOCCrashRestartPlaynite">Restart Playnite</sys:String>
     <sys:String x:Key="LOCCrashClosePlaynite">Exit Playnite</sys:String>
-    <sys:String x:Key="LOCCrashUserActionsDescription">Actions taken before the crash:</sys:String>
+    <sys:String x:Key="LOCCrashUserActionsDescription">Actions taken before the crash (in English):</sys:String>
 
     <sys:String x:Key="LOCLibraryManager">Library Manager</sys:String>
     <sys:String x:Key="LOCGameRemoveAskTitle">Remove Game(s)?</sys:String>

--- a/source/Playnite/ViewModels/CrashHandlerViewModel.cs
+++ b/source/Playnite/ViewModels/CrashHandlerViewModel.cs
@@ -1,18 +1,11 @@
-﻿using Playnite;
-using Playnite.Common;
+﻿using Playnite.Common;
 using Playnite.SDK;
 using Playnite.Services;
-using Playnite.Settings;
-using Playnite.Commands;
+using Playnite.Windows;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
-using Playnite.Windows;
 
 namespace Playnite.ViewModels
 {
@@ -32,6 +25,17 @@ namespace Playnite.ViewModels
             set
             {
                 exception = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private string description;
+        public string Description
+        {
+            get => description;
+            set
+            {
+                description = value;
                 OnPropertyChanged();
             }
         }
@@ -125,7 +129,7 @@ namespace Playnite.ViewModels
 
             try
             {
-                Diagnostic.CreateDiagPackage(diagPath);
+                Diagnostic.CreateDiagPackage(diagPath, Description);
             }
             catch (Exception e) when (!PlayniteEnvironment.ThrowAllErrors)
             {


### PR DESCRIPTION
#1349 

This PR adds the option for the user to provide additional information about steps taken before a crash occurred. This description is then added as a text file to the diagnostic package.

There is another CrashWindow in the FullscreenApp project. Is that still work in progress? Should I add the textbox there as well?