### PR TITLE
Fix not possible to use TextWrap in CheckBox control

### DIFF
--- a/source/Playnite.DesktopApp/Themes/Desktop/Default/DefaultControls/CheckBox.xaml
+++ b/source/Playnite.DesktopApp/Themes/Desktop/Default/DefaultControls/CheckBox.xaml
@@ -17,8 +17,9 @@
                 <ControlTemplate TargetType="{x:Type CheckBox}">
                     <Border Background="{TemplateBinding Background}"
                             Padding="{TemplateBinding Padding}">
-                        <StackPanel Orientation="Horizontal">
+                        <DockPanel>
                             <Border x:Name="BulletBorder" CornerRadius="{DynamicResource ControlCornerRadius}"
+                                    VerticalAlignment="Center"
                                     BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}"
                                     BorderBrush="{TemplateBinding BorderBrush}">
                                 <Grid Width="18" Height="18" Background="{DynamicResource CheckBoxCheckMarkBkBrush}">
@@ -33,7 +34,7 @@
                                 </Grid>
                             </Border>                            
                             <ContentPresenter RecognizesAccessKey="True" Margin="5,0,0,0" VerticalAlignment="Center" HorizontalAlignment="Left" />
-                        </StackPanel>
+                        </DockPanel>
                     </Border>                    
                     <ControlTemplate.Triggers>
                         <MultiTrigger>


### PR DESCRIPTION
I have verified that:
- [x] These changes work, by building the application and testing them.
- [x] Pull request is targeting `devel` branch.
- [x] I added myself into [contributors file](https://github.com/JosefNemec/Playnite/blob/devel/source/Playnite.DesktopApp/Resources/contributors.txt) if I want to receive contribution credit in the application itself.

Currently it's not possible to use Textwrap in checkboxes, even when setting the control to do so like this.

```xml
<CheckBox IsChecked="{Binding Settings.Option2}">
    <TextBlock>
        <AccessText TextWrapping="Wrap" 
                    Text="This is a long piece of text attached to a checkbox This is a long piece of text attached to a checkbox This is a long piece of text attached to a checkbox This is a long piece of text attached to a checkbox"/>
    </TextBlock>
</CheckBox>
```

This is caused by the control using a StackPanel. Changing to a DockPanel fixes it.

Before:
![Playnite DesktopApp_C2SqSTopIl](https://user-images.githubusercontent.com/1389286/182722511-e3207d87-b17e-404b-82b9-fc6448c93d51.png)

After:
![RXSppTtNE3](https://user-images.githubusercontent.com/1389286/182722529-25275c49-e86c-458d-a6b4-0767a664a977.png)


