### PR TITLE
Refernce `pwsh.exe` without explicit path

### DIFF
--- a/build/copyPluginsToBuild.ps1
+++ b/build/copyPluginsToBuild.ps1
@@ -1,3 +1,5 @@
+#Requires -Version 7
+
 param(
     [string]$ConfigurationName,
     [string]$TargetDir,

--- a/source/Playnite.DesktopApp/Playnite.DesktopApp.csproj
+++ b/source/Playnite.DesktopApp/Playnite.DesktopApp.csproj
@@ -1134,7 +1134,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>SETX PLAYNITE_SLN $(SolutionDir)
-"C:\Program Files\PowerShell\7\pwsh.exe" -file "$(SolutionDir)\..\build\copyPluginsToBuild.ps1" "$(ConfigurationName)" "$(TargetDir)\" "$(SolutionDir)\"</PostBuildEvent>
+"pwsh.exe" -file "$(SolutionDir)\..\build\copyPluginsToBuild.ps1" "$(ConfigurationName)" "$(TargetDir)\" "$(SolutionDir)\"</PostBuildEvent>
     <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
   </PropertyGroup>
   <Import Project="..\packages\SQLitePCL.raw.0.8.4\build\net45\SQLitePCL.raw.targets" Condition="Exists('..\packages\SQLitePCL.raw.0.8.4\build\net45\SQLitePCL.raw.targets')" />

--- a/source/Playnite.FullscreenApp/Playnite.FullscreenApp.csproj
+++ b/source/Playnite.FullscreenApp/Playnite.FullscreenApp.csproj
@@ -514,7 +514,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>SETX PLAYNITE_SLN $(SolutionDir)
-"C:\Program Files\PowerShell\7\pwsh.exe" -file "$(SolutionDir)\..\build\copyPluginsToBuild.ps1" "$(ConfigurationName)" "$(TargetDir)\" "$(SolutionDir)\"</PostBuildEvent>
+"pwsh.exe" -file "$(SolutionDir)\..\build\copyPluginsToBuild.ps1" "$(ConfigurationName)" "$(TargetDir)\" "$(SolutionDir)\"</PostBuildEvent>
     <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
   </PropertyGroup>
   <Import Project="..\packages\SQLitePCL.raw.0.8.4\build\net45\SQLitePCL.raw.targets" Condition="Exists('..\packages\SQLitePCL.raw.0.8.4\build\net45\SQLitePCL.raw.targets')" />


### PR DESCRIPTION
PowerShell installs into different directories depending on how it was
installed. Use whatever `pwsh.exe` is in the path but explicitly check
version using `#Requires -Version` in the script files.

This change targets `master` because it's a fix for a build break rather than new feature work.

I have verified that:
- [x] These changes work, by building the application and testing them.
- [ ] Pull request is targeting `devel` branch.
- [x] I added myself into [contributors file](https://github.com/JosefNemec/Playnite/blob/devel/source/Playnite.DesktopApp/Resources/contributors.txt) if I want to receive contribution credit in the application itself.
