### PR TITLE
Exit fullscreen

### DIFF
--- a/source/Playnite.FullscreenApp/Controls/Views/Main.cs
+++ b/source/Playnite.FullscreenApp/Controls/Views/Main.cs
@@ -193,12 +193,14 @@ namespace Playnite.FullscreenApp.Controls.Views
                     ViewHost.InputBindings.Add(new KeyBinding() { Command = mainModel.SwitchToDesktopCommand, Key = Key.F11 });
                     ViewHost.InputBindings.Add(new KeyBinding() { Command = mainModel.OpenSearchCommand, Key = Key.Y });
                     ViewHost.InputBindings.Add(new KeyBinding() { Command = mainModel.ToggleFiltersCommand, Key = Key.F });
+                    ViewHost.InputBindings.Add(new KeyBinding() { Command = mainModel.ExitCommandConf, Key = Key.B });
 
                     ViewHost.InputBindings.Add(new XInputBinding(mainModel.ToggleMainMenuCommand, XInputButton.Back));
                     ViewHost.InputBindings.Add(new XInputBinding(mainModel.PrevFilterViewCommand, XInputButton.LeftShoulder));
                     ViewHost.InputBindings.Add(new XInputBinding(mainModel.NextFilterViewCommand, XInputButton.RightShoulder));
                     ViewHost.InputBindings.Add(new XInputBinding(mainModel.OpenSearchCommand, XInputButton.Y));
                     ViewHost.InputBindings.Add(new XInputBinding(mainModel.ToggleFiltersCommand, XInputButton.RightStick));
+                    ViewHost.InputBindings.Add(new XInputBinding(mainModel.ExitCommandConf, XInputButton.B));
                 }
 
                 MainHost = Template.FindName("PART_MainHost", this) as FrameworkElement;

--- a/source/Playnite.FullscreenApp/Themes/Fullscreen/Default/Views/Main.xaml
+++ b/source/Playnite.FullscreenApp/Themes/Fullscreen/Default/Views/Main.xaml
@@ -244,6 +244,19 @@
                                             </StackPanel>
                                         </Button.Content>
                                     </Button>
+
+                                    <!--Exit-->
+                                    <Button x:Name="PART_ButtonExit" Focusable="False"
+                                        Style="{DynamicResource ButtonBottomMenu}">
+                                    <Button.Content>
+                                        <StackPanel Orientation="Horizontal">
+                                            <ContentControl Style="{DynamicResource ButtonPromptB}"
+                                                                Height="30" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                                            <TextBlock Text="{DynamicResource LOCExitAppLabel}" Style="{DynamicResource TextBlockBaseStyle}"
+                                                       VerticalAlignment="Center"/>
+                                        </StackPanel>
+                                    </Button.Content>
+                                </Button>
                                 </StackPanel>
 
                                 <StackPanel Grid.Column="2" x:Name="PART_ElemSearchActive"

--- a/source/Playnite.FullscreenApp/ViewModels/FullscreenAppViewModel.cs
+++ b/source/Playnite.FullscreenApp/ViewModels/FullscreenAppViewModel.cs
@@ -415,6 +415,7 @@ namespace Playnite.FullscreenApp.ViewModels
         public RelayCommand<CancelEventArgs> WindowClosingCommand { get; private set; }
         public RelayCommand<EventArgs> WindowGotFocusCommand { get; private set; }
         public RelayCommand<object> ExitCommand { get; private set; }
+        public RelayCommand<object> ExitCommandConf { get; private set; }
         public RelayCommand<object> SwitchToDesktopCommand { get; private set; }
         public RelayCommand<object> ToggleFullscreenCommand { get; private set; }
         public RelayCommand<object> ToggleMainMenuCommand { get; private set; }
@@ -520,7 +521,10 @@ namespace Playnite.FullscreenApp.ViewModels
 
         internal void SetQuickFilter(FullscreenSettings settings)
         {
-            settings.FilterSettings.ClearFilters();
+            settings.FilterSettings.ClearFilters(false);
+            settings.ViewSettings.SuppressNotifications = true;
+            settings.FilterSettings.SuppressFilterChanges = true;
+
             switch (settings.ActiveView)
             {
                 case ActiveFullscreenView.RecentlyPlayed:
@@ -551,6 +555,10 @@ namespace Playnite.FullscreenApp.ViewModels
                 //case ActiveFullscreenView.Explore:
                 //    break;
             }
+
+            settings.FilterSettings.SuppressFilterChanges = false;
+            settings.ViewSettings.SuppressNotifications = false;
+            settings.ViewSettings.OnPropertyChanged(nameof(settings.ViewSettings.SortingOrder));
         }
 
         internal bool GetIsExtraFilterActive(FullscreenSettings settings)
