### PR TITLE
Add new include_free_sub parameter for Steam GetOwnedGames API call.

### DIFF
--- a/source/PlayniteServices/Controllers/Steam/LibraryController.cs
+++ b/source/PlayniteServices/Controllers/Steam/LibraryController.cs
@@ -83,7 +83,7 @@ namespace PlayniteServices.Controllers.Steam
             var steamId = ulong.TryParse(userName, out var directId) ? directId.ToString() : GetUserId(userName);
 
             var libraryUrl = string.Format(
-                @"http://api.steampowered.com/IPlayerService/GetOwnedGames/v0001/?key={0}&include_appinfo=1&format=json&steamid={1}&include_played_free_games=1",
+                @"http://api.steampowered.com/IPlayerService/GetOwnedGames/v0001/?key={0}&include_appinfo=1&format=json&steamid={1}&include_played_free_games=1&include_free_sub=1",
                 Steam.ApiKey, steamId);
             WaitRequest();
 

--- a/source/Plugins/SteamLibrary/SteamLibrary.cs
+++ b/source/Plugins/SteamLibrary/SteamLibrary.cs
@@ -368,7 +368,7 @@ namespace SteamLibrary
 
         internal GetOwnedGamesResult GetPrivateOwnedGames(ulong userId, string apiKey)
         {
-            var libraryUrl = @"https://api.steampowered.com/IPlayerService/GetOwnedGames/v0001/?key={0}&include_appinfo=1&include_played_free_games=1&format=json&steamid={1}";
+            var libraryUrl = @"https://api.steampowered.com/IPlayerService/GetOwnedGames/v0001/?key={0}&include_appinfo=1&include_played_free_games=1&include_free_sub=1&format=json&steamid={1}";
             var stringLibrary = HttpDownloader.DownloadString(string.Format(libraryUrl, apiKey, userId));
             return JsonConvert.DeserializeObject<GetOwnedGamesResult>(stringLibrary);
         }


### PR DESCRIPTION
Recreating #1778 against devel8 per https://github.com/JosefNemec/Playnite/pull/1778#issuecomment-647020228
> Earlier this week, Steam added a new parameter to their IPlayerService/GetOwnedGames Web API call to opt into including free games that everyone owns. By adding this, more uninstalled games can be synced.
>
> In testing, it does pull at least some more for me.
>
> See: SteamDatabase/SteamTracking@e84ef2b#diff-1dd8848646dd2385514346656345b4d4R90 or https://api.steampowered.com/ISteamWebAPIUtil/GetSupportedAPIList/v1?key=KEYHERE

I have verified that:
- [x] These changes work, by building the application and testing them.
- [ ] Pull request is targeting `devel` branch.
- [x] I added myself into [contributors file](https://github.com/JosefNemec/Playnite/blob/devel/source/Playnite.DesktopApp/Resources/contributors.txt) if I want to receive contribution credit in the application itself.
