### PR TITLE
Github CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,14 @@
+name: Build
+on: [push, pull_request]
+
+jobs:
+  Launcher:
+    runs-on: windows-2019
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup MSBuild.exe
+      uses: microsoft/setup-msbuild@v1.0.2
+    - name: Restore packages
+      run: msbuild /t:restore source/Playnite.sln
+    - name: Build with MSBuild
+      run: msbuild source/Playnite.sln

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,4 +21,4 @@ jobs:
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.0.2
     - name: Build with MSBuild
-      run: msbuild source/Playnite.sln
+      run: msbuild source/Playnite.sln /property:Platform=x86

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,10 +5,14 @@ jobs:
   Launcher:
     runs-on: windows-2019
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Setup Nuget.exe
+      uses: nuget/setup-nuget@v1
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.0.2
     - name: Restore packages
-      run: msbuild /t:restore source/Playnite.sln
+      run: nuget restore source/Playnite.sln
     - name: Build with MSBuild
       run: msbuild source/Playnite.sln

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,9 +10,15 @@ jobs:
 
     - name: Setup Nuget.exe
       uses: nuget/setup-nuget@v1
-    - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1.0.2
     - name: Restore packages
       run: nuget restore source/Playnite.sln
+
+    - name: Copy font files to avoid build errors
+      run: |
+        cp references\Fonts\TitilliumWeb-Black.ttf references\Fonts\PlayStation4.ttf
+        cp references\Fonts\TitilliumWeb-Black.ttf references\Fonts\XBOXONE.ttf
+
+    - name: Setup MSBuild.exe
+      uses: microsoft/setup-msbuild@v1.0.2
     - name: Build with MSBuild
       run: msbuild source/Playnite.sln

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 on: [push, pull_request]
 
 jobs:
-  Launcher:
+  Playnite-sln:
     runs-on: windows-2019
     steps:
     - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# <img src="https://github.com/JosefNemec/Playnite/raw/master/web/applogo.png" width="32">  Playnite
+# <img src="https://github.com/JosefNemec/Playnite/raw/master/web/applogo.png" width="32">  Playnite ![Build](https://github.com/JosefNemec/Playnite/workflows/Build/badge.svg)
 An open source video game library manager and launcher with support for 3rd party libraries like Steam, GOG, Origin, Battle.net and Uplay. Includes game emulation support, providing one unified interface for your games.
 
 Screenshots are available at the [Homepage](http://playnite.link/)

--- a/source/Playnite.DesktopApp/Resources/contributors.txt
+++ b/source/Playnite.DesktopApp/Resources/contributors.txt
@@ -41,3 +41,4 @@ elisherer
 awbooze
 erri120
 greggameplayer
+ScoWalt


### PR DESCRIPTION
I noticed there wasn't any continuous integration hooked up for Playnite. Using CI is great because it not only validates external pull requests, but also self-documents how to compile the code. Github is my favorite CI platform because it's free (for open source), simple to set up, and has nice integration with the rest of Github.

Example of a passing job: https://github.com/scowalt/Playnite/actions/runs/507747214

I have verified that:
- [x] These changes work, by building the application and testing them.
- [x] Pull request is targeting `devel` branch.
- [x] I added myself into [contributors file](https://github.com/JosefNemec/Playnite/blob/devel/source/Playnite.DesktopApp/Resources/contributors.txt) if I want to receive contribution credit in the application itself.
