### PR TITLE
Makes images in description fit description size

### DIFF
--- a/source/Playnite/Resources/DescriptionView.html
+++ b/source/Playnite/Resources/DescriptionView.html
@@ -1,7 +1,7 @@
 ﻿<!DOCTYPE html>
 <html>
 <head>
-    <meta charset="UTF-8"> 
+    <meta charset="UTF-8">
     <style type="text/css">
         HTML,BODY
         {
@@ -16,6 +16,10 @@
             color: {link_foreground};
             text-decoration: none;
         }
+        
+        img {
+            max-width: 100%;
+        }
     </style>
     <title>Game Description</title>
 </head>
@@ -24,4 +28,4 @@
 {text}
 </div>
 </body>
-</html> 
+</html>


### PR DESCRIPTION
Makes images in description fit description size by modifying the default "img" style

I have verified that:
- [x] These changes work, by building the application and testing them.
- [x] Pull request is targeting `devel` branch.
- [x] I added myself into [contributors file](https://github.com/JosefNemec/Playnite/blob/devel/source/Playnite.DesktopApp/Resources/contributors.txt) if I want to receive contribution credit in the application itself.
