### PR TITLE
Add StringToUpperCaseConverter

### DIFF
--- a/source/Playnite.DesktopApp/GlobalResources.xaml
+++ b/source/Playnite.DesktopApp/GlobalResources.xaml
@@ -46,6 +46,7 @@
     <pcon:StrechToStringConverter x:Key="StrechToStringConverter" />
     <pcon:StringNullOrEmptyToBoolConverter x:Key="StringNullOrEmptyToBoolConverter" />
     <pcon:StringNullOrEmptyToVisibilityConverter x:Key="StringNullOrEmptyToVisibilityConverter" />
+    <pcon:StringToUpperCaseConverter x:Key="StringToUpperCaseConverter" />
     <pcon:ValueConverterGroup x:Key="ValueConverterGroup" />
     <pcon:WidthToFontSizeConverter x:Key="WidthToFontSizeConverter" />
     <pcon:IntToVisibilityConverter x:Key="IntToVisibilityConverter" />

--- a/source/Playnite.FullscreenApp/GlobalResources.xaml
+++ b/source/Playnite.FullscreenApp/GlobalResources.xaml
@@ -51,6 +51,7 @@
     <pcon:StrechToStringConverter x:Key="StrechToStringConverter" />
     <pcon:StringNullOrEmptyToBoolConverter x:Key="StringNullOrEmptyToBoolConverter" />
     <pcon:StringNullOrEmptyToVisibilityConverter x:Key="StringNullOrEmptyToVisibilityConverter" />
+    <pcon:StringToUpperCaseConverter x:Key="StringToUpperCaseConverter" />
     <pcon:ValueConverterGroup x:Key="ValueConverterGroup" />
     <pcon:WidthToFontSizeConverter x:Key="WidthToFontSizeConverter" />
     <pcon:IntToVisibilityConverter x:Key="IntToVisibilityConverter" />

--- a/source/Playnite/Converters/StringToUpperCaseConverter.cs
+++ b/source/Playnite/Converters/StringToUpperCaseConverter.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Data;
+using System.Windows.Markup;
+
+namespace Playnite.Converters
+{
+    public class StringToUpperCaseConverter : MarkupExtension, IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            var str = value as string;
+            if (string.IsNullOrEmpty(str))
+            {
+                return string.Empty;
+            }
+
+            return str.ToUpperInvariant();
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            return new NotSupportedException();
+        }
+
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            return this;
+        }
+    }
+}

--- a/source/Playnite/Playnite.csproj
+++ b/source/Playnite/Playnite.csproj
@@ -367,6 +367,7 @@
     <Compile Include="Converters\StringNullOrEmptyToBoolConverter.cs" />
     <Compile Include="Converters\IntToVisibilityConverter.cs" />
     <Compile Include="Converters\StringNullOrEmptyToVisibilityConverter.cs" />
+    <Compile Include="Converters\StringToUpperCaseConverter.cs" />
     <Compile Include="Converters\ValueConverterGroup.cs" />
     <Compile Include="Converters\WidthToFontSizeConverter.cs" />
     <Compile Include="Database\Collections\EmulatorsCollection.cs" />


### PR DESCRIPTION
I have verified that:
- [x] These changes work, by building the application and testing them.
- [x] Pull request is targeting `devel` branch.
- [x] I added myself into [contributors file](https://github.com/JosefNemec/Playnite/blob/devel/source/Playnite.DesktopApp/Resources/contributors.txt) if I want to receive contribution credit in the application itself.

Some notes:
- I used `ToUpperInvariant()` method to make sure the converted value is consistent in all systems
- To use the converter with localization strings, they must be used as StaticResource in the binding, for example:
```xml
<TextBlock Text="{Binding Source={StaticResource LOCGameDescriptionTitle}, Converter={StaticResource StringToUpperCaseConverter}}" />
```