### PR TITLE
Show collection view count in filter panel

### DIFF
--- a/source/Playnite.DesktopApp/Controls/SettingsSections/AppearanceGeneral.xaml
+++ b/source/Playnite.DesktopApp/Controls/SettingsSections/AppearanceGeneral.xaml
@@ -86,6 +86,9 @@
 
         <CheckBox Content="{DynamicResource LOCSettingsShowGroupCount}" Margin="0,15,0,0"
                   Name="CheckShowGroupCount" IsChecked="{Binding Settings.ShowGroupCount}"/>
+        <CheckBox Content="{DynamicResource LOCSettingsShowGamesInViewCountOnFilterPanel}" Margin="0,15,0,0"
+                  Name="CheckShowGamesInViewCountOnFilterPanel"
+                  IsChecked="{Binding Settings.ShowGamesInViewCountOnFilterPanel}"/>
         <CheckBox Content="{DynamicResource LOCSettingsUsedFieldsOnlyOnFilterLists}" Margin="0,15,0,0"
                   IsChecked="{Binding Settings.UsedFieldsOnlyOnFilterLists}"/>
         <CheckBox Content="{DynamicResource LOCSettingsShowBackgroundWindowImage}" Margin="0,15,0,0"

--- a/source/Playnite.DesktopApp/Controls/Views/FilterPanel.cs
+++ b/source/Playnite.DesktopApp/Controls/Views/FilterPanel.cs
@@ -125,6 +125,26 @@ namespace Playnite.DesktopApp.Controls.Views
                 ComboFilterPresets.DisplayMemberPath = nameof(FilterPreset.Name);
             }
 
+            if (PanelItemsHost != null)
+            {
+                var gamesCountLabel = new Label();
+                gamesCountLabel.SetResourceReference(Label.StyleProperty, "FilterPanelLabel");
+                BindingTools.SetBinding(gamesCountLabel,
+                    Label.ContentProperty,
+                    mainModel,
+                    $"{nameof(mainModel.GamesView)}.{nameof(BaseCollectionView.CollectionView)}.{nameof(BaseCollectionView.CollectionView.Count)}",
+                    converter: new NullableIntToStringConverter());
+                BindingTools.SetBinding(gamesCountLabel,
+                    Label.VisibilityProperty,
+                    mainModel,
+                    $"{nameof(mainModel.AppSettings)}.{nameof(PlayniteSettings.ShowGamesInViewCountOnFilterPanel)}.",
+                    converter: new Converters.BooleanToVisibilityConverter());
+                
+                gamesCountLabel.ContentStringFormat = ResourceProvider.GetString(LOC.ShowGameCountInViewLabel) + " {0}";
+                gamesCountLabel.Tag = true;
+                PanelItemsHost.Children.Add(gamesCountLabel);
+            }
+
             SetToggleFilter(nameof(FilterSettings.IsInstalled), nameof(DatabaseStats.Installed), LOC.GameIsInstalledTitle);
             SetToggleFilter(nameof(FilterSettings.IsUnInstalled), nameof(DatabaseStats.UnInstalled), LOC.GameIsUnInstalledTitle);
             SetToggleFilter(nameof(FilterSettings.Hidden), nameof(DatabaseStats.Hidden), LOC.GameHiddenTitle);

--- a/source/Playnite/Localization/LocSource.xaml
+++ b/source/Playnite/Localization/LocSource.xaml
@@ -201,6 +201,7 @@ Selecting "add to exclusion list" option will prevent games from being imported 
     <sys:String x:Key="LOCMetaSourceIGDB">IGDB</sys:String>
     <sys:String x:Key="LOCMetaDescriptionFields">Please select which fields should be automatically populated by Playnite and which sources should be used to obtain the data from.</sys:String>
     <sys:String x:Key="LOCMetaIgdbContribNotif">Please consider clicking on the logo above and contribute updates to igdb.com database in order to improve data Playnite uses.</sys:String>
+    <sys:String x:Key="LOCShowGameCountInViewLabel">Games in view:</sys:String>
     <!--Progess string-->
     <sys:String x:Key="LOCProgressMetadata">Downloading metadata…</sys:String>
     <sys:String x:Key="LOCProgressInstalledGames">Importing installed games…</sys:String>
@@ -292,6 +293,7 @@ Selecting "add to exclusion list" option will prevent games from being imported 
     <sys:String x:Key="LOCSettingsInvalidDBLocation">Invalid database file location, proper file path must be set.</sys:String>
     <sys:String x:Key="LOCSettingsInvalidAccountName">Account name cannot be empty.</sys:String>
     <sys:String x:Key="LOCSettingsDownloadMetadataOnImport">Download metadata after importing games</sys:String>
+    <sys:String x:Key="LOCSettingsShowGamesInViewCountOnFilterPanel">Show count of games in view on filter panel</sys:String>
     <sys:String x:Key="LOCSettingsStartMinimized">Launch Playnite minimized</sys:String>
     <sys:String x:Key="LOCSettingsStartOnBoot">Launch Playnite when you start your computer</sys:String>
     <sys:String x:Key="LOCSettingsStartOnBootRegistrationError">Failed to register Playnite to launch when computer starts.</sys:String>

--- a/source/Playnite/Localization/LocalizationKeys.cs
+++ b/source/Playnite/Localization/LocalizationKeys.cs
@@ -718,6 +718,10 @@ namespace Playnite
         /// </summary>
         public const string MetaIgdbContribNotif = "LOCMetaIgdbContribNotif";
         /// <summary>
+        /// Games in view:
+        /// </summary>
+        public const string ShowGameCountInViewLabel = "LOCShowGameCountInViewLabel";
+        /// <summary>
         /// Downloading metadata…
         /// </summary>
         public const string ProgressMetadata = "LOCProgressMetadata";

--- a/source/Playnite/Settings/PlayniteSettings.cs
+++ b/source/Playnite/Settings/PlayniteSettings.cs
@@ -779,6 +779,21 @@ namespace Playnite
             }
         }
 
+        private bool showGamesInViewCountOnFilterPanel = true;
+        public bool ShowGamesInViewCountOnFilterPanel
+        {
+            get
+            {
+                return showGamesInViewCountOnFilterPanel;
+            }
+
+            set
+            {
+                showGamesInViewCountOnFilterPanel = value;
+                OnPropertyChanged();
+            }
+        }
+
         private bool showIconsOnList = true;
         public bool ShowIconsOnList
         {


### PR DESCRIPTION
I have verified that:
- [x] These changes work, by building the application and testing them.
- [x] Pull request is targeting `devel` branch.
- [x ] I added myself into [contributors file](https://github.com/JosefNemec/Playnite/blob/devel/source/Playnite.DesktopApp/Resources/contributors.txt) if I want to receive contribution credit in the application itself.

Draft just as an idea for #1150

In my opinion the display count show go in the filters panel:
- Can be seen in all views
- Non intrusive
- Makes sense because everything in the filter panel has direct control in the number of games that will be displayed

Current issue is that it displays the number of games including duplicates. Ideally it should only show the number of distinct games.

### Screenshots
![image](https://user-images.githubusercontent.com/1389286/185056054-7e2b39b2-d918-4f30-b53b-43aaa71d7933.png)
