### PR TITLE
Re-add Flash Projector emulator definition

### DIFF
--- a/source/Playnite/Emulators/Definitions.yaml
+++ b/source/Playnite/Emulators/Definitions.yaml
@@ -1,4 +1,13 @@
-﻿- Name: Reicast
+﻿- Name: Flash Player Projector
+  Website: 'https://www.adobe.com/support/flashplayer/debug_downloads.html'
+  Profiles:
+    - Name: Default
+      DefaultArguments: '"{ImagePath}"'
+      Platforms: [Adobe Flash]
+      ImageExtensions: [swf]
+      ExecutableLookup: ^flashplayer_\d+_sa\.exe$
+
+- Name: Reicast
   Website: 'https://reicast.com/'
   Profiles:
     - Name: Default


### PR DESCRIPTION
This is a duplicate of https://github.com/JosefNemec/Playnite/pull/893, but the Flash Projector emulator definition got [accidentally removed while updating RetroArch profiles](https://github.com/JosefNemec/Playnite/commit/68daa0b9e91d40090e2b54322aa0e7afd7bd9d7e#diff-0cf990744ae74442b8bc3b741400b3d0L1869-L1876).

I have not compiled this, but it's literally a copy-paste of the old definition. I added it to the top of the file this time, I'm not sure what the organization of this file is, it doesn't appear to be alphabetized.

I have verified that:
- [ ] These changes work, by building the application and testing them.
- [x] Pull request is targeting `devel` branch.
- [x] I added myself into [contributors file](https://github.com/JosefNemec/Playnite/blob/devel/source/Playnite.DesktopApp/Resources/contributors.txt) if I want to receive contribution credit in the application itself.
