### PR TITLE
New: Added settings to darken elements on Grid and Details View. Fixes #2209

### DIFF
--- a/source/Playnite.DesktopApp/Controls/SettingsSections/AppearanceDetailsView.xaml
+++ b/source/Playnite.DesktopApp/Controls/SettingsSections/AppearanceDetailsView.xaml
@@ -35,7 +35,12 @@
                                    IsEnabled="{Binding Settings.IndentGameDetails}" />
         </StackPanel>
 
-        <StackPanel Orientation="Horizontal" Margin="0,0,0,15">
+        <CheckBox Content="{DynamicResource LOCSettingsDarkenUninstalledIcons}" Margin="0,0,0,0"
+                  Name="CheckDarkenUninstalledDetailsIcons" IsChecked="{Binding Settings.DarkenUninstalledDetailsIcons}"/>
+        <CheckBox Content="{DynamicResource LOCSettingsDarkenUninstalledNames}" Margin="0,15,0,0"
+                  Name="CheckDarkenUninstalledDetailsNames" IsChecked="{Binding Settings.DarkenUninstalledDetailsNames}"/>
+
+        <StackPanel Orientation="Horizontal" Margin="0,15,0,15">
             <TextBlock VerticalAlignment="Center"
                        Text="{DynamicResource LOCSettingsGameDetailsCoverHeight}"/>
             <pctrls:NullIntNumericBox MinValue="0" MaxValue="4096" Width="60" Margin="10,0,0,0"

--- a/source/Playnite.DesktopApp/Controls/SettingsSections/AppearanceGridView.xaml
+++ b/source/Playnite.DesktopApp/Controls/SettingsSections/AppearanceGridView.xaml
@@ -52,7 +52,9 @@
         <CheckBox Content="{DynamicResource LOCSettingsShowNamesUnderCover}" Margin="0,15,0,0"
                   Name="CheckNameUnderCover" IsChecked="{Binding Settings.ShowNamesUnderCovers}"/>
         <CheckBox Content="{DynamicResource LOCSettingsDarkenUninstalledGridCovers}" Margin="0,15,0,0"
-                  Name="CheckDarkenUninstalledCovers" IsChecked="{Binding Settings.DarkenUninstalledGamesGrid}"/>
+                  Name="CheckDarkenUninstalledGridCovers" IsChecked="{Binding Settings.DarkenUninstalledGridCovers}"/>
+        <CheckBox Content="{DynamicResource LOCSettingsDarkenUninstalledNames}" Margin="0,15,0,0"
+                  Name="CheckDarkenUninstalledGridNames" IsChecked="{Binding Settings.DarkenUninstalledGridNames}"/>
 
         <StackPanel Orientation="Horizontal" Margin="0,15,0,0">
             <TextBlock Text="{DynamicResource LOCGridViewScrollAmountModifier}" VerticalAlignment="Center" Margin="0,0,5,0" />

--- a/source/Playnite.DesktopApp/Themes/Desktop/Default/DerivedStyles/DetailsViewItemStyle.xaml
+++ b/source/Playnite.DesktopApp/Themes/Desktop/Default/DerivedStyles/DetailsViewItemStyle.xaml
@@ -2,7 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
     <Style x:Key="DetailsViewItemStyle" TargetType="{x:Type ListBoxItem}">
-        <Setter Property="Foreground" Value="{DynamicResource TextBrushDarker}" />
+        <Setter Property="Foreground" Value="{DynamicResource TextBrush}" />
         <Setter Property="OverridesDefaultStyle" Value="True" />
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
         <Setter Property="FontSize" Value="{DynamicResource FontSizeLarge}" />
@@ -19,12 +19,13 @@
                         </Border>
                     </Grid>
                     <ControlTemplate.Triggers>
-                        <DataTrigger Binding="{Binding IsInstalled}" Value="True">
-                            <Setter Property="Foreground" Value="{DynamicResource TextBrush}" />
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding IsInstalled}" Value="False">
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsInstalled}" Value="False" />
+                                <Condition Binding="{Settings DarkenUninstalledDetailsNames}" Value="True" />
+                            </MultiDataTrigger.Conditions>
                             <Setter Property="Foreground" Value="{DynamicResource TextBrushDarker}" />
