### PR TITLE
Choosing the language for the game descriptions (#136)

### DIFF
--- a/source/Plugins/EpicLibrary/EpicLibrary.cs
+++ b/source/Plugins/EpicLibrary/EpicLibrary.cs
@@ -23,11 +23,39 @@ namespace EpicLibrary
         internal readonly string TokensPath;
         internal readonly EpicLibrarySettings LibrarySettings;
 
+        // For acces to staic function from EpicAccountClient / EpicMetadataProvider // WebStoreClient
+        public static string _EpicLang { get; set; }
+
         public EpicLibrary(IPlayniteAPI api) : base(api)
         {
             playniteApi = api;
-            LibrarySettings = new EpicLibrarySettings(this, api);
+            LibrarySettings = new EpicLibrarySettings(this, api)
+            {
+                EpicLangs = GetEpicLangs()
+            };
             TokensPath = Path.Combine(GetPluginUserDataPath(), "tokens.json");
+            _EpicLang = LibrarySettings.EpicLang;
+        }
+
+        // Initialize available language list for Steam if exist in Playnite language.
+        internal List<LocalEpicLang> GetEpicLangs()
+        {
+            //https://partner.steamgames.com/doc/store/localization?#supported_languages
+            List<LocalEpicLang> _EpicLang = new List<LocalEpicLang>();
+
+            _EpicLang.Add(new LocalEpicLang { EpicLangName = "zh-Hant", LocalLang = "繁體中文" });
+            _EpicLang.Add(new LocalEpicLang { EpicLangName = "en-US", LocalLang = "english" });
+            _EpicLang.Add(new LocalEpicLang { EpicLangName = "fr-FR", LocalLang = "Français" });
+            _EpicLang.Add(new LocalEpicLang { EpicLangName = "de-DE", LocalLang = "Deutsch" });
+            _EpicLang.Add(new LocalEpicLang { EpicLangName = "it-IT", LocalLang = "Italiano" });
+            _EpicLang.Add(new LocalEpicLang { EpicLangName = "ja-JP", LocalLang = "日本語" });
+            _EpicLang.Add(new LocalEpicLang { EpicLangName = "ko-KR", LocalLang = "한국어" });
+            _EpicLang.Add(new LocalEpicLang { EpicLangName = "ru-RU", LocalLang = "Русский" });
+            _EpicLang.Add(new LocalEpicLang { EpicLangName = "es-ES", LocalLang = "Español" });
+            _EpicLang.Add(new LocalEpicLang { EpicLangName = "pl-PL", LocalLang = "Polski" });
+            _EpicLang.Add(new LocalEpicLang { EpicLangName = "tr-TR", LocalLang = "Türkçe" });
+
+            return _EpicLang.OrderBy(a => a.LocalLang).ToList();
         }
 
         internal Dictionary<string, GameInfo> GetInstalledGames()

--- a/source/Plugins/EpicLibrary/EpicLibrary.csproj
+++ b/source/Plugins/EpicLibrary/EpicLibrary.csproj
@@ -80,6 +80,7 @@
     <Compile Include="Models\CatalogResponse.cs" />
     <Compile Include="Models\ErrorResponse.cs" />
     <Compile Include="Models\LauncherInstalled.cs" />
+    <Compile Include="Models\LocalEpicLang.cs" />
     <Compile Include="Models\OauthResponse.cs" />
     <Compile Include="EpicMetadataProvider.cs" />
     <Compile Include="Models\WebStoreModels.cs" />

--- a/source/Plugins/EpicLibrary/EpicLibrarySettings.cs
+++ b/source/Plugins/EpicLibrary/EpicLibrarySettings.cs
@@ -13,6 +13,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows.Media;
+using EpicLibrary.Models;
 
 namespace EpicLibrary
 {
@@ -35,7 +36,12 @@ namespace EpicLibrary
 
         public bool StartGamesWithoutLauncher { get; set; } = false;
 
+        public string EpicLang { get; set; } = "en-US";
+
         #endregion Settings
+
+        [JsonIgnore]
+        public List<LocalEpicLang> EpicLangs { get; set; }
 
         [JsonIgnore]
         public bool IsFirstRunUse { get; set; }
@@ -97,6 +103,7 @@ namespace EpicLibrary
         public void EndEdit()
         {
             library.SavePluginSettings(this);
+            EpicLibrary._EpicLang = this.EpicLang;
         }
 
         public bool VerifySettings(out List<string> errors)

--- a/source/Plugins/EpicLibrary/EpicLibrarySettingsView.xaml
+++ b/source/Plugins/EpicLibrary/EpicLibrarySettingsView.xaml
@@ -8,7 +8,7 @@
              xmlns:pcon="clr-namespace:Playnite.Converters"
              xmlns:pcmd="clr-namespace:Playnite.Commands"
              mc:Ignorable="d"
-             d:DesignHeight="250" d:DesignWidth="400">
+             d:DesignHeight="290" d:DesignWidth="400">
 
     <d:DesignerProperties.DesignStyle>
         <Style TargetType="UserControl">
@@ -84,5 +84,15 @@
                 <Run Text="{DynamicResource LOCTroubleShootingIssues}" />
             </Hyperlink>
         </TextBlock>
+
+        <StackPanel DockPanel.Dock="Top" Margin="0,25,5,5" Orientation="Horizontal">
+            <TextBlock Text="{DynamicResource LOCLanguageSettingsLabel}"
+                   VerticalAlignment="Center"/>
+            <ComboBox IsReadOnly="True" Margin="10,0,0,0"
+                      Name="ComboEpicLangMetadataImport"
+                      SelectedValue="{Binding EpicLang}"
+                      DisplayMemberPath="LocalLang" SelectedValuePath="EpicLangName"
+                      ItemsSource="{Binding EpicLangs}" />
+        </StackPanel>
     </StackPanel>
 </UserControl>

--- a/source/Plugins/EpicLibrary/EpicMetadataProvider.cs
+++ b/source/Plugins/EpicLibrary/EpicMetadataProvider.cs
@@ -39,13 +39,20 @@ namespace EpicLibrary
                     var product = client.GetProductInfo(catalogs[0].productSlug).GetAwaiter().GetResult();
                     if (product.pages.HasItems())
                     {
+                        string EpicLang = EpicLibrary._EpicLang;
+                        string EpicLangCountryFirst = EpicLang.Substring(0, 2);
+                        if (EpicLang == "es-ES" || EpicLang == "zh-Hant")
+                        {
+                            EpicLangCountryFirst = EpicLang;
+                        }
+
                         var page = product.pages[0];
                         gameInfo.Description = page.data.about.description;
                         gameInfo.Developers = new List<string>() { page.data.about.developerAttribution };
                         metadata.BackgroundImage = new MetadataFile(page.data.hero.backgroundImageUrl);
                         gameInfo.Links.Add(new Link(
                             library.PlayniteApi.Resources.GetString("LOCCommonLinksStorePage"),
-                            "https://www.epicgames.com/store/en-US/product/" + catalogs[0].productSlug));
+                            "https://www.epicgames.com/store/" + EpicLangCountryFirst + "/product/" + catalogs[0].productSlug));
 
                         if (page.data.socialLinks.HasItems())
                         {

--- a/source/Plugins/EpicLibrary/Models/LocalEpicLang.cs
+++ b/source/Plugins/EpicLibrary/Models/LocalEpicLang.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EpicLibrary.Models
+{
+    public class LocalEpicLang
+    {
+        public string EpicLangName
+        {
+            get; set;
+        }
+
+        public string LocalLang
+        {
+            get; set;
+        }
+    }
+}

--- a/source/Plugins/EpicLibrary/Models/WebStoreModels.cs
+++ b/source/Plugins/EpicLibrary/Models/WebStoreModels.cs
@@ -13,8 +13,8 @@ namespace EpicLibrary.Models
             public class Variables
             {
                 public string @namespace = "epic";
-                public string locale = "en-US";
-                public string country = "US";
+                public string locale = EpicLibrary._EpicLang;
+                public string country = EpicLibrary._EpicLang.Substring((EpicLibrary._EpicLang.Length - 2));
                 public string query;
             }
 

--- a/source/Plugins/EpicLibrary/Services/EpicAccountClient.cs
+++ b/source/Plugins/EpicLibrary/Services/EpicAccountClient.cs
@@ -187,7 +187,9 @@ namespace EpicLibrary.Services
                     throw new Exception("User is not authenticated.");
                 }
 
-                var url = string.Format("{0}/bulk/items?id={1}&country=US&locale=en-US", nameSpace, id);
+                string EpicLang = EpicLibrary._EpicLang;
+                string EpicLangCountry = EpicLang.Substring((EpicLang.Length - 2));
+                var url = string.Format("{0}/bulk/items?id={1}&country={2}&locale={3}", nameSpace, id, EpicLangCountry, EpicLang);
                 var catalogResponse = InvokeRequest<Dictionary<string, CatalogItem>>(catalogUrl + url, loadTokens()).GetAwaiter().GetResult();
                 result = catalogResponse.Item2;
                 FileSystem.WriteStringToFile(cachePath, catalogResponse.Item1);

--- a/source/Plugins/EpicLibrary/Services/WebStoreClient.cs
+++ b/source/Plugins/EpicLibrary/Services/WebStoreClient.cs
@@ -14,7 +14,7 @@ namespace EpicLibrary.Services
         private HttpClient httpClient = new HttpClient();
 
         public const string GraphQLEndpoint = @"https://graphql.epicgames.com/graphql";
-        public const string ProductUrlBase = @"https://store-content.ak.epicgames.com/api/en-US/content/products/{0}";
+        public const string ProductUrlBase = @"https://store-content.ak.epicgames.com/api/{1}/content/products/{0}";
 
         public WebStoreClient()
         {
@@ -38,8 +38,15 @@ namespace EpicLibrary.Services
 
         public async Task<WebStoreModels.ProductResponse> GetProductInfo(string productSlug)
         {
+            string EpicLang = EpicLibrary._EpicLang;
+            string EpicLangCountryFirst = EpicLang.Substring(0, 2);
+            if (EpicLang == "es-ES" || EpicLang == "zh-Hant")
+            {
+                EpicLangCountryFirst = EpicLang;
+            }
+
             var slugUri = productSlug.Split('/').First();
-            var productUrl = string.Format(ProductUrlBase, slugUri);
+            var productUrl = string.Format(ProductUrlBase, slugUri, EpicLangCountryFirst);
             var str = await httpClient.GetStringAsync(productUrl);
             return Serialization.FromJson<WebStoreModels.ProductResponse>(str);
         }

--- a/source/Plugins/OriginLibrary/Models/LocalOriginLang.cs
+++ b/source/Plugins/OriginLibrary/Models/LocalOriginLang.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OriginLibrary.Models
+{
+    public class LocalOriginLang
+    {
+        public string OriginLangName
+        {
+            get; set;
+        }
+
+        public string LocalLang
+        {
+            get; set;
+        }
+    }
+}

--- a/source/Plugins/OriginLibrary/OriginLibrary.cs
+++ b/source/Plugins/OriginLibrary/OriginLibrary.cs
@@ -50,9 +50,39 @@ namespace OriginLibrary
 
         internal OriginLibrarySettings LibrarySettings { get; private set; }
 
+        // For acces to staic function from OriginApiClient
+        public static string _OriginLang { get; set; }
+
         public OriginLibrary(IPlayniteAPI api) : base(api)
         {
-            LibrarySettings = new OriginLibrarySettings(this, PlayniteApi);
+            LibrarySettings = new OriginLibrarySettings(this, PlayniteApi)
+            {
+                OriginLangs = GetOriginLangs()
+            };
+            _OriginLang = LibrarySettings.OriginLang;
+        }
+
+        // Initialize available language list for Steam if exist in Playnite language.
+        internal List<LocalOriginLang> GetOriginLangs()
+        {
+            //https://partner.steamgames.com/doc/store/localization?#supported_languages
+            List<LocalOriginLang> _OriginLang = new List<LocalOriginLang>();
+
+            _OriginLang.Add(new LocalOriginLang { OriginLangName = "zh_TW", LocalLang = "繁體中文" });
+            _OriginLang.Add(new LocalOriginLang { OriginLangName = "nl_NL", LocalLang = "Nederlands" });
+            _OriginLang.Add(new LocalOriginLang { OriginLangName = "en_US", LocalLang = "english" });
+            _OriginLang.Add(new LocalOriginLang { OriginLangName = "fr_FR", LocalLang = "Français" });
+            _OriginLang.Add(new LocalOriginLang { OriginLangName = "de_DE", LocalLang = "Deutsch" });
+            _OriginLang.Add(new LocalOriginLang { OriginLangName = "it_IT", LocalLang = "Italiano" });
+            _OriginLang.Add(new LocalOriginLang { OriginLangName = "ja_JP", LocalLang = "日本語" });
+            _OriginLang.Add(new LocalOriginLang { OriginLangName = "ko_KR", LocalLang = "한국어" });
+            _OriginLang.Add(new LocalOriginLang { OriginLangName = "no_NO", LocalLang = "Norsk" });
+            _OriginLang.Add(new LocalOriginLang { OriginLangName = "pt_BR", LocalLang = "Português Brasileiro" });
+            _OriginLang.Add(new LocalOriginLang { OriginLangName = "ru_RU", LocalLang = "Русский" });
+            _OriginLang.Add(new LocalOriginLang { OriginLangName = "es_ES", LocalLang = "Español" });
+            _OriginLang.Add(new LocalOriginLang { OriginLangName = "sv_SE", LocalLang = "Svenska" });
+
+            return _OriginLang.OrderBy(a => a.LocalLang).ToList();
         }
 
         internal PlatformPath GetPathFromPlatformPath(string path, RegistryView platformView)

--- a/source/Plugins/OriginLibrary/OriginLibrary.csproj
+++ b/source/Plugins/OriginLibrary/OriginLibrary.csproj
@@ -71,6 +71,7 @@
     </Compile>
     <Compile Include="Environment.cs" />
     <Compile Include="Models\GameInstallerData.cs" />
+    <Compile Include="Models\LocalOriginLang.cs" />
     <Compile Include="Models\UsageReponse.cs" />
     <Compile Include="Models\AccountEntitlementsResponse.cs" />
     <Compile Include="Models\AccountInfoResponse.cs" />

--- a/source/Plugins/OriginLibrary/OriginLibrarySettings.cs
+++ b/source/Plugins/OriginLibrary/OriginLibrarySettings.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using OriginLibrary.Models;
 
 namespace OriginLibrary
 {
@@ -27,6 +28,8 @@ namespace OriginLibrary
         public bool ConnectAccount { get; set; } = false;
 
         public bool ImportUninstalledGames { get; set; } = false;
+
+        public string OriginLang { get; set; } = "en_US";
 
         #endregion Settings
 
@@ -51,6 +54,9 @@ namespace OriginLibrary
                 Login();
             });
         }
