### PR TITLE
Add platforms to SearchView GameItem subtext

### DIFF
--- a/source/Playnite.DesktopApp/Themes/Desktop/Default/Views/SearchView.xaml
+++ b/source/Playnite.DesktopApp/Themes/Desktop/Default/Views/SearchView.xaml
@@ -51,6 +51,9 @@
                 </StackPanel>
 
                 <StackPanel Orientation="Horizontal" Margin="0,5,0,0">
+                    <TextBlock Text="{Binding Game.Platforms, Converter={StaticResource ListToStringConverter}, StringFormat='{}{0} - '}"
+                               Visibility="{Binding Game.Platforms, Converter={StaticResource NullToVisibilityConverter}}"
+                               Foreground="{DynamicResource TextBrushDarker}" />
                     <TextBlock Text="{Binding Game.Playtime, Converter={StaticResource PlayTimeToStringConverter}}"
                                Foreground="{DynamicResource TextBrushDarker}" />
                     <TextBlock Text="{Binding Game.CompletionStatus.Name, StringFormat=' - {0}'}"


### PR DESCRIPTION
I think that the game platform(s) is very important data to know when viewing a game. It can also help in cases where multiple games share the same name and the only way to distinguish them is the platform.

Screenshot:

![image](https://user-images.githubusercontent.com/1389286/178146232-ac8374ff-86f1-46f8-83fc-6a632e82a49a.png)

I have verified that:
- [x] These changes work, by building the application and testing them.
- [x] Pull request is targeting `devel` branch.
- [x] I added myself into [contributors file](https://github.com/JosefNemec/Playnite/blob/devel/source/Playnite.DesktopApp/Resources/contributors.txt) if I want to receive contribution credit in the application itself.
