### PR TITLE
Added names to PowerShell runspaces for easier debugging

### DIFF
--- a/source/Playnite/GamesEditor.cs
+++ b/source/Playnite/GamesEditor.cs
@@ -1107,7 +1107,7 @@ namespace Playnite
             switch (language)
             {
                 case ScriptLanguage.PowerShell:
-                    runtime = new Scripting.PowerShell.PowerShellRuntime();
+                    runtime = new Scripting.PowerShell.PowerShellRuntime($"Inline script: {game.Name}");
                     break;
                 case ScriptLanguage.IronPython:
                     runtime = new Scripting.IronPython.IronPythonRuntime();

--- a/source/Playnite/Scripting/PowerShell/PowerShell.cs
+++ b/source/Playnite/Scripting/PowerShell/PowerShell.cs
@@ -26,9 +26,10 @@ namespace Playnite.Scripting.PowerShell
             }
         }
 
-        public PowerShellRuntime()
+        public PowerShellRuntime(string name)
         {
             runspace = RunspaceFactory.CreateRunspace();
+            runspace.Name = name;
             runspace.ApartmentState = System.Threading.ApartmentState.MTA;
             runspace.ThreadOptions = PSThreadOptions.UseCurrentThread;
             runspace.Open();
@@ -48,9 +49,9 @@ namespace Playnite.Scripting.PowerShell
             runspace.Close();
         }
 
-        public static PowerShellRuntime CreateRuntime()
+        public static PowerShellRuntime CreateRuntime(string name)
         {
-            return new PowerShellRuntime();
+            return new PowerShellRuntime(name);
         }
 
         public object Execute(string script, string workDir = null)

--- a/source/Playnite/Scripting/PowerShell/PowerShellScript.cs
+++ b/source/Playnite/Scripting/PowerShell/PowerShellScript.cs
@@ -21,7 +21,7 @@ namespace Playnite.Scripting.PowerShell
 
         public PowerShellScript(string path) : base(path)
         {
-            Runtime = new PowerShellRuntime();
+            Runtime = new PowerShellRuntime(Name);
             Runtime.ExecuteFile(path);
             SupportedEvents = GetSupportedEvents();
             SupportedMenus = GetSupportedMenus();

--- a/source/Tests/Playnite.Tests/Scripting/PowerShell/PowerShellTests.cs
+++ b/source/Tests/Playnite.Tests/Scripting/PowerShell/PowerShellTests.cs
@@ -18,7 +18,7 @@ namespace Playnite.Tests.Scripting.PowerShell
         [Test]
         public void ExecuteTest()
         {
-            using (var ps = new PowerShellRuntime())
+            using (var ps = new PowerShellRuntime("ExecuteTest"))
             {
                 var res = ps.Execute("return 2 + 2");
                 Assert.AreEqual(4, res);
@@ -28,7 +28,7 @@ namespace Playnite.Tests.Scripting.PowerShell
         [Test]
         public void ExecuteArgumentsTest()
         {
-            using (var ps = new PowerShellRuntime())
+            using (var ps = new PowerShellRuntime("ExecuteArgumentsTest"))
             {
                 var res = ps.Execute("return $param1 + $param2",
                     new Dictionary<string, object>()
@@ -44,7 +44,7 @@ namespace Playnite.Tests.Scripting.PowerShell
         [Test]
         public void FunctionExecuteTest()
         {
-            using (var ps = new PowerShellRuntime())
+            using (var ps = new PowerShellRuntime("FunctionExecuteTest"))
             {
                 ps.Execute(@"
 function TestFunc()
@@ -60,7 +60,7 @@ function TestFunc()
         [Test]
         public void ErrorHandlingTest()
         {
-            using (var ps = new PowerShellRuntime())
+            using (var ps = new PowerShellRuntime("ErrorHandlingTest"))
             {
                 Assert.Throws<ScriptRuntimeException>(() => ps.Execute("throw \"Testing Exception\""));
                 Assert.Throws<ScriptRuntimeException>(() => ps.Execute("1 / 0"));
@@ -70,7 +70,7 @@ function TestFunc()
         [Test]
         public void GetFunctionExitsTest()
         {
-            using (var ps = new PowerShellRuntime())
+            using (var ps = new PowerShellRuntime("GetFunctionExitsTest"))
             {
                 Assert.IsFalse(ps.GetFunctionExits("TestFunc"));
                 ps.Execute(@"
@@ -87,7 +87,7 @@ function TestFunc()
         public void ExecuteWorkDirTest()
         {
             using (var tempDir = TempDirectory.Create())
-            using (var runtime = new PowerShellRuntime())
+            using (var runtime = new PowerShellRuntime("ExecuteWorkDirTest"))
             {
                 var outPath = "workDirTest.txt";
                 FileSystem.DeleteFile(outPath);


### PR DESCRIPTION
Add names to PowerShell runspaces for easier debugging.

Example usage:
```
PS C:\Users\Blake\Code\playnite\Playnite> Enter-PSHostProcess -Name Playnite.DesktopApp
[Process:19948]: PS C:\Users\Blake\Documents> Get-Runspace
 Id Name            ComputerName    Type          State         Availability
 -- ----            ------------    ----          -----         ------------
  1 LibraryExpor... localhost       Local         Opened        Available
  3 RemoteHost      localhost       Local         Opened        Busy
  4 Inline scrip... localhost       Local         Opened        Busy
[Process:19948]: PS C:\Users\Blake\Documents> (Get-Runspace).Name
LibraryExporter.ps1
RemoteHost
Inline script: EnterTheGungeon
[Process:19948]: PS C:\Users\Blake\Documents> Debug-Runspace -Name "LibraryExporter.ps1"
Debugging Runspace: LibraryExporter.ps1
To end the debugging session type the 'Detach' command at the debugger prompt, or type 'Ctrl+C' otherwise.

Entering debug mode. Use h or ? for help.
```

If you run the above commands in the VS Code integrated PowerShell console it will attach VS Code's debugger to the extension. Breakpoints _do not_ appear to be working, instead the debugger breaks immediately on the next line of PS code executed. That actually doesn't work very well for events or [`GetMainMenuItems`](https://github.com/JosefNemec/Playnite/blob/dda4f037ae1d23b81c51f52fe5c9c0fa1e349a5b/source/Plugins/LibraryExporter/LibraryExporter.ps1), you never get the debugger to land in your code. To reattach the debugger you have to press Control-C and rerun `Debug-Runspace`.

Some reason my implementation in #924 didn't have the above limitations. That PR also had significant PS changes and loaded extension code as PS modules instead of eval-ing the script source. That caused the debugger to show the correct filename when debugging, and may be related. This PR is far simpler though and hopefully can be merged easily.

If you click "Reload Scripts" you will see duplicate runspaces and will need to select the most recent one using `Debug-Runspace -Id 123`.

Even with those limitations, I think this is an improvement for debugging PS extensions. I'll see if I can make more improvments in future PRs.

I tried to get the tests to build and run but I ran into [missing fonts](https://github.com/JosefNemec/Playnite/wiki/Building#fullscreen-mode-development).

I have verified that:
- [x] These changes work, by building the application and testing them.
- [x] Pull request is targeting `devel` branch.
- [x] I added myself into [contributors file](https://github.com/JosefNemec/Playnite/blob/devel/source/Playnite.DesktopApp/Resources/contributors.txt) if I want to receive contribution credit in the application itself.
