### PR TITLE
Add SwanStation profile for RetroArch

### DIFF
--- a/source/Playnite/Emulation/Emulators/RetroArch/emulator.yaml
+++ b/source/Playnite/Emulation/Emulators/RetroArch/emulator.yaml
@@ -688,6 +688,13 @@ Profiles:
     ProfileFiles: ['cores\stella2014_libretro.dll']
     StartupExecutable: ^retroarch\.exe$
 
+  - Name: SwanStation
+    StartupArguments: '-L ".\cores\swanstation_libretro.dll" "{ImagePath}"'
+    Platforms: [sony_playstation]
+    ImageExtensions: [exe, psexe, cue, bin, img, iso, chd, pbp, ecm, mds, psf, m3u]
+    ProfileFiles: ['cores\swanstation_libretro.dll']
+    StartupExecutable: ^retroarch\.exe$
+
   - Name: TempGBA
     StartupArguments: '-L ".\cores\tempgba_libretro.dll" "{ImagePath}"'
     Platforms: [nintendo_gameboyadvance]


### PR DESCRIPTION
Adds a profile for https://github.com/libretro/swanstation

I have verified that:
- [x] These changes work, by building the application and testing them.
- [x] Pull request is targeting `devel` branch.
- [ ] I added myself into [contributors file](https://github.com/JosefNemec/Playnite/blob/devel/source/Playnite.DesktopApp/Resources/contributors.txt) if I want to receive contribution credit in the application itself.
