### PR TITLE
Fix: Game Edit media drag and drop fixes

### DIFF
--- a/source/Playnite/Localization/LocSource.xaml
+++ b/source/Playnite/Localization/LocSource.xaml
@@ -795,6 +795,8 @@ Covers: {1} mega pixels
 Backgrounds: {2} mega pixels</sys:String>
     <sys:String x:Key="LOCPerformanceWarningTitle">Performance Warning</sys:String>
     <sys:String x:Key="LOCDontShowAgainTitle">Don't Show Again</sys:String>
+    <sys:String x:Key="LOCIncompatibleDragAndDropExtensionError">File with extension {0} is not compatible.</sys:String>
+    <sys:String x:Key="LOCIncompatibleDragAndDropExtensionErrorTitle">Incompatible file extension</sys:String>
     <sys:String x:Key="LOCLargeMediaWarningTooltip">Selected image file might be too large for optimal performance.</sys:String>
     <sys:String x:Key="LOCThemeUninstallQuestion">Are you sure you want to uninstall selected theme? Uninstallation will be queued to next application start.</sys:String>
     <sys:String x:Key="LOCThemeBuiltInUninstallHint">Built-in themes can't be uninstalled.</sys:String>

--- a/source/Playnite/Localization/LocalizationKeys.cs
+++ b/source/Playnite/Localization/LocalizationKeys.cs
@@ -2850,13 +2850,21 @@ namespace Playnite
         /// </summary>
         public const string UrlNavigationMessage = "LOCUrlNavigationMessage";
         /// <summary>
-        /// The selected image(s) might be too large for optimal performance. Using very large images can result in worse UI responsiveness and increased memory usage. 
+        /// The selected image(s) might be too large for optimal performance. Using very large images can result in worse UI responsiveness and increased memory usage.
         /// </summary>
         public const string GameImageSizeWarning = "LOCGameImageSizeWarning";
         /// <summary>
         /// Performance Warning
         /// </summary>
         public const string PerformanceWarningTitle = "LOCPerformanceWarningTitle";
+        /// <summary>
+        /// File with extension {0} is not compatible.
+        /// </summary>
+        public const string IncompatibleDragAndDropExtensionError = "LOCIncompatibleDragAndDropExtensionError";
+        /// <summary>
+        /// Incompatible file extension
+        /// </summary>
+        public const string IncompatibleDragAndDropExtensionErrorTitle = "LOCIncompatibleDragAndDropExtensionErrorTitle";
         /// <summary>
         /// Don't Show Again
         /// </summary>


### PR DESCRIPTION
I have verified that:
- [x] These changes work, by building the application and testing them.
- [x] Pull request is targeting `devel` branch.
- [x] I added myself into [contributors file](https://github.com/JosefNemec/Playnite/blob/devel/source/Playnite.DesktopApp/Resources/contributors.txt) if I want to receive contribution credit in the application itself.


Fixes:
- Allow drag and drop of all compatible extensions listed in the file selection dialog. Fixes #1679
- Show an error dialog if a file with an incompatible extension is dragged
![image](https://user-images.githubusercontent.com/1389286/131761903-2cbf3ec1-52df-406b-9410-c2bd0f33f5e5.png)

- Small refactor to prevent duplicate code in several methods
- Added the performance check in methods missing them for consistency