+
+        [JsonIgnore]
+        public List<LocalOriginLang> OriginLangs { get; set; }
 
         public OriginLibrarySettings()
         {
@@ -91,6 +97,7 @@ namespace OriginLibrary
         public void EndEdit()
         {
             library.SavePluginSettings(this);
+            OriginLibrary._OriginLang = this.OriginLang;
         }
 
         public bool VerifySettings(out List<string> errors)

--- a/source/Plugins/OriginLibrary/OriginLibrarySettingsView.xaml
+++ b/source/Plugins/OriginLibrary/OriginLibrarySettingsView.xaml
@@ -68,5 +68,15 @@
                 </TextBlock>
             </StackPanel>
         </StackPanel>
+
+        <StackPanel DockPanel.Dock="Top" Margin="0,25,5,5" Orientation="Horizontal">
+            <TextBlock Text="{DynamicResource LOCLanguageSettingsLabel}"
+                   VerticalAlignment="Center"/>
+            <ComboBox IsReadOnly="True" Margin="10,0,0,0"
+                      Name="ComboOriginLangMetadataImport"
+                      SelectedValue="{Binding OriginLang}"
+                      DisplayMemberPath="LocalLang" SelectedValuePath="OriginLangName"
+                      ItemsSource="{Binding OriginLangs}" />
+        </StackPanel>
     </StackPanel>
 </UserControl>

--- a/source/Plugins/OriginLibrary/Services/OriginApiClient.cs
+++ b/source/Plugins/OriginLibrary/Services/OriginApiClient.cs
@@ -17,7 +17,10 @@ namespace OriginLibrary.Services
 
         public static GameStoreDataResponse GetGameStoreData(string gameId)
         {
-            var url = string.Format(@"https://api2.origin.com/ecommerce2/public/supercat/{0}/en_IE?country=IE", gameId);
+            string OriginLang = OriginLibrary._OriginLang;
+            string OriginLangCountry = OriginLang.Substring((OriginLang.Length - 2));
+            var url = string.Format(@"https://api2.origin.com/ecommerce2/public/supercat/{0}/{1}?country={2}", 
+                gameId, OriginLang, OriginLangCountry);
             var stringData = Encoding.UTF8.GetString(HttpDownloader.DownloadData(url));
             return JsonConvert.DeserializeObject<GameStoreDataResponse>(stringData);
         }
@@ -27,7 +30,8 @@ namespace OriginLibrary.Services
             // Remove edition from offer path, offer path is: /<franchise>/<game>/<edition>
             var match = Regex.Match(offerPath, @"(\/(.+?)\/(.+?))\/");
             var offer = match.Groups[1].Value.ToString();
-            var url = string.Format(@"https://data3.origin.com/ocd{0}.en-us.irl.ocd", offer);
+            string OriginLang = OriginLibrary._OriginLang.ToLower().Replace("_", "-");
+            var url = string.Format(@"https://data3.origin.com/ocd{0}.{1}.irl.ocd", offer, OriginLang);
             if (HttpDownloader.GetResponseCode(url) == System.Net.HttpStatusCode.OK)
             {
                 var stringData = Encoding.UTF8.GetString(HttpDownloader.DownloadData(url));
@@ -43,7 +47,8 @@ namespace OriginLibrary.Services
         {
             try
             {
-                var url = string.Format(@"https://api1.origin.com/ecommerce2/public/{0}/en_US", gameId);
+                string OriginLang = OriginLibrary._OriginLang;
+                var url = string.Format(@"https://api1.origin.com/ecommerce2/public/{0}/{1}", gameId, OriginLang);
                 var stringData = Encoding.UTF8.GetString(HttpDownloader.DownloadData(url));
                 return JsonConvert.DeserializeObject<GameLocalDataResponse>(stringData);
             }

--- a/source/Plugins/SteamLibrary/Models/LocalSteamLang.cs
+++ b/source/Plugins/SteamLibrary/Models/LocalSteamLang.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SteamLibrary.Models
+{
+    public class LocalSteamLang
+    {
+        public string SteamLangName
+        {
+            get; set;
+        }
+
+        public string LocalLang
+        {
+            get; set;
+        }
+    }
+}

--- a/source/Plugins/SteamLibrary/SteamLibrary.cs
+++ b/source/Plugins/SteamLibrary/SteamLibrary.cs
@@ -36,6 +36,9 @@ namespace SteamLibrary
         internal SteamLibrarySettings LibrarySettings { get; private set; }
         internal SteamServicesClient ServicesClient;
 
+        // For acces to staic function from WebApiClient
+        public static string _SteamLang { get; set; }
+
         public SteamLibrary(IPlayniteAPI api) : base(api)
         {
             Initialize(api);
@@ -53,8 +56,10 @@ namespace SteamLibrary
         {
             LibrarySettings = new SteamLibrarySettings(this, PlayniteApi)
             {
-                SteamUsers = GetSteamUsers()
+                SteamUsers = GetSteamUsers(),
+                SteamLangs = GetSteamLangs()
             };
+            _SteamLang = LibrarySettings.SteamLang;
         }
 
         internal static GameAction CreatePlayTask(GameID gameId)
@@ -348,6 +353,38 @@ namespace SteamLibrary
             }
 
             return users;
+        }
+
+        // Initialize available language list for Steam if exist in Playnite language.
+        internal List<LocalSteamLang> GetSteamLangs() {
+            //https://partner.steamgames.com/doc/store/localization?#supported_languages
+            List<LocalSteamLang> _SteamLangs = new List<LocalSteamLang>();
+
+            _SteamLangs.Add(new LocalSteamLang { SteamLangName = "arabic", LocalLang = "إنجليزية" });
+            _SteamLangs.Add(new LocalSteamLang { SteamLangName = "schinese", LocalLang = "简体中文" });
+            _SteamLangs.Add(new LocalSteamLang { SteamLangName = "tchinese", LocalLang = "繁體中文" });
+            _SteamLangs.Add(new LocalSteamLang { SteamLangName = "czech", LocalLang = "Čeština" });
+            _SteamLangs.Add(new LocalSteamLang { SteamLangName = "dutch", LocalLang = "Nederlands" });
+            _SteamLangs.Add(new LocalSteamLang { SteamLangName = "english", LocalLang = "english" });
+            _SteamLangs.Add(new LocalSteamLang { SteamLangName = "finnish", LocalLang = "Suomi" });
+            _SteamLangs.Add(new LocalSteamLang { SteamLangName = "french", LocalLang = "Français" });
+            _SteamLangs.Add(new LocalSteamLang { SteamLangName = "german", LocalLang = "Deutsch" });
+            _SteamLangs.Add(new LocalSteamLang { SteamLangName = "greek", LocalLang = "Greek" });
+            _SteamLangs.Add(new LocalSteamLang { SteamLangName = "hungarian", LocalLang = "Magyar" });
+            _SteamLangs.Add(new LocalSteamLang { SteamLangName = "italian", LocalLang = "Italiano" });
+            _SteamLangs.Add(new LocalSteamLang { SteamLangName = "japanese", LocalLang = "日本語" });
+            _SteamLangs.Add(new LocalSteamLang { SteamLangName = "koreana", LocalLang = "한국어" });
+            _SteamLangs.Add(new LocalSteamLang { SteamLangName = "norwegian", LocalLang = "Norsk" });
+            _SteamLangs.Add(new LocalSteamLang { SteamLangName = "polish", LocalLang = "Polski" });
+            _SteamLangs.Add(new LocalSteamLang { SteamLangName = "brazilian", LocalLang = "Português Brasileiro" });
+            _SteamLangs.Add(new LocalSteamLang { SteamLangName = "romanian", LocalLang = "Română" });
+            _SteamLangs.Add(new LocalSteamLang { SteamLangName = "russian", LocalLang = "Русский" });
+            _SteamLangs.Add(new LocalSteamLang { SteamLangName = "spanish", LocalLang = "Español" });
+            _SteamLangs.Add(new LocalSteamLang { SteamLangName = "swedish", LocalLang = "Svenska" });
+            _SteamLangs.Add(new LocalSteamLang { SteamLangName = "turkish", LocalLang = "Türkçe" });
+            _SteamLangs.Add(new LocalSteamLang { SteamLangName = "ukrainian", LocalLang = "Українська" });
+
+            return _SteamLangs.OrderBy(a => a.LocalLang).ToList();
         }
 
         internal List<GameInfo> GetLibraryGames(SteamLibrarySettings settings)

--- a/source/Plugins/SteamLibrary/SteamLibrary.csproj
+++ b/source/Plugins/SteamLibrary/SteamLibrary.csproj
@@ -83,6 +83,7 @@
     <Compile Include="GameExtension.cs" />
     <Compile Include="AppState.cs" />
     <Compile Include="Models\GetOwnedGamesResult.cs" />
+    <Compile Include="Models\LocalSteamLang.cs" />
     <Compile Include="Models\LocalSteamUser.cs" />
     <Compile Include="Models\ResolveVanityResult.cs" />
     <Compile Include="SteamShared\SteamGameMetadata.cs" />

--- a/source/Plugins/SteamLibrary/SteamLibrarySettings.cs
+++ b/source/Plugins/SteamLibrary/SteamLibrarySettings.cs
@@ -75,6 +75,8 @@ namespace SteamLibrary
 
         public BackgroundSource BackgroundSource { get; set; } = BackgroundSource.Image;
 
+        public string SteamLang { get; set; } = "english";
+
         #endregion Settings
 
         [JsonIgnore]
@@ -151,6 +153,9 @@ namespace SteamLibrary
         public List<LocalSteamUser> SteamUsers { get; set; }
 
         [JsonIgnore]
+        public List<LocalSteamLang> SteamLangs { get; set; }
+
+        [JsonIgnore]
         public RelayCommand<LocalSteamUser> ImportSteamCategoriesCommand
         {
             get => new RelayCommand<LocalSteamUser>((a) =>
@@ -207,6 +212,7 @@ namespace SteamLibrary
         public void EndEdit()
         {
             library.SavePluginSettings(this);
+            SteamLibrary._SteamLang = this.SteamLang;
         }
 
         public bool VerifySettings(out List<string> errors)

--- a/source/Plugins/SteamLibrary/SteamLibrarySettingsView.xaml
+++ b/source/Plugins/SteamLibrary/SteamLibrarySettingsView.xaml
@@ -9,7 +9,7 @@
              xmlns:pcon="clr-namespace:Playnite.Converters"
              xmlns:sys="clr-namespace:System;assembly=mscorlib"
              mc:Ignorable="d"              
-             d:DesignHeight="400" d:DesignWidth="600">
+             d:DesignHeight="450" d:DesignWidth="600">
 
     <d:DesignerProperties.DesignStyle>
         <Style TargetType="UserControl">
@@ -150,6 +150,17 @@
             <Button Content="{DynamicResource LOCImportSteamLastActivityLabel}" Name="ButtonImportSteamLastActivity"
                         Command="{Binding ImportSteamLastActivityCommand}"
                         CommandParameter="{Binding SelectedItem, ElementName=ComboSteamMetadataImport}"/>
+        </StackPanel>
+
+        <StackPanel DockPanel.Dock="Top" Margin="0,25,5,5" Orientation="Horizontal"
+                    Visibility="{Binding IsFirstRunUse, Converter={pcon:InvertedBooleanToVisibilityConverter}}">
+            <TextBlock Text="{DynamicResource LOCLanguageSettingsLabel}"
+                   VerticalAlignment="Center"/>
+            <ComboBox IsReadOnly="True" Margin="10,0,0,0"
+                      Name="ComboSteamLangMetadataImport"
+                      SelectedValue="{Binding SteamLang}"
+                      DisplayMemberPath="LocalLang" SelectedValuePath="SteamLangName"
+                      ItemsSource="{Binding SteamLangs}" />
         </StackPanel>
     </StackPanel>
 </UserControl>

--- a/source/Plugins/SteamLibrary/SteamShared/WebApiClient.cs
+++ b/source/Plugins/SteamLibrary/SteamShared/WebApiClient.cs
@@ -20,7 +20,8 @@ namespace Steam
 
         public static string GetRawStoreAppDetail(uint appId)
         {
-            var url = $"https://store.steampowered.com/api/appdetails?appids={appId}&l=english";
+            string SteamLang = SteamLibrary.SteamLibrary._SteamLang;
+            var url = $"https://store.steampowered.com/api/appdetails?appids={appId}&l={SteamLang}";
             return HttpDownloader.DownloadString(url);
         }
 


### PR DESCRIPTION
This modification is a way to propose the language selection for the store with a localization (#136).
Surely not the best.

Only for Steam, Origin and Epic store.

GOG script is already localized (perhaps with default).
It's possible to force a selectable localization.
I do it in my "SuccessStory plugin".

The others scripts uses IGDB.