-                        </DataTrigger>                        
+                        </MultiDataTrigger>
                         <Trigger Property="IsSelected" Value="True">
                             <Setter Property="Visibility" Value="Visible" TargetName="SelectedRectangle" />
                             <Setter Property="Foreground" Value="{DynamicResource GlyphBrush}" />

--- a/source/Playnite.DesktopApp/Themes/Desktop/Default/DerivedStyles/DetailsViewItemTemplate.xaml
+++ b/source/Playnite.DesktopApp/Themes/Desktop/Default/DerivedStyles/DetailsViewItemTemplate.xaml
@@ -20,6 +20,15 @@
                             </TextBlock>
                         </DockPanel>
                     </Border>
+                    <ControlTemplate.Triggers>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsInstalled}" Value="False" />
+                                <Condition Binding="{Settings DarkenUninstalledDetailsIcons}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="Opacity" Value="0.4" TargetName="PART_ImageIcon" />
+                        </MultiDataTrigger>
+                    </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>

--- a/source/Playnite.DesktopApp/Themes/Desktop/Default/DerivedStyles/GridViewItemTemplate.xaml
+++ b/source/Playnite.DesktopApp/Themes/Desktop/Default/DerivedStyles/GridViewItemTemplate.xaml
@@ -38,7 +38,7 @@
                                     </StackPanel>
                                 </Viewbox>
                             </Grid>
-                            <TextBlock Text="{Binding DisplayName}"
+                            <TextBlock x:Name="DisplayName" Text="{Binding DisplayName}"
                                    Style="{DynamicResource BaseTextBlockStyle}"                                                                   
                                    TextAlignment="Center" TextTrimming="CharacterEllipsis"
                                    VerticalAlignment="Center"
@@ -54,9 +54,16 @@
                         <MultiDataTrigger>
                             <MultiDataTrigger.Conditions>
                                 <Condition Binding="{Binding IsInstalled}" Value="False" />
-                                <Condition Binding="{Settings DarkenUninstalledGamesGrid}" Value="True" />
+                                <Condition Binding="{Settings DarkenUninstalledGridCovers}" Value="True" />
                             </MultiDataTrigger.Conditions>
                             <Setter Property="Visibility" Value="Visible" TargetName="BorderMouseOver" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsInstalled}" Value="False" />
+                                <Condition Binding="{Settings DarkenUninstalledGridNames}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="Foreground" Value="{DynamicResource TextBrushDarker}" TargetName="DisplayName" />
                         </MultiDataTrigger>
                         <MultiDataTrigger>
                             <MultiDataTrigger.Conditions>

--- a/source/Playnite/Localization/LocSource.xaml
+++ b/source/Playnite/Localization/LocSource.xaml
@@ -294,7 +294,9 @@ Selecting "add to exclusion list" option will prevent games from being imported 
     <sys:String x:Key="LOCSettingsAsyncImageLoadingTooltip">Can improve scrolling smoothness of game lists in exchange for slower image load times.</sys:String>
     <sys:String x:Key="LOCSettingsShowNameEmptyCover">Show game name if cover art is missing</sys:String>
     <sys:String x:Key="LOCSettingsShowNamesUnderCover">Show game names on Grid view</sys:String>
-    <sys:String x:Key="LOCSettingsDarkenUninstalledGridCovers">Darken not installed games</sys:String>
+    <sys:String x:Key="LOCSettingsDarkenUninstalledGridCovers">Darken cover image of not installed games</sys:String>
+    <sys:String x:Key="LOCSettingsDarkenUninstalledIcons">Darken icons of not installed games</sys:String>
+    <sys:String x:Key="LOCSettingsDarkenUninstalledNames">Darken name of not installed games</sys:String>
     <sys:String x:Key="LOCSettingsShowIconList">Show game icons on Details view list</sys:String>
     <sys:String x:Key="LOCSettingsShowGroupCount">Show item count on group descriptions</sys:String>
     <sys:String x:Key="LOCSettingsUsedFieldsOnlyOnFilterLists">Show only assigned fields on filter and explorer panels</sys:String>

