### PR TITLE
Fix: audio playback using linear Volume

### DIFF
--- a/source/Playnite/Audio.cs
+++ b/source/Playnite/Audio.cs
@@ -275,7 +275,7 @@ namespace Playnite.Audio
 
             var mixInput = new CachedSoundSampleProvider(sound);
             var ss = new VolumeSampleProvider(mixInput);
-            ss.Volume = volume;
+            ss.Volume = volume * volume;
             AddMixerInput(ss);
             return ss;
         }


### PR DESCRIPTION
Currently the volume settings behave weirdly because it's volume is linear. The volume should be calculated with a logarithm

Some resources:
- https://www.dr-lex.be/info-stuff/volumecontrols.html
- https://www.reddit.com/r/programming/comments/9n2y0/stop_making_linear_volume_controls/

There's some debate but the proposed and simple solutions is to calculate the volume with `x4` and `x2` respectively. 

![image](https://user-images.githubusercontent.com/1389286/131268374-29609c50-befa-4ce9-ad5c-ff6d31725623.png)

I tested both solutions and found `x2` to sound more natural. Notice how the volume growth sounds very unnatural in the lower values in the linear function.

Current (Linear):

https://user-images.githubusercontent.com/1389286/131268349-c9ff1f23-d0e2-4c00-a22f-66757c52f523.mp4

Proposed (`x2`):

https://user-images.githubusercontent.com/1389286/131268359-37b89e1e-7674-41f4-997d-020445e91f5d.mp4

I have verified that:
- [x] These changes work, by building the application and testing them.
- [x] Pull request is targeting `devel` branch.
- [x] I added myself into [contributors file](https://github.com/JosefNemec/Playnite/blob/devel/source/Playnite.DesktopApp/Resources/contributors.txt) if I want to receive contribution credit in the application itself.
