### PR TITLE
add submenu for changing completion status to game context menu (#1796)

### DIFF
--- a/source/Playnite.DesktopApp/Controls/GameMenu.cs
+++ b/source/Playnite.DesktopApp/Controls/GameMenu.cs
@@ -266,6 +266,24 @@ namespace Playnite.DesktopApp.Controls
                 };
 
                 Items.Add(categoryItem);
+
+
+                //Set Completion Status
+                var completionItem = new MenuItem()
+                {
+                    Header = resources.GetString("LOCSetCompletionStatus")
+                };
+                foreach (CompletionStatus status in Enum.GetValues(typeof(CompletionStatus)))
+                {
+                    completionItem.Items.Add(new MenuItem
+                    {
+                        Header = status.GetDescription(),
+                        Command = model.SetGamesCompletionStatusCommand,
+                        CommandParameter = new Tuple<IEnumerable<Game>, CompletionStatus>(Games, status)
+                    });
+                }
+
+                Items.Add(completionItem);
                 Items.Add(new Separator());
 
                 // Remove
@@ -441,14 +459,14 @@ namespace Playnite.DesktopApp.Controls
                 //Set Completion Status
                 var completionItem = new MenuItem()
                 {
-                    Header = resources.GetString("LOCCompletionStatus")
+                    Header = resources.GetString("LOCSetCompletionStatus")
                 };
                 foreach(CompletionStatus status in Enum.GetValues(typeof(CompletionStatus)))
                 {
                     completionItem.Items.Add(new MenuItem
                     {
                         Header = status.GetDescription(),
-                        Command = model.SetCompletionStatusCommand,
+                        Command = model.SetGameCompletionStatusCommand,
                         CommandParameter = new Tuple<Game, CompletionStatus>(Game, status)
                     });
                 }

--- a/source/Playnite.DesktopApp/Controls/GameMenu.cs
+++ b/source/Playnite.DesktopApp/Controls/GameMenu.cs
@@ -437,6 +437,23 @@ namespace Playnite.DesktopApp.Controls
                 };
 
                 Items.Add(categoryItem);
+
+                //Set Completion Status
+                var completionItem = new MenuItem()
+                {
+                    Header = resources.GetString("LOCCompletionStatus")
+                };
+                foreach(CompletionStatus status in Enum.GetValues(typeof(CompletionStatus)))
+                {
+                    completionItem.Items.Add(new MenuItem
+                    {
+                        Header = status.GetDescription(),
+                        Command = model.SetCompletionStatusCommand,
+                        CommandParameter = new Tuple<Game, CompletionStatus>(Game, status)
+                    });
+                }
+
+                Items.Add(completionItem);
                 Items.Add(new Separator());
                 
                 // Remove

--- a/source/Playnite.DesktopApp/ViewModels/DesktopAppViewModel.cs
+++ b/source/Playnite.DesktopApp/ViewModels/DesktopAppViewModel.cs
@@ -358,8 +358,9 @@ namespace Playnite.DesktopApp.ViewModels
         public RelayCommand<IEnumerable<Game>> SetAsHiddensCommand { get; private set; }
         public RelayCommand<IEnumerable<Game>> RemoveAsHiddensCommand { get; private set; }
         public RelayCommand<Game> AssignGameCategoryCommand { get; private set; }
-        public RelayCommand<Tuple<Game, CompletionStatus>> SetCompletionStatusCommand { get; private set; }
         public RelayCommand<IEnumerable<Game>> AssignGamesCategoryCommand { get; private set; }
+        public RelayCommand<Tuple<Game, CompletionStatus>> SetGameCompletionStatusCommand { get; private set; }
+        public RelayCommand<Tuple<IEnumerable<Game>, CompletionStatus>> SetGamesCompletionStatusCommand { get; private set; }
         public RelayCommand<Game> RemoveGameCommand { get; private set; }
         public RelayCommand<IEnumerable<Game>> RemoveGamesCommand { get; private set; }
         public RelayCommand<object> SelectRandomGameCommand { get; private set; }
@@ -773,14 +774,19 @@ namespace Playnite.DesktopApp.ViewModels
                 }
             });
 
