### PR TITLE
Add Explorer panel Keyboard Shortcut for #1704

### DIFF
--- a/source/Playnite.DesktopApp/ViewModels/DesktopAppViewModel.cs
+++ b/source/Playnite.DesktopApp/ViewModels/DesktopAppViewModel.cs
@@ -414,7 +414,7 @@ namespace Playnite.DesktopApp.ViewModels
             ToggleExplorerPanelCommand = new RelayCommand<object>((game) =>
             {
                 AppSettings.ExplorerPanelVisible = !AppSettings.ExplorerPanelVisible;
-            });
+            }, new KeyGesture(Key.E, ModifierKeys.Control));
 
             ToggleFilterPanelCommand = new RelayCommand<object>((game) =>
             {
@@ -529,7 +529,7 @@ namespace Playnite.DesktopApp.ViewModels
                     Dialogs,
                     Resources));
             }, (a) => Database?.IsOpen == true,
-            new KeyGesture(Key.E, ModifierKeys.Control));
+            new KeyGesture(Key.Q, ModifierKeys.Control));
 
             AddWindowsStoreGamesCommand = new RelayCommand<object>((a) =>
             {

--- a/source/Playnite.DesktopApp/Windows/MainWindow.xaml
+++ b/source/Playnite.DesktopApp/Windows/MainWindow.xaml
@@ -65,6 +65,9 @@
         <KeyBinding Command="{Binding OpenSearchCommand}"
                 Key ="{Binding OpenSearchCommand.Gesture.Key}"
                 Modifiers="{Binding OpenSearchCommand.Gesture.Modifiers}" />
+        <KeyBinding Command="{Binding ToggleExplorerPanelCommand}"
+                Key ="{Binding ToggleExplorerPanelCommand.Gesture.Key}"
+                Modifiers="{Binding ToggleExplorerPanelCommand.Gesture.Modifiers}" />
         <KeyBinding Command="{Binding ToggleFilterPanelCommand}"
                 Key ="{Binding ToggleFilterPanelCommand.Gesture.Key}"
                 Modifiers="{Binding ToggleFilterPanelCommand.Gesture.Modifiers}" />


### PR DESCRIPTION
I have verified that:
- [ ] These changes work, by building the application and testing them.
- [x] Pull request is targeting `devel` branch.
- [x] I added myself into [contributors file](https://github.com/JosefNemec/Playnite/blob/devel/source/Playnite.DesktopApp/Resources/contributors.txt) if I want to receive contribution credit in the application itself.

For #1704
I think it makes more sense to use `ctrl+e` for the explorer panel, since the emulator import wizard is rarely used. I changed that one to `ctrl+q`, that way the key combination will be next to the library manager.
