### PR TITLE
Improved single file import in InstalledGamesView for .lnk files

### DIFF
--- a/source/Playnite.DesktopApp/Resources/contributors.txt
+++ b/source/Playnite.DesktopApp/Resources/contributors.txt
@@ -41,3 +41,4 @@ elisherer
 awbooze
 erri120
 greggameplayer
+felixkmh

--- a/source/Playnite.DesktopApp/ViewModels/InstalledGamesViewModel.cs
+++ b/source/Playnite.DesktopApp/ViewModels/InstalledGamesViewModel.cs
@@ -360,7 +360,7 @@ namespace Playnite.DesktopApp.ViewModels
             };
 
             // Use shortcut name as game name for .lnk shortcuts
-            if (Path.GetExtension(path).EndsWith(".lnk", StringComparison.OrdinalIgnoreCase))
+            if (path.EndsWith(".lnk", StringComparison.OrdinalIgnoreCase))
             {
                 var shortcutName = Path.GetFileNameWithoutExtension(path);
                 if (!shortcutName.IsNullOrEmpty())

--- a/source/Playnite.DesktopApp/ViewModels/InstalledGamesViewModel.cs
+++ b/source/Playnite.DesktopApp/ViewModels/InstalledGamesViewModel.cs
@@ -347,13 +347,6 @@ namespace Playnite.DesktopApp.ViewModels
             }
             var program = Common.Programs.GetProgramData(path);
 
-            // Ignore all target files that are not bat or exe files
-            if (!program.Path.EndsWith(".exe", StringComparison.OrdinalIgnoreCase) &&
-                !program.Path.EndsWith(".bat", StringComparison.OrdinalIgnoreCase))
-            {
-                return;
-            }
-
             var import = new ImportableProgram(program, ProgramType.Win32)
             {
                 Selected = true

--- a/source/Playnite.DesktopApp/ViewModels/InstalledGamesViewModel.cs
+++ b/source/Playnite.DesktopApp/ViewModels/InstalledGamesViewModel.cs
@@ -365,7 +365,7 @@ namespace Playnite.DesktopApp.ViewModels
                 var shortcutName = Path.GetFileNameWithoutExtension(path);
                 if (!shortcutName.IsNullOrEmpty())
                 {
-                    import.Item.Name = Path.GetFileNameWithoutExtension(path);
+                    import.Item.Name = shortcutName;
                 }
             }
 


### PR DESCRIPTION
addressing #2215 
import single files similarly to how a whole folder is imported. Addtionally enables to import single .lnk files pointing to .exe or .bat files, or .bat files themselves.
Also: for .lnk files the file name of the shortcut is used as the game name, if it is not empty.