-            SetCompletionStatusCommand = new RelayCommand<Tuple<Game, CompletionStatus>>((a) =>
+            AssignGamesCategoryCommand = new RelayCommand<IEnumerable<Game>>((a) =>
+            {
+                GamesEditor.SetGamesCategories(a.ToList());
+            });
+
+            SetGameCompletionStatusCommand = new RelayCommand<Tuple<Game, CompletionStatus>>((a) =>
             {
                 GamesEditor.SetCompletionStatus(a.Item1, a.Item2);
             });
 
-            AssignGamesCategoryCommand = new RelayCommand<IEnumerable<Game>>((a) =>
+            SetGamesCompletionStatusCommand = new RelayCommand<Tuple<IEnumerable<Game>, CompletionStatus>>((a) =>
             {
-                GamesEditor.SetGamesCategories(a.ToList());
+                GamesEditor.SetCompletionStatus(a.Item1.ToList(), a.Item2);
             });
 
             RemoveGameCommand = new RelayCommand<Game>((a) =>

--- a/source/Playnite.DesktopApp/ViewModels/DesktopAppViewModel.cs
+++ b/source/Playnite.DesktopApp/ViewModels/DesktopAppViewModel.cs
@@ -358,6 +358,7 @@ namespace Playnite.DesktopApp.ViewModels
         public RelayCommand<IEnumerable<Game>> SetAsHiddensCommand { get; private set; }
         public RelayCommand<IEnumerable<Game>> RemoveAsHiddensCommand { get; private set; }
         public RelayCommand<Game> AssignGameCategoryCommand { get; private set; }
+        public RelayCommand<Tuple<Game, CompletionStatus>> SetCompletionStatusCommand { get; private set; }
         public RelayCommand<IEnumerable<Game>> AssignGamesCategoryCommand { get; private set; }
         public RelayCommand<Game> RemoveGameCommand { get; private set; }
         public RelayCommand<IEnumerable<Game>> RemoveGamesCommand { get; private set; }
@@ -770,6 +771,11 @@ namespace Playnite.DesktopApp.ViewModels
                 {
                     SelectedGame = GamesView.Items.FirstOrDefault(g => g.Id == a.Id);
                 }
+            });
+
+            SetCompletionStatusCommand = new RelayCommand<Tuple<Game, CompletionStatus>>((a) =>
+            {
+                GamesEditor.SetCompletionStatus(a.Item1, a.Item2);
             });
 
             AssignGamesCategoryCommand = new RelayCommand<IEnumerable<Game>>((a) =>

--- a/source/Playnite/GamesEditor.cs
+++ b/source/Playnite/GamesEditor.cs
@@ -328,6 +328,12 @@ namespace Playnite
             }
         }
 
+        public void SetCompletionStatus(Game game, CompletionStatus status)
+        {
+            game.CompletionStatus = status;
+            Database.Games.Update(game);
+        }
+
         public void RemoveGame(Game game)
         {
             if (game.IsInstalling || game.IsRunning || game.IsLaunching || game.IsUninstalling)

--- a/source/Playnite/GamesEditor.cs
+++ b/source/Playnite/GamesEditor.cs
@@ -330,8 +330,19 @@ namespace Playnite
 
         public void SetCompletionStatus(Game game, CompletionStatus status)
         {
-            game.CompletionStatus = status;
-            Database.Games.Update(game);
+            if (game.CompletionStatus != status)
+            {
+                game.CompletionStatus = status;
+                Database.Games.Update(game);
+            }
+        }
+
+        public void SetCompletionStatus(List<Game> games, CompletionStatus status)
+        {
+            foreach(var game in games)
+            {
+                SetCompletionStatus(game, status);
+            }
         }
 
         public void RemoveGame(Game game)

--- a/source/Playnite/Localization/LocSource.xaml
+++ b/source/Playnite/Localization/LocSource.xaml
@@ -741,6 +741,7 @@ You can try these to fix the issue:
     <sys:String x:Key="LOCUnHideGame">Show in Library</sys:String>
     <sys:String x:Key="LOCEditGame">Edit…</sys:String>
     <sys:String x:Key="LOCSetGameCategory">Set Category…</sys:String>
+    <sys:String x:Key="LOCSetCompletionStatus">Set Completion Status</sys:String>
     <sys:String x:Key="LOCRemoveGame">Remove</sys:String>
     <sys:String x:Key="LOCPlayGame">Play</sys:String>
     <sys:String x:Key="LOCInstallGame">Install</sys:String>

--- a/source/Playnite/Localization/de_DE.xaml
+++ b/source/Playnite/Localization/de_DE.xaml
@@ -740,6 +740,7 @@ Du kannst folgende Maßnahmen versuchen, um das Problem zu beheben:
     <sys:String x:Key="LOCUnHideGame">In Bibliothek anzeigen</sys:String>
     <sys:String x:Key="LOCEditGame">Bearbeiten …</sys:String>
     <sys:String x:Key="LOCSetGameCategory">Kategorie zuweisen …</sys:String>
+    <sys:String x:Key="LOCSetCompletionStatus">Spielfortschritt setzten</sys:String>
     <sys:String x:Key="LOCRemoveGame">Entfernen</sys:String>
     <sys:String x:Key="LOCPlayGame">Spielen</sys:String>
     <sys:String x:Key="LOCInstallGame">Installieren</sys:String>


### PR DESCRIPTION
Since this is my first contribution I wanted to make sure I can get everything to work before making promises on the ticket. So sorry for the "surprise" pull request.

As proposed in https://github.com/JosefNemec/Playnite/issues/1796 I added an item in the game context menu to change the completion status:
![completionStatus](https://user-images.githubusercontent.com/65420350/82093319-2f22f800-96fb-11ea-858f-f232a146b57a.png)

If this change is welcome I'd also make a similar change to the version of the context menu that handles multiple selected games.

Obviously the Header should be "Set Completion Status", but I don't know the process for updating the localizations so I reused the existing string.

I have verified that:

* [x]  These changes work, by building the application and testing them.
* [x]  Pull request is targeting `devel` branch.
* [ ]  I added myself into [contributors file](https://github.com/JosefNemec/Playnite/blob/devel/source/Playnite.DesktopApp/Resources/contributors.txt) if I want to receive contribution credit in the application itself.