### PR TITLE
 New: Support to search for specific resolutions during google image searches and added resolution presets. Fixes #1674

### DIFF
--- a/source/Playnite.DesktopApp/ViewModels/GoogleImageDownloadViewModel.cs
+++ b/source/Playnite.DesktopApp/ViewModels/GoogleImageDownloadViewModel.cs
@@ -227,7 +227,7 @@ namespace Playnite.DesktopApp.ViewModels
         {
             AvailableImages = new List<GoogleImage>();
             var searchTerm = SearchTerm;
-            if (!string.IsNullOrEmpty(SearchWidth) && !string.IsNullOrEmpty(SearchWidth))
+            if (!string.IsNullOrEmpty(SearchWidth) && !string.IsNullOrEmpty(SearchHeight))
             {
                 searchTerm = $"{searchTerm} imagesize:{SearchWidth}x{SearchHeight}";
             }

--- a/source/Playnite.DesktopApp/Windows/GoogleImageDownloadWindow.xaml
+++ b/source/Playnite.DesktopApp/Windows/GoogleImageDownloadWindow.xaml
@@ -4,7 +4,9 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:controls="clr-namespace:Playnite.Controls;assembly=Playnite"
+        xmlns:pctrls="clr-namespace:Playnite.DesktopApp.Controls"
         xmlns:pcon="clr-namespace:Playnite.Converters;assembly=Playnite"
+        xmlns:pbeh="clr-namespace:Playnite.Behaviors;assembly=Playnite" 
         xmlns:i="clr-namespace:System.Windows.Interactivity;assembly=System.Windows.Interactivity"
         xmlns:prism="clr-namespace:Prism.Interactivity;assembly=Prism.Wpf"
         mc:Ignorable="d"
@@ -24,6 +26,7 @@
         <pcon:StringNullOrEmptyToVisibilityConverter x:Key="StringNullOrEmptyToVisibilityConverter" />
         <pcon:NegateConverter x:Key="NegateConverter" />
         <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+        <Style TargetType="TextBlock" BasedOn="{StaticResource BaseTextBlockStyle}" />
     </controls:WindowBase.Resources>
 
     <Grid Margin="0,4,0,0">
@@ -72,9 +75,38 @@
                 Command="{Binding LoadMoreCommand}"
                 Content="{DynamicResource LOCLoadMore}" />
 
-        <DockPanel Grid.Row="2" Margin="15,5,10,5">
+        <DockPanel Grid.Row="2" Margin="15,5,10,5" LastChildFill="True">
             <Button Name="ButtonSearch" Content="{DynamicResource LOCSearchLabel}" Padding="10,5,10,5" DockPanel.Dock="Left"
                     Command="{Binding SearchCommand}"/>
+            <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" VerticalAlignment="Center">
+                <TextBlock Name="TextBlockResolution" Text="{DynamicResource LOCSearchResolutionLabel}" Margin="10,0,0,0" VerticalAlignment="Center"/>
+                <pctrls:NullableIntBox MinValue="1" MaxValue="9999" Width="40"
+                                        Margin="10,0,0,0"
+                                        Value="{Binding SearchWidth}"/>
+                <TextBlock Text="x" VerticalAlignment="Center"
+                           Margin="4,0,4,0"/>
+                <pctrls:NullableIntBox MinValue="1" MaxValue="9999" Width="40"
+                                       Value="{Binding SearchHeight}"/>
+
+                <Button Content="{DynamicResource LOCPresets}" Margin="15,0,0,0" Padding="2"
+                        pbeh:LeftClickContextMenuBehavior.Enabled="True">
+                    <Button.ContextMenu>
+                        <ContextMenu Placement="Bottom">
+                            <MenuItem Header="{DynamicResource LOCSearchResolutionAnyLabel}"
+                                    Command="{Binding ClearSearchResolutionCommand}"/>
+                            <MenuItem Header="1920x620 (Steam Hero)"
+                                    Command="{Binding SetSearchResolutionCommand}"
+                                    CommandParameter="1920x620"/>
+                            <MenuItem Header="1920x1080 (1080p)"
+                                    Command="{Binding SetSearchResolutionCommand}"
+                                    CommandParameter="1920x1080"/>
+                            <MenuItem Header="2560x1440 (1440p)"
+                                    Command="{Binding SetSearchResolutionCommand}"
+                                    CommandParameter="2560x1440"/>
+                        </ContextMenu>
+                    </Button.ContextMenu>
+                </Button>
+            </StackPanel>
             <TextBox Name="TextSearch" Margin="10,0,0,0" DockPanel.Dock="Right" VerticalAlignment="Center"
                      Text="{Binding SearchTerm, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
                 <TextBox.InputBindings>

--- a/source/Playnite/Localization/LocSource.xaml
+++ b/source/Playnite/Localization/LocSource.xaml
@@ -146,6 +146,8 @@ Selecting "add to exclusion list" option will prevent games from being imported 
     <sys:String x:Key="LOCRemoveLabel">Remove</sys:String>
     <sys:String x:Key="LOCDownloadLabel">Download</sys:String>
     <sys:String x:Key="LOCSearchLabel">Search</sys:String>
+    <sys:String x:Key="LOCSearchResolutionLabel">Resolution:</sys:String>
+    <sys:String x:Key="LOCSearchResolutionAnyLabel">Any</sys:String>
     <sys:String x:Key="LOCZoomLabel">Zoom</sys:String>
     <sys:String x:Key="LOCListViewLabel">List View</sys:String>
     <sys:String x:Key="LOCCoversLabel">Covers</sys:String>


### PR DESCRIPTION
Fixes #1674
I have verified that:
- [x] These changes work, by building the application and testing them.
- [x] Pull request is targeting `devel` branch.
- [x] I added myself into [contributors file](https://github.com/JosefNemec/Playnite/blob/devel/source/Playnite.DesktopApp/Resources/contributors.txt) if I want to receive contribution credit in the application itself.

![image](https://user-images.githubusercontent.com/1389286/128782608-dd2d32d3-8076-4cd9-bc54-b711f276727c.png)
Added presets for background images for now. The `Any` option clears the text boxes