### PR TITLE
Log all exceptions when loading Plugins

### DIFF
--- a/source/Playnite/Plugins/ExtensionFactory.cs
+++ b/source/Playnite/Plugins/ExtensionFactory.cs
@@ -419,6 +419,14 @@ namespace Playnite.Plugins
                         logger.Error(e, string.Empty);
                     }
 
+                    if (e is ReflectionTypeLoadException reflectionTypeLoadException)
+                    {
+                        foreach (var loaderException in reflectionTypeLoadException.LoaderExceptions)
+                        {
+                            logger.Error(loaderException, string.Empty);
+                        }
+                    }
+
                     FailedExtensions.Add((desc, AddonLoadError.Uknown));
                 }
             }


### PR DESCRIPTION
Assembly.GetTypes() can throw a ReflectionTypeLoadException which
contains all exceptions thrown by the class loader in the
LoaderExceptions property.

Resolves #2758