### PR TITLE
ListToStringConverter seperator as parameter

### DIFF
--- a/source/Playnite/Converters/ListToStringConverter.cs
+++ b/source/Playnite/Converters/ListToStringConverter.cs
@@ -50,6 +50,8 @@ namespace Playnite.Converters
 
     public class ListToStringConverter : MarkupExtension, IValueConverter
     {
+        private const string defaultSeperator = ",";
+    
         public static string MakeString(IEnumerable<string> source)
         {
             return string.Join(",", source);
@@ -62,7 +64,7 @@ namespace Playnite.Converters
                 return string.Empty;
             }
 
-            string sep = ",";
+            string sep = defaultSeperator;
 
             if (parameter is string customSep)
             {
@@ -82,7 +84,7 @@ namespace Playnite.Converters
             }
             else
             {
-                string sep = ",";
+                string sep = defaultSeperator;
                 
                 if (parameter is string customSep)
                 {

--- a/source/Playnite/Converters/ListToStringConverter.cs
+++ b/source/Playnite/Converters/ListToStringConverter.cs
@@ -63,9 +63,7 @@ namespace Playnite.Converters
             {
                 return string.Empty;
             }
-
             string sep = defaultSeperator;
-
             if (parameter is string customSep)
             {
                 sep = customSep;

--- a/source/Playnite/Converters/ListToStringConverter.cs
+++ b/source/Playnite/Converters/ListToStringConverter.cs
@@ -62,7 +62,14 @@ namespace Playnite.Converters
                 return string.Empty;
             }
 
-            return string.Join(",", (IEnumerable<object>)value);
+            string sep = ",";
+
+            if (parameter is string customSep)
+            {
+                sep = customSep;
+            }
+            
+            return string.Join(sep, (IEnumerable<object>)value);
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
@@ -75,7 +82,14 @@ namespace Playnite.Converters
             }
             else
             {
-                var converted = stringVal.Split(new char[] { ',' });
+                string sep = ",";
+                
+                if (parameter is string customSep)
+                {
+                    sep = customSep;
+                }
+                
+                var converted = stringVal.Split(new [] { sep }, StringSplitOptions.RemoveEmptyEntries);
                 if (targetType == typeof(ComparableList<string>))
                 {
                     return new ComparableList<string>(converted);


### PR DESCRIPTION
Added custom seperator string to ListToString converter using the parameter object

I have verified that:
- [x] These changes work, by building the application and testing them.
- [x] Pull request is targeting `devel` branch.
- [ ] I added myself into [contributors file](https://github.com/JosefNemec/Playnite/blob/devel/source/Playnite.DesktopApp/Resources/contributors.txt) if I want to receive contribution credit in the application itself.
