### PR TITLE
Open details on GridView for Random Game Picker if active view

### DIFF
--- a/source/Playnite.DesktopApp/ViewModels/DesktopAppViewModel.cs
+++ b/source/Playnite.DesktopApp/ViewModels/DesktopAppViewModel.cs
@@ -943,7 +943,18 @@ namespace Playnite.DesktopApp.ViewModels
             }
             else if (model.SelectedAction == RandomGameSelectAction.Navigate)
             {
-                AppSettings.ViewSettings.GamesViewType = DesktopView.Details;
+                if (AppSettings.ViewSettings.GamesViewType == DesktopView.List)
+                {
+                    AppSettings.ViewSettings.GamesViewType = DesktopView.Details;
+                }
+                else if (AppSettings.ViewSettings.GamesViewType == DesktopView.Grid)
+                {
+                    if (!AppSettings.GridViewSideBarVisible)
+                    {
+                        AppSettings.GridViewSideBarVisible = true;
+                    }
+                }
+
                 SelectGame(model.SelectedGame.Id);
             }
         }


### PR DESCRIPTION
Currently the details for the Random Game Picker always open the details in DetailsView. With this PR, the view change is only done if the current view is ListView, which can't display the game details. If the current view is GridView then the view is not switched and the game details will be displayed there.

I have verified that:
- [x] These changes work, by building the application and testing them.
- [x] Pull request is targeting `devel` branch.
- [x] I added myself into [contributors file](https://github.com/JosefNemec/Playnite/blob/devel/source/Playnite.DesktopApp/Resources/contributors.txt) if I want to receive contribution credit in the application itself.
