### PR TITLE
Use base game install folder with process watch for Steam mods (fixes #1936)

### DIFF
--- a/source/Plugins/SteamLibrary/SteamGameController.cs
+++ b/source/Plugins/SteamLibrary/SteamGameController.cs
@@ -44,15 +44,26 @@ namespace SteamLibrary
         public override void Play()
         {
             ReleaseResources();
+
+            var installDirectory = Game.InstallDirectory;
+            if (gameId.IsMod)
+            {
+                var allGames = library.GetInstalledGames(false);
+                if (allGames.TryGetValue(gameId.AppID.ToString(), out GameInfo realGame))
+                {
+                    installDirectory = realGame.InstallDirectory;
+                }
+            }
+
             OnStarting(this, new GameControllerEventArgs(this, 0));
             stopWatch = Stopwatch.StartNew();
             ProcessStarter.StartUrl($"steam://rungameid/{Game.GameId}");
             procMon = new ProcessMonitor();
             procMon.TreeStarted += ProcMon_TreeStarted;
             procMon.TreeDestroyed += Monitor_TreeDestroyed;
-            if (Directory.Exists(Game.InstallDirectory))
+            if (Directory.Exists(installDirectory))
             {
-                procMon.WatchDirectoryProcesses(Game.InstallDirectory, false);
+                procMon.WatchDirectoryProcesses(installDirectory, false);
             }
             else
             {


### PR DESCRIPTION
Look up install folder of base game when launching a mod, using that in place of the mod's own install directory for the process watcher. Fixes #1936. Tested with a regular Steam game, a GoldSrc mod, and a Source mod.

I have verified that:
- [X] These changes work, by building the application and testing them.
- [X] Pull request is targeting `devel` branch.
- [X] I added myself into [contributors file](https://github.com/JosefNemec/Playnite/blob/devel/source/Playnite.DesktopApp/Resources/contributors.txt) if I want to receive contribution credit in the application itself.
