### PR TITLE
Fix Auto-close client executing even if another game from the same library is running

### DIFF
--- a/source/Playnite/GamesEditor.cs
+++ b/source/Playnite/GamesEditor.cs
@@ -1010,6 +1010,10 @@ namespace Playnite
                 {
                     logger.Debug("Game session was too short for client to be shutdown.");
                 }
+                else if (Database.Games.Any(x => x.IsRunning && x.PluginId == game.PluginId))
+                {
+                    logger.Debug("Shutdown process canceled because another game from library was detected as running.");
+                }
                 else
                 {
                     var plugin = Extensions.GetLibraryPlugin(game.PluginId);


### PR DESCRIPTION
Fix Auto-close client executing even if another game from the same library is running

Fixes https://github.com/JosefNemec/Playnite/issues/2635
I have verified that:
- [x] These changes work, by building the application and testing them.
- [ ] Pull request is targeting `devel` branch.
- [x] I added myself into [contributors file](https://github.com/JosefNemec/Playnite/blob/devel/source/Playnite.DesktopApp/Resources/contributors.txt) if I want to receive contribution credit in the application itself.