@@ -596,6 +604,19 @@ namespace Playnite.FullscreenApp.ViewModels
             ExitCommand = new RelayCommand<object>((a) =>
             {
                 Shutdown();
+            });
+
+            ExitCommandConf = new RelayCommand<object>((a) =>
+            {
+                if (Dialogs.ShowMessage("LOCConfirumationAskGeneric", "LOCExitPlaynite", MessageBoxButton.YesNo, MessageBoxImage.Question) != MessageBoxResult.Yes)
+                {
+                    return;
+                }
+
+                if (!PlayniteEnvironment.IsDebuggerAttached)
+                {
+                    Shutdown();
+                }
             });
 
             ToggleFullscreenCommand = new RelayCommand<object>((a) =>
@@ -1025,14 +1046,14 @@ namespace Playnite.FullscreenApp.ViewModels
             }
 
             CloseView();
-            application.Quit();
-            var cmdline = new CmdLineOptions()
-            {
-                SkipLibUpdate = true,
-                StartInDesktop = true
-            };
-
-            ProcessStarter.StartProcess(PlaynitePaths.DesktopExecutablePath, cmdline.ToString());
+            application.QuitAndStart(
+                PlaynitePaths.DesktopExecutablePath,
+                new CmdLineOptions()
+                {
+                    SkipLibUpdate = true,
+                    StartInDesktop = true,
+                    MasterInstance = true
+                }.ToString());
         }
 
         private GamesCollectionViewEntry SelectClosestGameDetails()

--- a/source/Playnite.FullscreenApp/ViewModels/FullscreenAppViewModel.cs
+++ b/source/Playnite.FullscreenApp/ViewModels/FullscreenAppViewModel.cs
@@ -521,10 +521,7 @@ namespace Playnite.FullscreenApp.ViewModels
 
         internal void SetQuickFilter(FullscreenSettings settings)
         {
-            settings.FilterSettings.ClearFilters(false);
-            settings.ViewSettings.SuppressNotifications = true;
-            settings.FilterSettings.SuppressFilterChanges = true;
-
+            settings.FilterSettings.ClearFilters();
             switch (settings.ActiveView)
             {
                 case ActiveFullscreenView.RecentlyPlayed:
@@ -555,10 +552,6 @@ namespace Playnite.FullscreenApp.ViewModels
                 //case ActiveFullscreenView.Explore:
                 //    break;
             }
-
-            settings.FilterSettings.SuppressFilterChanges = false;
-            settings.ViewSettings.SuppressNotifications = false;
-            settings.ViewSettings.OnPropertyChanged(nameof(settings.ViewSettings.SortingOrder));
         }
 
         internal bool GetIsExtraFilterActive(FullscreenSettings settings)
@@ -1046,14 +1039,14 @@ namespace Playnite.FullscreenApp.ViewModels
             }
 
             CloseView();
-            application.QuitAndStart(
-                PlaynitePaths.DesktopExecutablePath,
-                new CmdLineOptions()
-                {
-                    SkipLibUpdate = true,
-                    StartInDesktop = true,
-                    MasterInstance = true
-                }.ToString());
+            application.Quit();
+            var cmdline = new CmdLineOptions()
+            {
+                SkipLibUpdate = true,
+                StartInDesktop = true
+            };
+
+            ProcessStarter.StartProcess(PlaynitePaths.DesktopExecutablePath, cmdline.ToString());
         }
 
         private GamesCollectionViewEntry SelectClosestGameDetails()


### PR DESCRIPTION
I have verified that:
- [x] These changes work, by building the application and testing them.
- [x] Pull request is targeting `devel` branch.
- [ ] I added myself into [contributors file](https://github.com/JosefNemec/Playnite/blob/devel/source/Playnite.DesktopApp/Resources/contributors.txt) if I want to receive contribution credit in the application itself.

I closed the previous PR due to the excess commits. This now just contains my change. I also fixed the tabs.

This commit doesn't just initiate application shutdown when you press B, it asks for confirmation before it closes. I find this to be useful because if I'm using a controller for everything, I don't want to get my mouse and keyboard to exit Playnite. My use-case is launching Playnite from Kodi to play games and then back to Kodi for TV watching on my HTPC. Not having a way to exit with the controller adds extra steps. I know I'm not the only one that wants this, I saw a request on the subreddit asking for the same thing.

If the UI is too crowded at the bottom, the indicator for exiting could be removed but still have the functionality. Would it be better to have a setting option to enable/disable exiting by pressing B?