### PR TITLE
Update game LastActivity, PlayCount and Completion Status on Running

### DIFF
--- a/source/Playnite/GamesEditor.cs
+++ b/source/Playnite/GamesEditor.cs
@@ -1011,7 +1011,7 @@ namespace Playnite
                 game.IsLaunching = launching.Value;
             }
 
-            if (launching == true)
+            if (running == true)
             {
                 game.LastActivity = DateTime.Now;
                 game.PlayCount += 1;


### PR DESCRIPTION
Update game LastActivity, PlayCount and Completion Status on Runningstate instead of Launching

I think it makes more sense to update those values when the game has started running, as it's not guaranteed that the game will run when the game is still in `Launching` state

I have verified that:
- [x] These changes work, by building the application and testing them.
- [x] Pull request is targeting `devel` branch.
- [x] I added myself into [contributors file](https://github.com/JosefNemec/Playnite/blob/devel/source/Playnite.DesktopApp/Resources/contributors.txt) if I want to receive contribution credit in the application itself.
