### PR TITLE
Fix: Prevent updating game library entries during library update when no data has changed. Fixes #2384

### DIFF
--- a/source/Playnite/Database/GameDatabase.cs
+++ b/source/Playnite/Database/GameDatabase.cs
@@ -1065,8 +1065,8 @@ namespace Playnite.Database
                             existingGame.IsInstalled = newGame.IsInstalled;
                             existingGameUpdated = true;
                         }
-                        
-                        if (existingGame.InstallDirectory.Equals(newGame.InstallDirectory, StringComparison.OrdinalIgnoreCase) == false)
+
+                        if (string.Equals(existingGame.InstallDirectory, newGame.InstallDirectory, StringComparison.OrdinalIgnoreCase) == false)
                         {
                             existingGame.InstallDirectory = newGame.InstallDirectory;
                             existingGameUpdated = true;

--- a/source/Playnite/Database/GameDatabase.cs
+++ b/source/Playnite/Database/GameDatabase.cs
@@ -1059,34 +1059,61 @@ namespace Playnite.Database
                     }
                     else
                     {
-                        existingGame.IsInstalled = newGame.IsInstalled;
-                        existingGame.InstallDirectory = newGame.InstallDirectory;
+                        var existingGameUpdated = false;
+                        if (existingGame.IsInstalled != newGame.IsInstalled)
+                        {
+                            existingGame.IsInstalled = newGame.IsInstalled;
+                            existingGameUpdated = true;
+                        }
+                        
+                        if (existingGame.InstallDirectory.Equals(newGame.InstallDirectory, StringComparison.OrdinalIgnoreCase) == false)
+                        {
+                            existingGame.InstallDirectory = newGame.InstallDirectory;
+                            existingGameUpdated = true;
+                        }
+                        
                         if (existingGame.PlayAction == null || existingGame.PlayAction.IsHandledByPlugin)
                         {
-                            existingGame.PlayAction = newGame.PlayAction;
+                            if (existingGame.PlayAction != newGame.PlayAction)
+                            {
+                                existingGame.PlayAction = newGame.PlayAction;
+                                existingGameUpdated = true;
+                            }
                         }
 
                         if ((existingGame.Playtime == 0 && newGame.Playtime > 0) ||
                            (newGame.Playtime > 0 && forcePlayTimeSync))
                         {
-                            existingGame.Playtime = newGame.Playtime;
+                            if (existingGame.Playtime != newGame.Playtime)
+                            {
+                                existingGame.Playtime = newGame.Playtime;
+                                existingGameUpdated = true;
+                            }
+
+                            
                             if (existingGame.CompletionStatus == CompletionStatus.NotPlayed)
                             {
                                 existingGame.CompletionStatus = CompletionStatus.Played;
+                                existingGameUpdated = true;
                             }
 
                             if (existingGame.LastActivity == null && newGame.LastActivity != null)
                             {
                                 existingGame.LastActivity = newGame.LastActivity;
+                                existingGameUpdated = true;
                             }
                         }
 
                         if (existingGame.OtherActions?.Any() != true && newGame.OtherActions?.Any() == true)
                         {
                             existingGame.OtherActions = new ObservableCollection<GameAction>(newGame.OtherActions);
+                            existingGameUpdated = true;
                         }
 
-                        Games.Update(existingGame);
+                        if (existingGameUpdated == true)
+                        {
+                            Games.Update(existingGame);
+                        }
                     }
                 }
 

--- a/source/Playnite/Database/GameDatabase.cs
+++ b/source/Playnite/Database/GameDatabase.cs
@@ -1090,7 +1090,6 @@ namespace Playnite.Database
                                 existingGameUpdated = true;
                             }
 
-                            
                             if (existingGame.CompletionStatus == CompletionStatus.NotPlayed)
                             {
                                 existingGame.CompletionStatus = CompletionStatus.Played;


### PR DESCRIPTION
Fix: Prevent updating game library entries during library update when no data has changed. Fixes #2384

I have verified that:
- [x] These changes work, by building the application and testing them.
- [x] Pull request is targeting `devel` branch.
- [x] I added myself into [contributors file](https://github.com/JosefNemec/Playnite/blob/devel/source/Playnite.DesktopApp/Resources/contributors.txt) if I want to receive contribution credit in the application itself.