--- a/source/Playnite/Localization/LocalizationKeys.cs
+++ b/source/Playnite/Localization/LocalizationKeys.cs
@@ -1086,9 +1086,21 @@ namespace Playnite
         /// </summary>
         public const string SettingsShowNamesUnderCover = "LOCSettingsShowNamesUnderCover";
         /// <summary>
-        /// Darken not installed games
+        /// Darken cover image of not installed games
         /// </summary>
         public const string SettingsDarkenUninstalledGridCovers = "LOCSettingsDarkenUninstalledGridCovers";
+        /// <summary>
+        /// Darken name of not installed games
+        /// </summary>
+        public const string SettingsDarkenUninstalledGridNames = "LOCSettingsDarkenUninstalledNames";
+        /// <summary>
+        /// Darken cover image of not installed games
+        /// </summary>
+        public const string SettingsDarkenUninstalledDetailsIcons = "LOCSettingsDarkenUninstalledIcons";
+        /// <summary>
+        /// Darken name of not installed games
+        /// </summary>
+        public const string SettingsDarkenUninstalledDetailsNames = "LOCSettingsDarkenUninstalledNames";
         /// <summary>
         /// Show game icons on Details view list
         /// </summary>

--- a/source/Playnite/Settings/PlayniteSettings.cs
+++ b/source/Playnite/Settings/PlayniteSettings.cs
@@ -1443,17 +1443,50 @@ namespace Playnite
             }
         }
 
-        private bool darkenUninstalledGamesGrid = false;
-        public bool DarkenUninstalledGamesGrid
+        private bool darkenUninstalledGridCovers = true;
+        public bool DarkenUninstalledGridCovers
         {
-            get => darkenUninstalledGamesGrid;
+            get => darkenUninstalledGridCovers;
             set
             {
-                darkenUninstalledGamesGrid = value;
+                darkenUninstalledGridCovers = value;
                 OnPropertyChanged();
             }
         }
 
+        private bool darkenUninstalledGridNames = true;
+        public bool DarkenUninstalledGridNames
+        {
+            get => darkenUninstalledGridNames;
+            set
+            {
+                darkenUninstalledGridNames = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private bool darkenUninstalledDetailsIcons = true;
+        public bool DarkenUninstalledDetailsIcons
+        {
+            get => darkenUninstalledDetailsIcons;
+            set
+            {
+                darkenUninstalledDetailsIcons = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private bool darkenUninstalledDetailsNames = true;
+        public bool DarkenUninstalledDetailsNames
+        {
+            get => darkenUninstalledDetailsNames;
+            set
+            {
+                darkenUninstalledDetailsNames = value;
+                OnPropertyChanged();
+            }
+        }
+        
         private bool usedFieldsOnlyOnFilterLists = true;
         public bool UsedFieldsOnlyOnFilterLists
         {


### PR DESCRIPTION
I have verified that:
- [x] These changes work, by building the application and testing them.
- [x] Pull request is targeting `devel` branch.
- [x] I added myself into [contributors file](https://github.com/JosefNemec/Playnite/blob/devel/source/Playnite.DesktopApp/Resources/contributors.txt) if I want to receive contribution credit in the application itself.

Fixes #2209

Added the following settings:

Details View:
- Setting to darken icons of not installed games. The darkening is done by lowering the opacity to achieve the same effect.
- Setting to darken game name of not installed games. The darkening is done by changing to `TextBrushDark`.

Grid View:
- Setting to darken cover images of not installed games. This is done with the current way of darkening the cover.
- Setting to darken game name of not installed games.

I didn't add anything for list view because there's no settings page for this particular view.

---

**Screenshots**
![image](https://user-images.githubusercontent.com/1389286/131777489-8273316f-26b3-4359-89d4-dc17074fb3ab.png)

![image](https://user-images.githubusercontent.com/1389286/131777436-20a0f609-04c1-479f-bed0-5d2b91662928.png)
