### PR TITLE
Parse doubles according to user culture

### DIFF
--- a/source/Playnite.DesktopApp/Controls/NumericDoubleBox.cs
+++ b/source/Playnite.DesktopApp/Controls/NumericDoubleBox.cs
@@ -1,18 +1,10 @@
 ﻿using Playnite.Common;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 
 namespace Playnite.DesktopApp.Controls
 {
@@ -121,7 +113,8 @@ namespace Playnite.DesktopApp.Controls
                 Text = "0";
             }
 
-            if (!double.TryParse(Text.Replace(".", ","), out var result))
+
+            if (!TryParseForCurrentCulture(Text, out var result))
             {
                 e.Handled = true;
                 Value = lastValue;
@@ -167,7 +160,7 @@ namespace Playnite.DesktopApp.Controls
             }
             else
             {
-                if (double.TryParse(obj.Text.Replace(".", ","), out var result) && result == (double)e.NewValue)
+                if (TryParseForCurrentCulture(obj.Text.Replace(".", ","), out var result) && result == (double)e.NewValue)
                 {
                 }
                 else
@@ -183,6 +176,15 @@ namespace Playnite.DesktopApp.Controls
 
         private static void MaxDoubleValuePropertyChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
         {
+        }
+
+        private static bool TryParseForCurrentCulture(string text, out double result)
+        {
+            var numberFormat = CultureInfo.CurrentCulture.NumberFormat;
+            var parsedText = text.Replace(",", numberFormat.NumberDecimalSeparator)
+                .Replace(".", numberFormat.NumberDecimalSeparator);
+
+            return double.TryParse(parsedText, out result);
         }
     }
 }

--- a/source/Playnite.DesktopApp/Controls/NumericDoubleBox.cs
+++ b/source/Playnite.DesktopApp/Controls/NumericDoubleBox.cs
@@ -1,10 +1,19 @@
 ﻿using Playnite.Common;
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
+using System.Windows.Documents;
 using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
 
 namespace Playnite.DesktopApp.Controls
 {

--- a/source/Playnite.DesktopApp/Resources/contributors.txt
+++ b/source/Playnite.DesktopApp/Resources/contributors.txt
@@ -44,3 +44,4 @@ greggameplayer
 felixkmh
 Curt Grimes
 Jeshibu
+UrbanCMC


### PR DESCRIPTION
This fixes #2789 by converting both possible separator characters to the one used by the user's current culture.

This is a somewhat naive solution, because it basically only extends the previous behavior to work for all cultures, which means it won't work for numbers that also contain a thousands separator.

This is probably not going to be an issue, but let me know if you would prefer a more accurate solution, which will require the user to use the correct decimal separator.

I have verified that:
- [x] These changes work, by building the application and testing them.
- [x] Pull request is targeting `devel` branch.
- [x] I added myself into [contributors file](https://github.com/JosefNemec/Playnite/blob/devel/source/Playnite.DesktopApp/Resources/contributors.txt) if I want to receive contribution credit in the application itself.
