### PR TITLE
[feat] Feature/allow exiting emulated game from gamepad

### DIFF
--- a/source/Playnite.DesktopApp/Resources/contributors.txt
+++ b/source/Playnite.DesktopApp/Resources/contributors.txt
@@ -44,3 +44,4 @@ greggameplayer
 felixkmh
 Curt Grimes
 Jeshibu
+jmvallejo


### PR DESCRIPTION
I'm adding the ability to close games from the gamepad, as requested (by myself) here https://github.com/JosefNemec/Playnite/issues/2715

I'm thinking about where an option for this should go, it can probably be in the emulator profile, but want to get the behavior validated first.

Changes:
- Add process attribute to GenericGameController
- Add StartGamepadPolling method
- Add jmvallejo to contributors.txt

I have verified that:
- [ ] These changes work, by building the application and testing them.
- [ ] Pull request is targeting `devel` branch.
- [ ] I added myself into [contributors file](https://github.com/JosefNemec/Playnite/blob/devel/source/Playnite.DesktopApp/Resources/contributors.txt) if I want to receive contribution credit in the application itself.
