### PR TITLE
Change "artwork" to "wallpaper" for google images for better results

### DIFF
--- a/source/Playnite.DesktopApp/ViewModels/GameEditViewModel.cs
+++ b/source/Playnite.DesktopApp/ViewModels/GameEditViewModel.cs
@@ -3286,7 +3286,7 @@ namespace Playnite.DesktopApp.ViewModels
 
         public void SelectGoogleBackground()
         {
-            var image = SelectGoogleImage($"{EditingGame.Name} artwork");
+            var image = SelectGoogleImage($"{EditingGame.Name} wallpaper");
             if (!image.IsNullOrEmpty())
             {
                 EditingGame.BackgroundImage = image;


### PR DESCRIPTION
I have verified that:
- [ ] These changes work, by building the application and testing them.
- [x] Pull request is targeting `devel` branch.
- [x] I added myself into [contributors file](https://github.com/JosefNemec/Playnite/blob/devel/source/Playnite.DesktopApp/Resources/contributors.txt) if I want to receive contribution credit in the application itself.

I've found that changing artwork to wallpaper in background images search for google images gets better results due to the following:

- Searching with artwork gives images with very diverse aspect ratios and resolutions
- Searching with wallpaper gives mostly images with widescreen aspect ratio and generally higher resolutions