### PR TITLE
Add support to sort by Recent Activity and support to use custom Date formats

### DIFF
--- a/source/Playnite.DesktopApp/Controls/GamesGridView.xaml
+++ b/source/Playnite.DesktopApp/Controls/GamesGridView.xaml
@@ -230,7 +230,14 @@
         </DataTemplate>
         
         <DataTemplate x:Key="CellTemplateRecentActivity">
-            <TextBlock Text="{Binding RecentActivity, Mode=OneWay, Converter={StaticResource NullableDateToStringConverter}}" />
+            <TextBlock Tag="{pmrk:Settings CustomDateTimeFormat}">
+                <TextBlock.Text>
+                    <MultiBinding Converter="{StaticResource MultiNullableDateToCustomFormatStringConverter}" Mode="OneWay">
+                        <Binding Path="RecentActivity" Mode="OneWay" />
+                        <Binding Path="Tag" RelativeSource="{RelativeSource Self}" />
+                    </MultiBinding>
+                </TextBlock.Text>
+            </TextBlock>
         </DataTemplate>
         
         <DataTemplate x:Key="HeaderTemplatePlaytime">
@@ -336,11 +343,18 @@
                                 Visibility="{pmrk:Settings ViewSettings.SortingOrder, Converter={StaticResource EnumCompVisibilityConverter}, ConverterParameter={x:Static sdkm:SortOrder.Added}}"/>
             </StackPanel>
         </DataTemplate>
-
+        
         <DataTemplate x:Key="CellTemplateAdded">
-            <TextBlock Text="{Binding Added, Mode=OneWay, Converter={StaticResource NullableDateToStringConverter}}" />
+            <TextBlock Tag="{pmrk:Settings CustomDateTimeFormat}">
+                <TextBlock.Text>
+                    <MultiBinding Converter="{StaticResource MultiNullableDateToCustomFormatStringConverter}" Mode="OneWay">
+                        <Binding Path="Added" Mode="OneWay"/>
+                        <Binding Path="Tag" RelativeSource="{RelativeSource Self}" />
+                    </MultiBinding>
+                </TextBlock.Text>
+            </TextBlock>
         </DataTemplate>
-
+        
         <DataTemplate x:Key="HeaderTemplateModified">
             <StackPanel Orientation="Horizontal">
                 <TextBlock Text="{DynamicResource LOCModifiedLabel}" />
@@ -350,7 +364,14 @@
         </DataTemplate>
 
         <DataTemplate x:Key="CellTemplateModified">
-            <TextBlock Text="{Binding Modified, Mode=OneWay, Converter={StaticResource NullableDateToStringConverter}}" />
+            <TextBlock Tag="{pmrk:Settings CustomDateTimeFormat}">
+                <TextBlock.Text>
+                    <MultiBinding Converter="{StaticResource MultiNullableDateToCustomFormatStringConverter}" Mode="OneWay">
+                        <Binding Path="Modified" Mode="OneWay" />
+                        <Binding Path="Tag" RelativeSource="{RelativeSource Self}" />
+                    </MultiBinding>
+                </TextBlock.Text>
+            </TextBlock>
         </DataTemplate>
 
         <DataTemplate x:Key="HeaderTemplateUserScore">

--- a/source/Playnite.DesktopApp/Controls/GamesGridView.xaml
+++ b/source/Playnite.DesktopApp/Controls/GamesGridView.xaml
@@ -230,7 +230,7 @@
         </DataTemplate>
         
         <DataTemplate x:Key="CellTemplateRecentActivity">
-            <TextBlock Text="{Binding RecentActivity, Mode=OneWay, Converter={StaticResource NullableDateToSortableStringConverter}}" />
+            <TextBlock Text="{Binding RecentActivity, Mode=OneWay, Converter={StaticResource NullableDateToStringConverter}}" />
         </DataTemplate>
         
         <DataTemplate x:Key="HeaderTemplatePlaytime">

--- a/source/Playnite.DesktopApp/Controls/GamesGridView.xaml
+++ b/source/Playnite.DesktopApp/Controls/GamesGridView.xaml
@@ -221,6 +221,18 @@
             <TextBlock Text="{Binding LastActivity, Mode=OneWay, Converter={StaticResource DateTimeToLastPlayedConverter}}" />
         </DataTemplate>
 
+        <DataTemplate x:Key="HeaderTemplateRecentActivity">
+            <StackPanel Orientation="Horizontal">
+                <TextBlock Text="{DynamicResource LOCRecentActivityLabel}" />
+                <ContentControl Style="{StaticResource SortIndicator}"
+                                Visibility="{pmrk:Settings ViewSettings.SortingOrder, Converter={StaticResource EnumCompVisibilityConverter}, ConverterParameter={x:Static sdkm:SortOrder.RecentActivity}}"/>
+            </StackPanel>
+        </DataTemplate>
+        
+        <DataTemplate x:Key="CellTemplateRecentActivity">
+            <TextBlock Text="{Binding RecentActivity, Mode=OneWay, Converter={StaticResource NullableDateToSortableStringConverter}}" />
+        </DataTemplate>
+        
         <DataTemplate x:Key="HeaderTemplatePlaytime">
             <StackPanel Orientation="Horizontal">
                 <TextBlock Text="{DynamicResource LOCTimePlayed}" />
@@ -459,6 +471,8 @@
                                     IsCheckable="True" IsChecked="{Binding ListViewColumns.InstallDirectory.Visible}" />
                         <MenuItem Header="{DynamicResource LOCGameLastActivityTitle}"
                                     IsCheckable="True" IsChecked="{Binding ListViewColumns.LastActivity.Visible}" />
+                        <MenuItem Header="{DynamicResource LOCRecentActivityLabel}"
+                                    IsCheckable="True" IsChecked="{Binding ListViewColumns.RecentActivity.Visible}" />
                         <MenuItem Header="{DynamicResource LOCTimePlayed}"
                                     IsCheckable="True" IsChecked="{Binding ListViewColumns.Playtime.Visible}" />
                         <MenuItem Header="{DynamicResource LOCPlayCountLabel}"

--- a/source/Playnite.DesktopApp/Controls/GamesGridView.xaml
+++ b/source/Playnite.DesktopApp/Controls/GamesGridView.xaml
@@ -230,11 +230,11 @@
         </DataTemplate>
         
         <DataTemplate x:Key="CellTemplateRecentActivity">
-            <TextBlock Tag="{pmrk:Settings CustomDateTimeFormat}">
+            <TextBlock>
                 <TextBlock.Text>
-                    <MultiBinding Converter="{StaticResource MultiNullableDateToCustomFormatStringConverter}" Mode="OneWay">
-                        <Binding Path="RecentActivity" Mode="OneWay" />
-                        <Binding Path="Tag" RelativeSource="{RelativeSource Self}" />
+                    <MultiBinding Converter="{StaticResource MultiNullableDateToCustomFormatStringConverter}">
+                        <Binding Path="Modified" Mode="OneWay" />
+                        <Binding Path="Settings.CustomDateTimeFormat" Mode="OneWay" />
                     </MultiBinding>
                 </TextBlock.Text>
             </TextBlock>
@@ -345,11 +345,11 @@
         </DataTemplate>
         
         <DataTemplate x:Key="CellTemplateAdded">
-            <TextBlock Tag="{pmrk:Settings CustomDateTimeFormat}">
+            <TextBlock>
                 <TextBlock.Text>
-                    <MultiBinding Converter="{StaticResource MultiNullableDateToCustomFormatStringConverter}" Mode="OneWay">
-                        <Binding Path="Added" Mode="OneWay"/>
-                        <Binding Path="Tag" RelativeSource="{RelativeSource Self}" />
+                    <MultiBinding Converter="{StaticResource MultiNullableDateToCustomFormatStringConverter}">
+                        <Binding Path="Modified" Mode="OneWay" />
+                        <Binding Path="Settings.CustomDateTimeFormat" Mode="OneWay" />
                     </MultiBinding>
                 </TextBlock.Text>
             </TextBlock>
@@ -364,11 +364,11 @@
         </DataTemplate>
 
         <DataTemplate x:Key="CellTemplateModified">
-            <TextBlock Tag="{pmrk:Settings CustomDateTimeFormat}">
+            <TextBlock>
                 <TextBlock.Text>
-                    <MultiBinding Converter="{StaticResource MultiNullableDateToCustomFormatStringConverter}" Mode="OneWay">
+                    <MultiBinding Converter="{StaticResource MultiNullableDateToCustomFormatStringConverter}">
                         <Binding Path="Modified" Mode="OneWay" />
-                        <Binding Path="Tag" RelativeSource="{RelativeSource Self}" />
+                        <Binding Path="Settings.CustomDateTimeFormat" Mode="OneWay" />
                     </MultiBinding>
                 </TextBlock.Text>
             </TextBlock>

--- a/source/Playnite.DesktopApp/Controls/GamesGridView.xaml
+++ b/source/Playnite.DesktopApp/Controls/GamesGridView.xaml
@@ -134,7 +134,7 @@
         </DataTemplate>
 
         <DataTemplate x:Key="CellTemplateReleaseDate">
-            <TextBlock Text="{Binding ReleaseDate, Mode=OneWay}" />
+            <TextBlock Text="{Binding ReleaseDate, Mode=OneWay, Converter={StaticResource ReleaseDateToStringConverter}, ConverterParameter={pmrk:Settings DateTimeFormatReleaseDate, DirectValue=True}}" />
         </DataTemplate>
 
         <DataTemplate x:Key="HeaderTemplateGenres">
@@ -228,16 +228,9 @@
                                 Visibility="{pmrk:Settings ViewSettings.SortingOrder, Converter={StaticResource EnumCompVisibilityConverter}, ConverterParameter={x:Static sdkm:SortOrder.RecentActivity}}"/>
             </StackPanel>
         </DataTemplate>
-        
+
         <DataTemplate x:Key="CellTemplateRecentActivity">
-            <TextBlock>
-                <TextBlock.Text>
-                    <MultiBinding Converter="{StaticResource MultiNullableDateToCustomFormatStringConverter}">
-                        <Binding Path="Modified" Mode="OneWay" />
-                        <Binding Path="Settings.CustomDateTimeFormat" Mode="OneWay" />
-                    </MultiBinding>
-                </TextBlock.Text>
-            </TextBlock>
+            <TextBlock Text="{Binding RecentActivity, Mode=OneWay, Converter={StaticResource NullableDateToStringConverter}, ConverterParameter={pmrk:Settings DateTimeFormatRecentActivity, DirectValue=True}}" />
         </DataTemplate>
         
         <DataTemplate x:Key="HeaderTemplatePlaytime">
@@ -345,14 +338,7 @@
         </DataTemplate>
         
         <DataTemplate x:Key="CellTemplateAdded">
-            <TextBlock>
-                <TextBlock.Text>
-                    <MultiBinding Converter="{StaticResource MultiNullableDateToCustomFormatStringConverter}">
-                        <Binding Path="Modified" Mode="OneWay" />
-                        <Binding Path="Settings.CustomDateTimeFormat" Mode="OneWay" />
-                    </MultiBinding>
-                </TextBlock.Text>
-            </TextBlock>
+            <TextBlock Text="{Binding Added, Mode=OneWay, Converter={StaticResource NullableDateToStringConverter}, ConverterParameter={pmrk:Settings DateTimeFormatAdded, DirectValue=True}}" />
         </DataTemplate>
         
         <DataTemplate x:Key="HeaderTemplateModified">
@@ -364,14 +350,7 @@
         </DataTemplate>
 
         <DataTemplate x:Key="CellTemplateModified">
-            <TextBlock>
-                <TextBlock.Text>
-                    <MultiBinding Converter="{StaticResource MultiNullableDateToCustomFormatStringConverter}">
-                        <Binding Path="Modified" Mode="OneWay" />
-                        <Binding Path="Settings.CustomDateTimeFormat" Mode="OneWay" />
-                    </MultiBinding>
-                </TextBlock.Text>
-            </TextBlock>
+            <TextBlock Text="{Binding Modified, Mode=OneWay, Converter={StaticResource NullableDateToStringConverter}, ConverterParameter={pmrk:Settings DateTimeFormatModified, DirectValue=True}}" />
         </DataTemplate>
 
         <DataTemplate x:Key="HeaderTemplateUserScore">

--- a/source/Playnite.DesktopApp/Controls/GamesGridView.xaml
+++ b/source/Playnite.DesktopApp/Controls/GamesGridView.xaml
@@ -218,7 +218,7 @@
         </DataTemplate>
 
         <DataTemplate x:Key="CellTemplateLastActivity">
-            <TextBlock Text="{Binding LastActivity, Mode=OneWay, Converter={StaticResource DateTimeToLastPlayedConverter}}" />
+            <TextBlock Text="{Binding LastActivity, Mode=OneWay, Converter={StaticResource DateTimeToLastPlayedConverter}, ConverterParameter={pmrk:Settings DateTimeFormatLastPlayed, DirectValue=True}}" />
         </DataTemplate>
 
         <DataTemplate x:Key="HeaderTemplateRecentActivity">

--- a/source/Playnite.DesktopApp/Controls/GamesGridView.xaml.cs
+++ b/source/Playnite.DesktopApp/Controls/GamesGridView.xaml.cs
@@ -118,6 +118,7 @@ namespace Playnite.DesktopApp.Controls
             AppSettings.ViewSettings.ListViewColumns.InstallDirectory.PropertyChanged += ListViewColumn_PropertyChanged;
             AppSettings.ViewSettings.ListViewColumns.IsInstalled.PropertyChanged += ListViewColumn_PropertyChanged;
             AppSettings.ViewSettings.ListViewColumns.LastActivity.PropertyChanged += ListViewColumn_PropertyChanged;
+            AppSettings.ViewSettings.ListViewColumns.RecentActivity.PropertyChanged += ListViewColumn_PropertyChanged;
             AppSettings.ViewSettings.ListViewColumns.Modified.PropertyChanged += ListViewColumn_PropertyChanged;
             AppSettings.ViewSettings.ListViewColumns.Name.PropertyChanged += ListViewColumn_PropertyChanged;
             AppSettings.ViewSettings.ListViewColumns.Platform.PropertyChanged += ListViewColumn_PropertyChanged;
@@ -312,6 +313,10 @@ namespace Playnite.DesktopApp.Controls
             else if (field == GameField.CommunityScore)
             {
                 newColumn = CreateColumn(field, SortOrder.CommunityScore, "CellTemplateCommunityScore", "HeaderTemplateCommunityScore");
+            }
+            else if (field == GameField.RecentActivity)
+            {
+                newColumn = CreateColumn(field, SortOrder.RecentActivity, "CellTemplateRecentActivity", "HeaderTemplateRecentActivity");
             }
 
             return newColumn;

--- a/source/Playnite.DesktopApp/Controls/SettingsSections/AppearanceAdvanced.xaml
+++ b/source/Playnite.DesktopApp/Controls/SettingsSections/AppearanceAdvanced.xaml
@@ -13,10 +13,8 @@
              xmlns:pctrls="clr-namespace:Playnite.DesktopApp.Controls"
              mc:Ignorable="d" 
              d:DesignHeight="700" d:DesignWidth="600">
-    
+
     <UserControl.Resources>
-        <sys:DateTime x:Key="DateTime">2022-12-22 12:54</sys:DateTime>
-        <pcon:MultiNullableDateToCustomFormatStringConverter x:Key="MultiNullableDateToCustomFormatStringConverter" />
         <Style TargetType="TextBlock" BasedOn="{StaticResource BaseTextBlockStyle}" />
         <Style TargetType="ContentControl">
             <Setter Property="Template">
@@ -184,7 +182,7 @@
                        TextWrapping="Wrap" Margin="0,10,0,0"/>
 
             <TextBlock Text="{DynamicResource LOCSettingsDatesFormatsLabel}" Margin="0,15,0,0" />
-            <GridEx ColumnCount="4" StarColumns="3" RowCount="4" AutoLayoutColumns="4">
+            <GridEx ColumnCount="4" StarColumns="3" RowCount="5" AutoLayoutColumns="4">
             
                 <!--Added-->
                 <ContentControl Content="{DynamicResource LOCAddedLabel}"
@@ -205,14 +203,7 @@
                 <Button Content="{DynamicResource LOCResetLabel}" Margin="10,5,0,0"
                         Command="{Binding ResetDateTimeFormatAddedCommand}" />
 
-                <TextBlock Margin="10,5,0,0" VerticalAlignment="Center">
-                    <TextBlock.Text>
-                        <MultiBinding Converter="{StaticResource MultiNullableDateToCustomFormatStringConverter}">
-                            <Binding Source="{StaticResource DateTime}" />
-                            <Binding Path="Settings.DateTimeFormatAdded" />
-                        </MultiBinding>
-                    </TextBlock.Text>
-                </TextBlock>
+                <TextBlock Margin="10,5,0,0" VerticalAlignment="Center" Text="Test" />
 
                 <!--Modified-->
                 <ContentControl Content="{DynamicResource LOCModifiedLabel}"
@@ -233,14 +224,7 @@
                 <Button Content="{DynamicResource LOCResetLabel}" Margin="10,5,0,0"
                         Command="{Binding ResetDateTimeFormatModifiedCommand}" />
 
-                <TextBlock Margin="10,5,0,0" VerticalAlignment="Center">
-                    <TextBlock.Text>
-                        <MultiBinding Converter="{StaticResource MultiNullableDateToCustomFormatStringConverter}">
-                            <Binding Source="{StaticResource DateTime}" />
-                            <Binding Path="Settings.DateTimeFormatModified" />
-                        </MultiBinding>
-                    </TextBlock.Text>
-                </TextBlock>
+                <TextBlock Margin="10,5,0,0" VerticalAlignment="Center" Text="Test" />
 
                 <!--RecentActivity-->
                 <ContentControl Content="{DynamicResource LOCRecentActivityLabel}"
@@ -261,14 +245,7 @@
                 <Button Content="{DynamicResource LOCResetLabel}" Margin="10,5,0,0"
                         Command="{Binding ResetDateTimeFormatRecentActivityCommand}" />
 
-                <TextBlock Margin="10,5,0,0" VerticalAlignment="Center">
-                    <TextBlock.Text>
-                        <MultiBinding Converter="{StaticResource MultiNullableDateToCustomFormatStringConverter}">
-                            <Binding Source="{StaticResource DateTime}" />
-                            <Binding Path="Settings.DateTimeFormatRecentActivity" />
-                        </MultiBinding>
-                    </TextBlock.Text>
-                </TextBlock>
+                <TextBlock Margin="10,5,0,0" VerticalAlignment="Center" Text="Test" />
 
                 <!--ReleaseDate-->
                 <ContentControl Content="{DynamicResource LOCGameReleaseDateTitle}"
@@ -289,14 +266,28 @@
                 <Button Content="{DynamicResource LOCResetLabel}" Margin="10,5,0,0"
                         Command="{Binding ResetDateTimeFormatReleaseDateCommand}" />
 
-                <TextBlock Margin="10,5,0,0" VerticalAlignment="Center">
-                    <TextBlock.Text>
-                        <MultiBinding Converter="{StaticResource MultiNullableDateToCustomFormatStringConverter}">
-                            <Binding Source="{StaticResource DateTime}" />
-                            <Binding Path="Settings.DateTimeFormatReleaseDate" />
-                        </MultiBinding>
-                    </TextBlock.Text>
-                </TextBlock>
+                <TextBlock Margin="10,5,0,0" VerticalAlignment="Center" Text="Test" />
+
+                <!--LastActivity-->
+                <ContentControl Content="{DynamicResource LOCLastPlayedLabel}"
+                                Margin="0,5,0,0" VerticalAlignment="Center"
+                                ContentStringFormat="{}{0} *" />
+                <TextBox Margin="10,5,0,0" MinWidth="150" VerticalAlignment="Center">
+                    <TextBox.Text>
+                        <Binding Path="Settings.DateTimeFormatLastPlayed"
+                                 UpdateSourceTrigger="PropertyChanged" 
+                                 ValidatesOnDataErrors="True"
+                                 NotifyOnValidationError="True">
+                            <Binding.ValidationRules>
+                                <pcon:DateTimeFormatToStringValidation />
+                            </Binding.ValidationRules>
+                        </Binding>
+                    </TextBox.Text>
+                </TextBox>
+                <Button Content="{DynamicResource LOCResetLabel}" Margin="10,5,0,0"
+                        Command="{Binding ResetDateTimeFormatLastPlayedCommand}" />
+
+                <TextBlock Margin="10,5,0,0" VerticalAlignment="Center" Text="Test" />
             </GridEx>
 
             <Button Content="{DynamicResource LOCMenuHelpTitle}"

--- a/source/Playnite.DesktopApp/Controls/SettingsSections/AppearanceAdvanced.xaml
+++ b/source/Playnite.DesktopApp/Controls/SettingsSections/AppearanceAdvanced.xaml
@@ -8,12 +8,15 @@
              xmlns:p="clr-namespace:Playnite;assembly=Playnite"
              xmlns:sys="clr-namespace:System;assembly=mscorlib"
              xmlns:sm="clr-namespace:System.Windows.Media;assembly=PresentationCore"
+             xmlns:pcmd="clr-namespace:Playnite.Commands;assembly=Playnite" 
              xmlns:pcon="clr-namespace:Playnite.Converters;assembly=Playnite"
              xmlns:pctrls="clr-namespace:Playnite.DesktopApp.Controls"
              mc:Ignorable="d" 
-             d:DesignHeight="500" d:DesignWidth="600">
+             d:DesignHeight="700" d:DesignWidth="600">
     
     <UserControl.Resources>
+        <sys:DateTime x:Key="DateTime">2022-12-22 12:54</sys:DateTime>
+        <pcon:MultiNullableDateToCustomFormatStringConverter x:Key="MultiNullableDateToCustomFormatStringConverter" />
         <Style TargetType="TextBlock" BasedOn="{StaticResource BaseTextBlockStyle}" />
         <Style TargetType="ContentControl">
             <Setter Property="Template">
@@ -178,5 +181,118 @@
 
         <TextBlock Text="{DynamicResource LOCSettingsTextRenderingNotice}"
                    TextWrapping="Wrap" Margin="0,10,0,0"/>
+
+        <TextBlock Text="{DynamicResource LOCSettingsDatesFormatsLabel}" Margin="0,15,0,0" />
+        <GridEx ColumnCount="4" StarColumns="3" RowCount="4" AutoLayoutColumns="4">
+            
+            <!--Added-->
+            <TextBlock Text="{DynamicResource LOCAddedLabel}" Margin="0,5,0,0" VerticalAlignment="Center" />
+            <TextBox Margin="10,5,0,0" MinWidth="150" VerticalAlignment="Center">
+                <TextBox.Text>
+                    <Binding Path="Settings.DateTimeFormatAdded"
+                             UpdateSourceTrigger="PropertyChanged" 
+                             ValidatesOnDataErrors="True"
+                             NotifyOnValidationError="True">
+                        <Binding.ValidationRules>
+                            <pcon:DateTimeFormatToStringValidation />
+                        </Binding.ValidationRules>
+                    </Binding>
+                </TextBox.Text>
+            </TextBox>
+            <Button Content="{DynamicResource LOCResetLabel}" Margin="10,5,0,0"
+                    Command="{Binding ResetDateTimeFormatAddedCommand}" />
+
+            <TextBlock Margin="10,5,0,0" VerticalAlignment="Center">
+                <TextBlock.Text>
+                    <MultiBinding Converter="{StaticResource MultiNullableDateToCustomFormatStringConverter}">
+                        <Binding Source="{StaticResource DateTime}" />
+                        <Binding Path="Settings.DateTimeFormatAdded" />
+                    </MultiBinding>
+                </TextBlock.Text>
+            </TextBlock>
+
+            <!--Modified-->
+            <TextBlock Text="{DynamicResource LOCModifiedLabel}" Margin="0,5,0,0" VerticalAlignment="Center" />
+            <TextBox Margin="10,5,0,0" MinWidth="150" VerticalAlignment="Center">
+                <TextBox.Text>
+                    <Binding Path="Settings.DateTimeFormatModified"
+                             UpdateSourceTrigger="PropertyChanged" 
+                             ValidatesOnDataErrors="True"
+                             NotifyOnValidationError="True">
+                        <Binding.ValidationRules>
+                            <pcon:DateTimeFormatToStringValidation />
+                        </Binding.ValidationRules>
+                    </Binding>
+                </TextBox.Text>
+            </TextBox>
+            <Button Content="{DynamicResource LOCResetLabel}" Margin="10,5,0,0"
+                    Command="{Binding ResetDateTimeFormatModifiedCommand}" />
+
+            <TextBlock Margin="10,5,0,0" VerticalAlignment="Center">
+                <TextBlock.Text>
+                    <MultiBinding Converter="{StaticResource MultiNullableDateToCustomFormatStringConverter}">
+                        <Binding Source="{StaticResource DateTime}" />
+                        <Binding Path="Settings.DateTimeFormatModified" />
+                    </MultiBinding>
+                </TextBlock.Text>
+            </TextBlock>
+
+            <!--RecentActivity-->
+            <TextBlock Text="{DynamicResource LOCRecentActivityLabel}" Margin="0,5,0,0" VerticalAlignment="Center" />
+            <TextBox Margin="10,5,0,0" MinWidth="150" VerticalAlignment="Center">
+                <TextBox.Text>
+                    <Binding Path="Settings.DateTimeFormatRecentActivity"
+                             UpdateSourceTrigger="PropertyChanged" 
+                             ValidatesOnDataErrors="True"
+                             NotifyOnValidationError="True">
+                        <Binding.ValidationRules>
+                            <pcon:DateTimeFormatToStringValidation />
+                        </Binding.ValidationRules>
+                    </Binding>
+                </TextBox.Text>
+            </TextBox>
+            <Button Content="{DynamicResource LOCResetLabel}" Margin="10,5,0,0"
+                    Command="{Binding ResetDateTimeFormatRecentActivityCommand}" />
+
+            <TextBlock Margin="10,5,0,0" VerticalAlignment="Center">
+                <TextBlock.Text>
+                    <MultiBinding Converter="{StaticResource MultiNullableDateToCustomFormatStringConverter}">
+                        <Binding Source="{StaticResource DateTime}" />
+                        <Binding Path="Settings.DateTimeFormatRecentActivity" />
+                    </MultiBinding>
+                </TextBlock.Text>
+            </TextBlock>
+
+            <!--ReleaseDate-->
+            <TextBlock Text="{DynamicResource LOCGameReleaseDateTitle}" Margin="0,5,0,0" VerticalAlignment="Center" />
+            <TextBox Margin="10,5,0,0" MinWidth="150" VerticalAlignment="Center">
+                <TextBox.Text>
+                    <Binding Path="Settings.DateTimeFormatReleaseDate"
+                             UpdateSourceTrigger="PropertyChanged" 
+                             ValidatesOnDataErrors="True"
+                             NotifyOnValidationError="True">
+                        <Binding.ValidationRules>
+                            <pcon:DateTimeFormatToStringValidation />
+                        </Binding.ValidationRules>
+                    </Binding>
+                </TextBox.Text>
+            </TextBox>
+            <Button Content="{DynamicResource LOCResetLabel}" Margin="10,5,0,0"
+                    Command="{Binding ResetDateTimeFormatReleaseDateCommand}" />
+
+            <TextBlock Margin="10,5,0,0" VerticalAlignment="Center">
+                <TextBlock.Text>
+                    <MultiBinding Converter="{StaticResource MultiNullableDateToCustomFormatStringConverter}">
+                        <Binding Source="{StaticResource DateTime}" />
+                        <Binding Path="Settings.DateTimeFormatReleaseDate" />
+                    </MultiBinding>
+                </TextBlock.Text>
+            </TextBlock>
+        </GridEx>
+
+        <Button Content="{DynamicResource LOCMenuHelpTitle}"
+                    Command="{x:Static pcmd:GlobalCommands.NavigateUrlCommand}"
+                    CommandParameter="https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings"
+                    HorizontalAlignment="Left" Margin="0,10,0,0" />
     </StackPanel>
 </UserControl>

--- a/source/Playnite.DesktopApp/Controls/SettingsSections/AppearanceAdvanced.xaml
+++ b/source/Playnite.DesktopApp/Controls/SettingsSections/AppearanceAdvanced.xaml
@@ -31,268 +31,270 @@
         </Style>
     </UserControl.Resources>
 
-    <StackPanel Margin="20">
-        <controls:GridEx ColumnCount="2" RowCount="3">
-            <ContentControl Content="{DynamicResource LOCSettingsDefaulIconSource}"
-                            ContentStringFormat="{}{0} *"
-                            Grid.Column="0" Grid.Row="0"
-                            Margin="0,10,10,10" VerticalAlignment="Center" />
-            <ComboBox SelectedValue="{Binding Settings.DefaultIconSource}"
-                      VerticalAlignment="Center" MinWidth="110"
-                      Grid.Column="1" Grid.Row="0">
-                <ComboBox.ItemsSource>
-                    <x:Array Type="{x:Type sys:Enum}">
-                        <p:DefaultIconSourceOptions>Library</p:DefaultIconSourceOptions>
-                        <p:DefaultIconSourceOptions>Platform</p:DefaultIconSourceOptions>
-                        <p:DefaultIconSourceOptions>General</p:DefaultIconSourceOptions>
-                        <p:DefaultIconSourceOptions>None</p:DefaultIconSourceOptions>
-                    </x:Array>
-                </ComboBox.ItemsSource>
-                <ComboBox.ItemTemplate>
-                    <DataTemplate>
-                        <TextBlock Text="{Binding Converter={pcon:ObjectToStringConverter}}"/>
-                    </DataTemplate>
-                </ComboBox.ItemTemplate>
-            </ComboBox>
+    <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+        <StackPanel Margin="20">
+            <controls:GridEx ColumnCount="2" RowCount="3">
+                <ContentControl Content="{DynamicResource LOCSettingsDefaulIconSource}"
+                                ContentStringFormat="{}{0} *"
+                                Grid.Column="0" Grid.Row="0"
+                                Margin="0,10,10,10" VerticalAlignment="Center" />
+                <ComboBox SelectedValue="{Binding Settings.DefaultIconSource}"
+                          VerticalAlignment="Center" MinWidth="110"
+                          Grid.Column="1" Grid.Row="0">
+                    <ComboBox.ItemsSource>
+                        <x:Array Type="{x:Type sys:Enum}">
+                            <p:DefaultIconSourceOptions>Library</p:DefaultIconSourceOptions>
+                            <p:DefaultIconSourceOptions>Platform</p:DefaultIconSourceOptions>
+                            <p:DefaultIconSourceOptions>General</p:DefaultIconSourceOptions>
+                            <p:DefaultIconSourceOptions>None</p:DefaultIconSourceOptions>
+                        </x:Array>
+                    </ComboBox.ItemsSource>
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Converter={pcon:ObjectToStringConverter}}"/>
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
 
-            <ContentControl Content="{DynamicResource LOCSettingsDefaulCoverSource}"
-                            ContentStringFormat="{}{0} *"
-                            Grid.Column="0" Grid.Row="1"
-                            Margin="0,10,10,10" VerticalAlignment="Center" />
-            <ComboBox SelectedValue="{Binding Settings.DefaultCoverSource}"
-                      VerticalAlignment="Center"
-                      Grid.Column="1" Grid.Row="1">
-                <ComboBox.ItemsSource>
-                    <x:Array Type="{x:Type sys:Enum}">
-                        <p:DefaultCoverSourceOptions>Platform</p:DefaultCoverSourceOptions>
-                        <p:DefaultCoverSourceOptions>General</p:DefaultCoverSourceOptions>
-                        <p:DefaultCoverSourceOptions>None</p:DefaultCoverSourceOptions>
-                    </x:Array>
-                </ComboBox.ItemsSource>
-                <ComboBox.ItemTemplate>
-                    <DataTemplate>
-                        <TextBlock Text="{Binding Converter={pcon:ObjectToStringConverter}}"/>
-                    </DataTemplate>
-                </ComboBox.ItemTemplate>
-            </ComboBox>
+                <ContentControl Content="{DynamicResource LOCSettingsDefaulCoverSource}"
+                                ContentStringFormat="{}{0} *"
+                                Grid.Column="0" Grid.Row="1"
+                                Margin="0,10,10,10" VerticalAlignment="Center" />
+                <ComboBox SelectedValue="{Binding Settings.DefaultCoverSource}"
+                          VerticalAlignment="Center"
+                          Grid.Column="1" Grid.Row="1">
+                    <ComboBox.ItemsSource>
+                        <x:Array Type="{x:Type sys:Enum}">
+                            <p:DefaultCoverSourceOptions>Platform</p:DefaultCoverSourceOptions>
+                            <p:DefaultCoverSourceOptions>General</p:DefaultCoverSourceOptions>
+                            <p:DefaultCoverSourceOptions>None</p:DefaultCoverSourceOptions>
+                        </x:Array>
+                    </ComboBox.ItemsSource>
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Converter={pcon:ObjectToStringConverter}}"/>
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
 
-            <ContentControl Content="{DynamicResource LOCSettingsDefaulBackgroundSource}"
-                            ContentStringFormat="{}{0} *"
-                            Grid.Column="0" Grid.Row="2"
-                            Margin="0,10,10,10" VerticalAlignment="Center" />
-            <ComboBox SelectedValue="{Binding Settings.DefaultBackgroundSource}"
-                      VerticalAlignment="Center"
-                      Grid.Column="1" Grid.Row="2">
-                <ComboBox.ItemsSource>
-                    <x:Array Type="{x:Type sys:Enum}">
-                        <p:DefaultBackgroundSourceOptions>Library</p:DefaultBackgroundSourceOptions>
-                        <p:DefaultBackgroundSourceOptions>Platform</p:DefaultBackgroundSourceOptions>
-                        <p:DefaultBackgroundSourceOptions>Cover</p:DefaultBackgroundSourceOptions>
-                        <p:DefaultBackgroundSourceOptions>None</p:DefaultBackgroundSourceOptions>
-                    </x:Array>
-                </ComboBox.ItemsSource>
-                <ComboBox.ItemTemplate>
-                    <DataTemplate>
-                        <TextBlock Text="{Binding Converter={pcon:ObjectToStringConverter}}"/>
-                    </DataTemplate>
-                </ComboBox.ItemTemplate>
-            </ComboBox>
-        </controls:GridEx>
+                <ContentControl Content="{DynamicResource LOCSettingsDefaulBackgroundSource}"
+                                ContentStringFormat="{}{0} *"
+                                Grid.Column="0" Grid.Row="2"
+                                Margin="0,10,10,10" VerticalAlignment="Center" />
+                <ComboBox SelectedValue="{Binding Settings.DefaultBackgroundSource}"
+                          VerticalAlignment="Center"
+                          Grid.Column="1" Grid.Row="2">
+                    <ComboBox.ItemsSource>
+                        <x:Array Type="{x:Type sys:Enum}">
+                            <p:DefaultBackgroundSourceOptions>Library</p:DefaultBackgroundSourceOptions>
+                            <p:DefaultBackgroundSourceOptions>Platform</p:DefaultBackgroundSourceOptions>
+                            <p:DefaultBackgroundSourceOptions>Cover</p:DefaultBackgroundSourceOptions>
+                            <p:DefaultBackgroundSourceOptions>None</p:DefaultBackgroundSourceOptions>
+                        </x:Array>
+                    </ComboBox.ItemsSource>
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Converter={pcon:ObjectToStringConverter}}"/>
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
+            </controls:GridEx>
 
-        <CheckBox Content="{DynamicResource LOCSettingsHiddenInQuickLaunch}" Margin="0,15,0,0"
-                  ToolTip="{DynamicResource LOCSettingsHiddenInQuickLaunchTooltip}"
-                  IsChecked="{Binding Settings.ShowHiddenInQuickLaunch}"/>
+            <CheckBox Content="{DynamicResource LOCSettingsHiddenInQuickLaunch}" Margin="0,15,0,0"
+                      ToolTip="{DynamicResource LOCSettingsHiddenInQuickLaunchTooltip}"
+                      IsChecked="{Binding Settings.ShowHiddenInQuickLaunch}"/>
 
-        <StackPanel Orientation="Horizontal" Margin="0,15,0,0">
-            <TextBlock Text="{DynamicResource LOCSettingsQuicLaunchItems}"
-                       VerticalAlignment="Center" Margin="0,0,5,0"/>
-            <pctrls:NullIntNumericBox MinValue="0" MaxValue="99" Width="50"
-                                   Value="{Binding Settings.QuickLaunchItems}"/>
-        </StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="0,15,0,0">
+                <TextBlock Text="{DynamicResource LOCSettingsQuicLaunchItems}"
+                           VerticalAlignment="Center" Margin="0,0,5,0"/>
+                <pctrls:NullIntNumericBox MinValue="0" MaxValue="99" Width="50"
+                                       Value="{Binding Settings.QuickLaunchItems}"/>
+            </StackPanel>
 
-        <StackPanel Orientation="Horizontal"  Margin="0,25,0,0">
-            <ContentControl Content="{DynamicResource LOCSettingsFontSizes}" Margin="0,0,10,0"
-                            ContentStringFormat="{}{0} *" VerticalAlignment="Top" />
-            <UniformGrid Rows="2">
-                <UniformGrid.Resources>
-                    <Style TargetType="pctrls:NullIntNumericBox" BasedOn="{StaticResource {x:Type pctrls:NullIntNumericBox}}">
-                        <Setter Property="Margin" Value="5,0,5,0" />
-                        <Setter Property="Width" Value="50" />
-                        <Setter Property="MinValue" Value="9" />
-                        <Setter Property="MaxValue" Value="100" />
-                    </Style>
-                </UniformGrid.Resources>
-                <TextBlock Text="{DynamicResource LOCFontSmall}" Margin="5,0,5,0"/>
-                <TextBlock Text="{DynamicResource LOCFontNormal}" Margin="5,0,5,0"/>
-                <TextBlock Text="{DynamicResource LOCFontLarge}" Margin="5,0,5,0"/>
-                <TextBlock Text="{DynamicResource LOCFontLarger}" Margin="5,0,5,0"/>
-                <TextBlock Text="{DynamicResource LOCFontLargest}" Margin="5,0,5,0"/>
+            <StackPanel Orientation="Horizontal"  Margin="0,25,0,0">
+                <ContentControl Content="{DynamicResource LOCSettingsFontSizes}" Margin="0,0,10,0"
+                                ContentStringFormat="{}{0} *" VerticalAlignment="Top" />
+                <UniformGrid Rows="2">
+                    <UniformGrid.Resources>
+                        <Style TargetType="pctrls:NullIntNumericBox" BasedOn="{StaticResource {x:Type pctrls:NullIntNumericBox}}">
+                            <Setter Property="Margin" Value="5,0,5,0" />
+                            <Setter Property="Width" Value="50" />
+                            <Setter Property="MinValue" Value="9" />
+                            <Setter Property="MaxValue" Value="100" />
+                        </Style>
+                    </UniformGrid.Resources>
+                    <TextBlock Text="{DynamicResource LOCFontSmall}" Margin="5,0,5,0"/>
+                    <TextBlock Text="{DynamicResource LOCFontNormal}" Margin="5,0,5,0"/>
+                    <TextBlock Text="{DynamicResource LOCFontLarge}" Margin="5,0,5,0"/>
+                    <TextBlock Text="{DynamicResource LOCFontLarger}" Margin="5,0,5,0"/>
+                    <TextBlock Text="{DynamicResource LOCFontLargest}" Margin="5,0,5,0"/>
 
-                <pctrls:NullIntNumericBox Value="{Binding Settings.FontSizeSmall}"/>
-                <pctrls:NullIntNumericBox Value="{Binding Settings.FontSize}"/>
-                <pctrls:NullIntNumericBox Value="{Binding Settings.FontSizeLarge}"/>
-                <pctrls:NullIntNumericBox Value="{Binding Settings.FontSizeLarger}"/>
-                <pctrls:NullIntNumericBox Value="{Binding Settings.FontSizeLargest}"/>
-            </UniformGrid>
+                    <pctrls:NullIntNumericBox Value="{Binding Settings.FontSizeSmall}"/>
+                    <pctrls:NullIntNumericBox Value="{Binding Settings.FontSize}"/>
+                    <pctrls:NullIntNumericBox Value="{Binding Settings.FontSizeLarge}"/>
+                    <pctrls:NullIntNumericBox Value="{Binding Settings.FontSizeLarger}"/>
+                    <pctrls:NullIntNumericBox Value="{Binding Settings.FontSizeLargest}"/>
+                </UniformGrid>
 
-            <Button Content="{DynamicResource LOCDefault}" VerticalAlignment="Bottom"
-                    Margin="10,0,0,0" Command="{Binding SetDefaultFontSizes}"/>
-        </StackPanel>
+                <Button Content="{DynamicResource LOCDefault}" VerticalAlignment="Bottom"
+                        Margin="10,0,0,0" Command="{Binding SetDefaultFontSizes}"/>
+            </StackPanel>
 
-        <GridEx ColumnCount="2" RowCount="2" Margin="0,20,0,0">
-            <ContentControl Content="{DynamicResource LOCSettingsTextRenderingMode}" Grid.Column="0" Grid.Row="0"
-                            Margin="0,10,10,10" VerticalAlignment="Center"
-                            ContentStringFormat="{}{0} *"/>
-            <ComboBox Grid.Column="1" Grid.Row="0" VerticalAlignment="Center" MinWidth="100"
-                      SelectedValue="{Binding Settings.TextRenderingMode}">
-                <ComboBox.ItemsSource>
-                    <x:Array Type="{x:Type sys:Enum}">
-                        <p:TextRenderingModeOptions>Auto</p:TextRenderingModeOptions>
-                        <p:TextRenderingModeOptions>Aliased</p:TextRenderingModeOptions>
-                        <p:TextRenderingModeOptions>Grayscale</p:TextRenderingModeOptions>
-                        <p:TextRenderingModeOptions>ClearType</p:TextRenderingModeOptions>
-                    </x:Array>
-                </ComboBox.ItemsSource>
-                <ComboBox.ItemTemplate>
-                    <DataTemplate>
-                        <TextBlock Text="{Binding Converter={pcon:ObjectToStringConverter}}"/>
-                    </DataTemplate>
-                </ComboBox.ItemTemplate>
-            </ComboBox>
+            <GridEx ColumnCount="2" RowCount="2" Margin="0,20,0,0">
+                <ContentControl Content="{DynamicResource LOCSettingsTextRenderingMode}" Grid.Column="0" Grid.Row="0"
+                                Margin="0,10,10,10" VerticalAlignment="Center"
+                                ContentStringFormat="{}{0} *"/>
+                <ComboBox Grid.Column="1" Grid.Row="0" VerticalAlignment="Center" MinWidth="100"
+                          SelectedValue="{Binding Settings.TextRenderingMode}">
+                    <ComboBox.ItemsSource>
+                        <x:Array Type="{x:Type sys:Enum}">
+                            <p:TextRenderingModeOptions>Auto</p:TextRenderingModeOptions>
+                            <p:TextRenderingModeOptions>Aliased</p:TextRenderingModeOptions>
+                            <p:TextRenderingModeOptions>Grayscale</p:TextRenderingModeOptions>
+                            <p:TextRenderingModeOptions>ClearType</p:TextRenderingModeOptions>
+                        </x:Array>
+                    </ComboBox.ItemsSource>
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Converter={pcon:ObjectToStringConverter}}"/>
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
 
-            <ContentControl Content="{DynamicResource LOCSettingsTextFormattingMode}" Grid.Column="0" Grid.Row="1"
-                            Margin="0,10,10,10" VerticalAlignment="Center"
-                            ContentStringFormat="{}{0} *"/>
-            <ComboBox Grid.Column="1" Grid.Row="1" VerticalAlignment="Center" MinWidth="100"
-                      SelectedValue="{Binding Settings.TextFormattingMode}">
-                <ComboBox.ItemsSource>
-                    <x:Array Type="{x:Type sys:Enum}">
-                        <p:TextFormattingModeOptions>Ideal</p:TextFormattingModeOptions>
-                        <p:TextFormattingModeOptions>Display</p:TextFormattingModeOptions>
-                    </x:Array>
-                </ComboBox.ItemsSource>
-                <ComboBox.ItemTemplate>
-                    <DataTemplate>
-                        <TextBlock Text="{Binding Converter={pcon:ObjectToStringConverter}}"/>
-                    </DataTemplate>
-                </ComboBox.ItemTemplate>
-            </ComboBox>
-        </GridEx>
+                <ContentControl Content="{DynamicResource LOCSettingsTextFormattingMode}" Grid.Column="0" Grid.Row="1"
+                                Margin="0,10,10,10" VerticalAlignment="Center"
+                                ContentStringFormat="{}{0} *"/>
+                <ComboBox Grid.Column="1" Grid.Row="1" VerticalAlignment="Center" MinWidth="100"
+                          SelectedValue="{Binding Settings.TextFormattingMode}">
+                    <ComboBox.ItemsSource>
+                        <x:Array Type="{x:Type sys:Enum}">
+                            <p:TextFormattingModeOptions>Ideal</p:TextFormattingModeOptions>
+                            <p:TextFormattingModeOptions>Display</p:TextFormattingModeOptions>
+                        </x:Array>
+                    </ComboBox.ItemsSource>
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Converter={pcon:ObjectToStringConverter}}"/>
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
+            </GridEx>
 
-        <TextBlock Text="{DynamicResource LOCSettingsTextRenderingNotice}"
-                   TextWrapping="Wrap" Margin="0,10,0,0"/>
+            <TextBlock Text="{DynamicResource LOCSettingsTextRenderingNotice}"
+                       TextWrapping="Wrap" Margin="0,10,0,0"/>
 
-        <TextBlock Text="{DynamicResource LOCSettingsDatesFormatsLabel}" Margin="0,15,0,0" />
-        <GridEx ColumnCount="4" StarColumns="3" RowCount="4" AutoLayoutColumns="4">
+            <TextBlock Text="{DynamicResource LOCSettingsDatesFormatsLabel}" Margin="0,15,0,0" />
+            <GridEx ColumnCount="4" StarColumns="3" RowCount="4" AutoLayoutColumns="4">
             
-            <!--Added-->
-            <TextBlock Text="{DynamicResource LOCAddedLabel}" Margin="0,5,0,0" VerticalAlignment="Center" />
-            <TextBox Margin="10,5,0,0" MinWidth="150" VerticalAlignment="Center">
-                <TextBox.Text>
-                    <Binding Path="Settings.DateTimeFormatAdded"
-                             UpdateSourceTrigger="PropertyChanged" 
-                             ValidatesOnDataErrors="True"
-                             NotifyOnValidationError="True">
-                        <Binding.ValidationRules>
-                            <pcon:DateTimeFormatToStringValidation />
-                        </Binding.ValidationRules>
-                    </Binding>
-                </TextBox.Text>
-            </TextBox>
-            <Button Content="{DynamicResource LOCResetLabel}" Margin="10,5,0,0"
-                    Command="{Binding ResetDateTimeFormatAddedCommand}" />
+                <!--Added-->
+                <TextBlock Text="{DynamicResource LOCAddedLabel}" Margin="0,5,0,0" VerticalAlignment="Center" />
+                <TextBox Margin="10,5,0,0" MinWidth="150" VerticalAlignment="Center">
+                    <TextBox.Text>
+                        <Binding Path="Settings.DateTimeFormatAdded"
+                                 UpdateSourceTrigger="PropertyChanged" 
+                                 ValidatesOnDataErrors="True"
+                                 NotifyOnValidationError="True">
+                            <Binding.ValidationRules>
+                                <pcon:DateTimeFormatToStringValidation />
+                            </Binding.ValidationRules>
+                        </Binding>
+                    </TextBox.Text>
+                </TextBox>
+                <Button Content="{DynamicResource LOCResetLabel}" Margin="10,5,0,0"
+                        Command="{Binding ResetDateTimeFormatAddedCommand}" />
 
-            <TextBlock Margin="10,5,0,0" VerticalAlignment="Center">
-                <TextBlock.Text>
-                    <MultiBinding Converter="{StaticResource MultiNullableDateToCustomFormatStringConverter}">
-                        <Binding Source="{StaticResource DateTime}" />
-                        <Binding Path="Settings.DateTimeFormatAdded" />
-                    </MultiBinding>
-                </TextBlock.Text>
-            </TextBlock>
+                <TextBlock Margin="10,5,0,0" VerticalAlignment="Center">
+                    <TextBlock.Text>
+                        <MultiBinding Converter="{StaticResource MultiNullableDateToCustomFormatStringConverter}">
+                            <Binding Source="{StaticResource DateTime}" />
+                            <Binding Path="Settings.DateTimeFormatAdded" />
+                        </MultiBinding>
+                    </TextBlock.Text>
+                </TextBlock>
 
-            <!--Modified-->
-            <TextBlock Text="{DynamicResource LOCModifiedLabel}" Margin="0,5,0,0" VerticalAlignment="Center" />
-            <TextBox Margin="10,5,0,0" MinWidth="150" VerticalAlignment="Center">
-                <TextBox.Text>
-                    <Binding Path="Settings.DateTimeFormatModified"
-                             UpdateSourceTrigger="PropertyChanged" 
-                             ValidatesOnDataErrors="True"
-                             NotifyOnValidationError="True">
-                        <Binding.ValidationRules>
-                            <pcon:DateTimeFormatToStringValidation />
-                        </Binding.ValidationRules>
-                    </Binding>
-                </TextBox.Text>
-            </TextBox>
-            <Button Content="{DynamicResource LOCResetLabel}" Margin="10,5,0,0"
-                    Command="{Binding ResetDateTimeFormatModifiedCommand}" />
+                <!--Modified-->
+                <TextBlock Text="{DynamicResource LOCModifiedLabel}" Margin="0,5,0,0" VerticalAlignment="Center" />
+                <TextBox Margin="10,5,0,0" MinWidth="150" VerticalAlignment="Center">
+                    <TextBox.Text>
+                        <Binding Path="Settings.DateTimeFormatModified"
+                                 UpdateSourceTrigger="PropertyChanged" 
+                                 ValidatesOnDataErrors="True"
+                                 NotifyOnValidationError="True">
+                            <Binding.ValidationRules>
+                                <pcon:DateTimeFormatToStringValidation />
+                            </Binding.ValidationRules>
+                        </Binding>
+                    </TextBox.Text>
+                </TextBox>
+                <Button Content="{DynamicResource LOCResetLabel}" Margin="10,5,0,0"
+                        Command="{Binding ResetDateTimeFormatModifiedCommand}" />
 
-            <TextBlock Margin="10,5,0,0" VerticalAlignment="Center">
-                <TextBlock.Text>
-                    <MultiBinding Converter="{StaticResource MultiNullableDateToCustomFormatStringConverter}">
-                        <Binding Source="{StaticResource DateTime}" />
-                        <Binding Path="Settings.DateTimeFormatModified" />
-                    </MultiBinding>
-                </TextBlock.Text>
-            </TextBlock>
+                <TextBlock Margin="10,5,0,0" VerticalAlignment="Center">
+                    <TextBlock.Text>
+                        <MultiBinding Converter="{StaticResource MultiNullableDateToCustomFormatStringConverter}">
+                            <Binding Source="{StaticResource DateTime}" />
+                            <Binding Path="Settings.DateTimeFormatModified" />
+                        </MultiBinding>
+                    </TextBlock.Text>
+                </TextBlock>
 
-            <!--RecentActivity-->
-            <TextBlock Text="{DynamicResource LOCRecentActivityLabel}" Margin="0,5,0,0" VerticalAlignment="Center" />
-            <TextBox Margin="10,5,0,0" MinWidth="150" VerticalAlignment="Center">
-                <TextBox.Text>
-                    <Binding Path="Settings.DateTimeFormatRecentActivity"
-                             UpdateSourceTrigger="PropertyChanged" 
-                             ValidatesOnDataErrors="True"
-                             NotifyOnValidationError="True">
-                        <Binding.ValidationRules>
-                            <pcon:DateTimeFormatToStringValidation />
-                        </Binding.ValidationRules>
-                    </Binding>
-                </TextBox.Text>
-            </TextBox>
-            <Button Content="{DynamicResource LOCResetLabel}" Margin="10,5,0,0"
-                    Command="{Binding ResetDateTimeFormatRecentActivityCommand}" />
+                <!--RecentActivity-->
+                <TextBlock Text="{DynamicResource LOCRecentActivityLabel}" Margin="0,5,0,0" VerticalAlignment="Center" />
+                <TextBox Margin="10,5,0,0" MinWidth="150" VerticalAlignment="Center">
+                    <TextBox.Text>
+                        <Binding Path="Settings.DateTimeFormatRecentActivity"
+                                 UpdateSourceTrigger="PropertyChanged" 
+                                 ValidatesOnDataErrors="True"
+                                 NotifyOnValidationError="True">
+                            <Binding.ValidationRules>
+                                <pcon:DateTimeFormatToStringValidation />
+                            </Binding.ValidationRules>
+                        </Binding>
+                    </TextBox.Text>
+                </TextBox>
+                <Button Content="{DynamicResource LOCResetLabel}" Margin="10,5,0,0"
+                        Command="{Binding ResetDateTimeFormatRecentActivityCommand}" />
 
-            <TextBlock Margin="10,5,0,0" VerticalAlignment="Center">
-                <TextBlock.Text>
-                    <MultiBinding Converter="{StaticResource MultiNullableDateToCustomFormatStringConverter}">
-                        <Binding Source="{StaticResource DateTime}" />
-                        <Binding Path="Settings.DateTimeFormatRecentActivity" />
-                    </MultiBinding>
-                </TextBlock.Text>
-            </TextBlock>
+                <TextBlock Margin="10,5,0,0" VerticalAlignment="Center">
+                    <TextBlock.Text>
+                        <MultiBinding Converter="{StaticResource MultiNullableDateToCustomFormatStringConverter}">
+                            <Binding Source="{StaticResource DateTime}" />
+                            <Binding Path="Settings.DateTimeFormatRecentActivity" />
+                        </MultiBinding>
+                    </TextBlock.Text>
+                </TextBlock>
 
-            <!--ReleaseDate-->
-            <TextBlock Text="{DynamicResource LOCGameReleaseDateTitle}" Margin="0,5,0,0" VerticalAlignment="Center" />
-            <TextBox Margin="10,5,0,0" MinWidth="150" VerticalAlignment="Center">
-                <TextBox.Text>
-                    <Binding Path="Settings.DateTimeFormatReleaseDate"
-                             UpdateSourceTrigger="PropertyChanged" 
-                             ValidatesOnDataErrors="True"
-                             NotifyOnValidationError="True">
-                        <Binding.ValidationRules>
-                            <pcon:DateTimeFormatToStringValidation />
-                        </Binding.ValidationRules>
-                    </Binding>
-                </TextBox.Text>
-            </TextBox>
-            <Button Content="{DynamicResource LOCResetLabel}" Margin="10,5,0,0"
-                    Command="{Binding ResetDateTimeFormatReleaseDateCommand}" />
+                <!--ReleaseDate-->
+                <TextBlock Text="{DynamicResource LOCGameReleaseDateTitle}" Margin="0,5,0,0" VerticalAlignment="Center" />
+                <TextBox Margin="10,5,0,0" MinWidth="150" VerticalAlignment="Center">
+                    <TextBox.Text>
+                        <Binding Path="Settings.DateTimeFormatReleaseDate"
+                                 UpdateSourceTrigger="PropertyChanged" 
+                                 ValidatesOnDataErrors="True"
+                                 NotifyOnValidationError="True">
+                            <Binding.ValidationRules>
+                                <pcon:DateTimeFormatToStringValidation />
+                            </Binding.ValidationRules>
+                        </Binding>
+                    </TextBox.Text>
+                </TextBox>
+                <Button Content="{DynamicResource LOCResetLabel}" Margin="10,5,0,0"
+                        Command="{Binding ResetDateTimeFormatReleaseDateCommand}" />
 
-            <TextBlock Margin="10,5,0,0" VerticalAlignment="Center">
-                <TextBlock.Text>
-                    <MultiBinding Converter="{StaticResource MultiNullableDateToCustomFormatStringConverter}">
-                        <Binding Source="{StaticResource DateTime}" />
-                        <Binding Path="Settings.DateTimeFormatReleaseDate" />
-                    </MultiBinding>
-                </TextBlock.Text>
-            </TextBlock>
-        </GridEx>
+                <TextBlock Margin="10,5,0,0" VerticalAlignment="Center">
+                    <TextBlock.Text>
+                        <MultiBinding Converter="{StaticResource MultiNullableDateToCustomFormatStringConverter}">
+                            <Binding Source="{StaticResource DateTime}" />
+                            <Binding Path="Settings.DateTimeFormatReleaseDate" />
+                        </MultiBinding>
+                    </TextBlock.Text>
+                </TextBlock>
+            </GridEx>
 
-        <Button Content="{DynamicResource LOCMenuHelpTitle}"
+            <Button Content="{DynamicResource LOCMenuHelpTitle}"
                     Command="{x:Static pcmd:GlobalCommands.NavigateUrlCommand}"
                     CommandParameter="https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings"
                     HorizontalAlignment="Left" Margin="0,10,0,0" />
-    </StackPanel>
+        </StackPanel>
+    </ScrollViewer>
 </UserControl>

--- a/source/Playnite.DesktopApp/Controls/SettingsSections/AppearanceAdvanced.xaml
+++ b/source/Playnite.DesktopApp/Controls/SettingsSections/AppearanceAdvanced.xaml
@@ -187,7 +187,9 @@
             <GridEx ColumnCount="4" StarColumns="3" RowCount="4" AutoLayoutColumns="4">
             
                 <!--Added-->
-                <TextBlock Text="{DynamicResource LOCAddedLabel}" Margin="0,5,0,0" VerticalAlignment="Center" />
+                <ContentControl Content="{DynamicResource LOCAddedLabel}"
+                                Margin="0,5,0,0" VerticalAlignment="Center"
+                                ContentStringFormat="{}{0} *" />
                 <TextBox Margin="10,5,0,0" MinWidth="150" VerticalAlignment="Center">
                     <TextBox.Text>
                         <Binding Path="Settings.DateTimeFormatAdded"
@@ -213,7 +215,9 @@
                 </TextBlock>
 
                 <!--Modified-->
-                <TextBlock Text="{DynamicResource LOCModifiedLabel}" Margin="0,5,0,0" VerticalAlignment="Center" />
+                <ContentControl Content="{DynamicResource LOCModifiedLabel}"
+                                Margin="0,5,0,0" VerticalAlignment="Center"
+                                ContentStringFormat="{}{0} *" />
                 <TextBox Margin="10,5,0,0" MinWidth="150" VerticalAlignment="Center">
                     <TextBox.Text>
                         <Binding Path="Settings.DateTimeFormatModified"
@@ -239,7 +243,9 @@
                 </TextBlock>
 
                 <!--RecentActivity-->
-                <TextBlock Text="{DynamicResource LOCRecentActivityLabel}" Margin="0,5,0,0" VerticalAlignment="Center" />
+                <ContentControl Content="{DynamicResource LOCRecentActivityLabel}"
+                                Margin="0,5,0,0" VerticalAlignment="Center"
+                                ContentStringFormat="{}{0} *" />
                 <TextBox Margin="10,5,0,0" MinWidth="150" VerticalAlignment="Center">
                     <TextBox.Text>
                         <Binding Path="Settings.DateTimeFormatRecentActivity"
@@ -265,7 +271,9 @@
                 </TextBlock>
 
                 <!--ReleaseDate-->
-                <TextBlock Text="{DynamicResource LOCGameReleaseDateTitle}" Margin="0,5,0,0" VerticalAlignment="Center" />
+                <ContentControl Content="{DynamicResource LOCGameReleaseDateTitle}"
+                                Margin="0,5,0,0" VerticalAlignment="Center"
+                                ContentStringFormat="{}{0} *" />
                 <TextBox Margin="10,5,0,0" MinWidth="150" VerticalAlignment="Center">
                     <TextBox.Text>
                         <Binding Path="Settings.DateTimeFormatReleaseDate"

--- a/source/Playnite.DesktopApp/Controls/SettingsSections/AppearanceDetailsView.xaml
+++ b/source/Playnite.DesktopApp/Controls/SettingsSections/AppearanceDetailsView.xaml
@@ -88,6 +88,9 @@
                 <CheckBox Content="{DynamicResource LOCGameLastActivityTitle}"
                                               IsChecked="{Binding Settings.DetailsVisibility.LastPlayed}"
                                               Margin="0,10,0,0"/>
+                <CheckBox Content="{DynamicResource LOCRecentActivityLabel}"
+                                              IsChecked="{Binding Settings.DetailsVisibility.RecentActivity}"
+                                              Margin="0,10,0,0"/>
                 <CheckBox Content="{DynamicResource LOCCompletionStatus}"
                                               IsChecked="{Binding Settings.DetailsVisibility.CompletionStatus}"
                                               Margin="0,10,0,0"/>

--- a/source/Playnite.DesktopApp/Controls/SettingsSections/AppearanceListView.xaml
+++ b/source/Playnite.DesktopApp/Controls/SettingsSections/AppearanceListView.xaml
@@ -3,12 +3,17 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:pcon="clr-namespace:Playnite.Converters;assembly=Playnite"
+             xmlns:pcmd="clr-namespace:Playnite.Commands;assembly=Playnite" 
+             xmlns:sys="clr-namespace:System;assembly=mscorlib"
              xmlns:local="clr-namespace:Playnite.DesktopApp.Controls.SettingsSections"
              xmlns:pctrls="clr-namespace:Playnite.DesktopApp.Controls"
              mc:Ignorable="d"
              d:DesignHeight="500" d:DesignWidth="600">
 
     <UserControl.Resources>
+        <sys:DateTime x:Key="DateTime">2022-12-22 12:54</sys:DateTime>
+        <pcon:MultiNullableDateToCustomFormatStringConverter x:Key="MultiNullableDateToCustomFormatStringConverter" />
         <Style TargetType="TextBlock" BasedOn="{StaticResource BaseTextBlockStyle}" />
         <Style TargetType="ContentControl">
             <Setter Property="Template">
@@ -43,6 +48,38 @@
                     IsSnapToTickEnabled="True" TickFrequency="500000"
                     HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10,0,10,0"
                     Value="{Binding Settings.ListViewScrollSpeed}" />
+        </StackPanel>
+
+        <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
+            <TextBlock Text="{DynamicResource LOCSettingsCustomDateTimeFormat}" VerticalAlignment="Center" />
+            <TextBox Margin="10,0,0,0" MinWidth="150">
+                <TextBox.Text>
+                    <Binding Path="Settings.CustomDateTimeFormat"
+                             UpdateSourceTrigger="PropertyChanged" 
+                             ValidatesOnDataErrors="True"
+                             NotifyOnValidationError="True">
+                        <Binding.ValidationRules>
+                            <pcon:DateTimeFormatToStringValidation />
+                        </Binding.ValidationRules>
+                    </Binding>
+                </TextBox.Text>
+            </TextBox>
+            <Button Content="{DynamicResource LOCResetLabel}" Margin="10,0,0,0"
+                    Command="{Binding ResetDefaultCustomDateTimeFormatCommand}" />
+
+            <Button Content="{DynamicResource LOCMenuHelpTitle}"
+                    Command="{x:Static pcmd:GlobalCommands.NavigateUrlCommand}"
+                    CommandParameter="https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings"
+                    HorizontalAlignment="Left" Margin="10,0,0,0" />
+            
+            <TextBlock Margin="10,0,0,0" VerticalAlignment="Center">
+                <TextBlock.Text>
+                    <MultiBinding Converter="{StaticResource MultiNullableDateToCustomFormatStringConverter}" Mode="OneWay">
+                        <Binding Source="{StaticResource DateTime}" />
+                        <Binding Path="Settings.CustomDateTimeFormat" />
+                    </MultiBinding>
+                </TextBlock.Text>
+            </TextBlock>
         </StackPanel>
     </StackPanel>
 </UserControl>

--- a/source/Playnite.DesktopApp/Controls/SettingsSections/AppearanceListView.xaml
+++ b/source/Playnite.DesktopApp/Controls/SettingsSections/AppearanceListView.xaml
@@ -3,17 +3,12 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:pcon="clr-namespace:Playnite.Converters;assembly=Playnite"
-             xmlns:pcmd="clr-namespace:Playnite.Commands;assembly=Playnite" 
-             xmlns:sys="clr-namespace:System;assembly=mscorlib"
              xmlns:local="clr-namespace:Playnite.DesktopApp.Controls.SettingsSections"
              xmlns:pctrls="clr-namespace:Playnite.DesktopApp.Controls"
              mc:Ignorable="d"
              d:DesignHeight="500" d:DesignWidth="600">
 
     <UserControl.Resources>
-        <sys:DateTime x:Key="DateTime">2022-12-22 12:54</sys:DateTime>
-        <pcon:MultiNullableDateToCustomFormatStringConverter x:Key="MultiNullableDateToCustomFormatStringConverter" />
         <Style TargetType="TextBlock" BasedOn="{StaticResource BaseTextBlockStyle}" />
         <Style TargetType="ContentControl">
             <Setter Property="Template">
@@ -48,38 +43,6 @@
                     IsSnapToTickEnabled="True" TickFrequency="500000"
                     HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10,0,10,0"
                     Value="{Binding Settings.ListViewScrollSpeed}" />
-        </StackPanel>
-
-        <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
-            <TextBlock Text="{DynamicResource LOCSettingsCustomDateTimeFormat}" VerticalAlignment="Center" />
-            <TextBox Margin="10,0,0,0" MinWidth="150">
-                <TextBox.Text>
-                    <Binding Path="Settings.CustomDateTimeFormat"
-                             UpdateSourceTrigger="PropertyChanged" 
-                             ValidatesOnDataErrors="True"
-                             NotifyOnValidationError="True">
-                        <Binding.ValidationRules>
-                            <pcon:DateTimeFormatToStringValidation />
-                        </Binding.ValidationRules>
-                    </Binding>
-                </TextBox.Text>
-            </TextBox>
-            <Button Content="{DynamicResource LOCResetLabel}" Margin="10,0,0,0"
-                    Command="{Binding ResetDefaultCustomDateTimeFormatCommand}" />
-
-            <Button Content="{DynamicResource LOCMenuHelpTitle}"
-                    Command="{x:Static pcmd:GlobalCommands.NavigateUrlCommand}"
-                    CommandParameter="https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings"
-                    HorizontalAlignment="Left" Margin="10,0,0,0" />
-            
-            <TextBlock Margin="10,0,0,0" VerticalAlignment="Center">
-                <TextBlock.Text>
-                    <MultiBinding Converter="{StaticResource MultiNullableDateToCustomFormatStringConverter}" Mode="OneWay">
-                        <Binding Source="{StaticResource DateTime}" />
-                        <Binding Path="Settings.CustomDateTimeFormat" />
-                    </MultiBinding>
-                </TextBlock.Text>
-            </TextBlock>
         </StackPanel>
     </StackPanel>
 </UserControl>

--- a/source/Playnite.DesktopApp/Controls/Views/GameOverview.cs
+++ b/source/Playnite.DesktopApp/Controls/Views/GameOverview.cs
@@ -24,6 +24,7 @@ namespace Playnite.DesktopApp.Controls.Views
 {
     [TemplatePart(Name = "PART_ElemPlayTime", Type = typeof(FrameworkElement))]
     [TemplatePart(Name = "PART_ElemLastPlayed", Type = typeof(FrameworkElement))]
+    [TemplatePart(Name = "PART_ElemRecentActivity", Type = typeof(FrameworkElement))]
     [TemplatePart(Name = "PART_ElemCompletionStatus", Type = typeof(FrameworkElement))]
     [TemplatePart(Name = "PART_ElemLibrary", Type = typeof(FrameworkElement))]
     [TemplatePart(Name = "PART_ElemPlatform", Type = typeof(FrameworkElement))]
@@ -47,6 +48,7 @@ namespace Playnite.DesktopApp.Controls.Views
     [TemplatePart(Name = "PART_ElemUserScore", Type = typeof(FrameworkElement))]
     [TemplatePart(Name = "PART_TextPlayTime", Type = typeof(TextBlock))]
     [TemplatePart(Name = "PART_TextLastActivity", Type = typeof(TextBlock))]
+    [TemplatePart(Name = "PART_TextRecentActivity", Type = typeof(TextBlock))]
     [TemplatePart(Name = "PART_ButtonCompletionStatus", Type = typeof(Button))]
     [TemplatePart(Name = "PART_TextNotes", Type = typeof(TextBox))]
     [TemplatePart(Name = "PART_TextCommunityScore", Type = typeof(TextBlock))]
@@ -345,6 +347,7 @@ namespace Playnite.DesktopApp.Controls.Views
 
             SetElemVisibility(ref ElemPlayTime, "PART_ElemPlayTime", nameof(GameDetailsViewModel.PlayTimeVisibility));
             SetElemVisibility(ref ElemLastPlayed, "PART_ElemLastPlayed", nameof(GameDetailsViewModel.LastPlayedVisibility));
+            SetElemVisibility(ref ElemLastPlayed, "PART_ElemRecentActivity", nameof(GameDetailsViewModel.RecentActivityVisibility));
             SetElemVisibility(ref ElemCompletionStatus, "PART_ElemCompletionStatus", nameof(GameDetailsViewModel.CompletionStatusVisibility));
             SetElemVisibility(ref ElemLibrary, "PART_ElemLibrary", nameof(GameDetailsViewModel.SourceLibraryVisibility));
             SetElemVisibility(ref ElemPlatform, "PART_ElemPlatform", nameof(GameDetailsViewModel.PlatformVisibility));
@@ -402,6 +405,12 @@ namespace Playnite.DesktopApp.Controls.Views
                 nameof(GameDetailsViewModel.Game.LastActivity),
                 nameof(GameDetailsViewModel.LastPlayedVisibility),
                 new DateTimeToLastPlayedConverter());
+
+            SetGameItemTextBinding(ref TextLastActivity, "PART_TextRecentActivity",
+                nameof(GameDetailsViewModel.Game.RecentActivity),
+                nameof(GameDetailsViewModel.RecentActivityVisibility),
+                new NullableDateToStringConverter(),
+                mainModel.AppSettings.DateTimeFormatRecentActivity);
 
             SetGameItemButtonBinding(ref ButtonCompletionStatus, "PART_ButtonCompletionStatus",
                 nameof(GameDetailsViewModel.SetCompletionStatusFilterCommand),
@@ -553,7 +562,7 @@ namespace Playnite.DesktopApp.Controls.Views
             }
         }
 
-        private void SetGameItemTextBinding(ref TextBlock text, string partId, string textContent, string visibility, IValueConverter converter = null)
+        private void SetGameItemTextBinding(ref TextBlock text, string partId, string textContent, string visibility, IValueConverter converter = null, object converterParameter = null)
         {
             text = Template.FindName(partId, this) as TextBlock;
             if (text != null)
@@ -561,7 +570,8 @@ namespace Playnite.DesktopApp.Controls.Views
                 BindingTools.SetBinding(text,
                     TextBlock.TextProperty,
                     GetGameBindingPath(textContent),
-                    converter: converter);
+                    converter: converter,
+                    converterParameter: converterParameter);
                 BindingTools.SetBinding(text,
                     TextBlock.VisibilityProperty,
                     visibility);

--- a/source/Playnite.DesktopApp/Controls/Views/GameOverview.cs
+++ b/source/Playnite.DesktopApp/Controls/Views/GameOverview.cs
@@ -372,12 +372,14 @@ namespace Playnite.DesktopApp.Controls.Views
                 GetGameBindingPath(nameof(GamesCollectionViewEntry.PluginId)),
                 GetGameBindingPath($"{nameof(GamesCollectionViewEntry.LibraryPlugin)}.{nameof(GamesCollectionViewEntry.LibraryPlugin.Name)}"),
                 nameof(GameDetailsViewModel.SourceLibraryVisibility));
-
+            
             SetGameItemButtonBinding(ref ButtonReleaseDate, "PART_ButtonReleaseDate",
                 nameof(GameDetailsViewModel.SetReleaseDateFilterCommand),
                 GetGameBindingPath(nameof(GamesCollectionViewEntry.ReleaseDate)),
                 GetGameBindingPath(nameof(GamesCollectionViewEntry.ReleaseDate)),
-                nameof(GameDetailsViewModel.ReleaseDateVisibility));
+                nameof(GameDetailsViewModel.ReleaseDateVisibility),
+                new ReleaseDateToStringConverter(),
+                mainModel.AppSettings.DateTimeFormatReleaseDate);
 
             SetGameItemButtonBinding(ref ButtonVersion, "PART_ButtonVersion",
                 nameof(GameDetailsViewModel.SetVersionFilterCommand),
@@ -566,7 +568,7 @@ namespace Playnite.DesktopApp.Controls.Views
             }
         }
 
-        private void SetGameItemButtonBinding(ref Button button, string partId, string command, string commandParameter, string content, string visibility, IValueConverter contentConverter = null)
+        private void SetGameItemButtonBinding(ref Button button, string partId, string command, string commandParameter, string content, string visibility, IValueConverter contentConverter = null, object contentConverterParameter = null)
         {
             button = Template.FindName(partId, this) as Button;
             if (button != null)
@@ -580,7 +582,8 @@ namespace Playnite.DesktopApp.Controls.Views
                 BindingTools.SetBinding(button,
                     Button.ContentProperty,
                     content,
-                    converter: contentConverter);
+                    converter: contentConverter,
+                    converterParameter: contentConverterParameter);
                 BindingTools.SetBinding(button,
                     Button.VisibilityProperty,
                     visibility);

--- a/source/Playnite.DesktopApp/Controls/Views/GameOverview.cs
+++ b/source/Playnite.DesktopApp/Controls/Views/GameOverview.cs
@@ -404,7 +404,8 @@ namespace Playnite.DesktopApp.Controls.Views
             SetGameItemTextBinding(ref TextLastActivity, "PART_TextLastActivity",
                 nameof(GameDetailsViewModel.Game.LastActivity),
                 nameof(GameDetailsViewModel.LastPlayedVisibility),
-                new DateTimeToLastPlayedConverter());
+                new DateTimeToLastPlayedConverter(),
+                mainModel.AppSettings.DateTimeFormatLastPlayed);
 
             SetGameItemTextBinding(ref TextLastActivity, "PART_TextRecentActivity",
                 nameof(GameDetailsViewModel.Game.RecentActivity),

--- a/source/Playnite.DesktopApp/GlobalResources.xaml
+++ b/source/Playnite.DesktopApp/GlobalResources.xaml
@@ -37,7 +37,6 @@
     <pcon:NegateConverter x:Key="NegateConverter" />
     <pcon:NotificationIconConverter x:Key="NotificationIconConverter" />
     <pcon:NullableDateToStringConverter x:Key="NullableDateToStringConverter" />
-    <pcon:NullableDateToSortableStringConverter x:Key="NullableDateToSortableStringConverter" />
     <pcon:NullToBoolConverter x:Key="NullToBoolConverter" />
     <pcon:NullToDependencyPropertyUnsetConverter x:Key="NullToDependencyPropertyUnsetConverter" />
     <pcon:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />

--- a/source/Playnite.DesktopApp/GlobalResources.xaml
+++ b/source/Playnite.DesktopApp/GlobalResources.xaml
@@ -37,12 +37,12 @@
     <pcon:NegateConverter x:Key="NegateConverter" />
     <pcon:NotificationIconConverter x:Key="NotificationIconConverter" />
     <pcon:NullableDateToStringConverter x:Key="NullableDateToStringConverter" />
-    <pcon:MultiNullableDateToCustomFormatStringConverter x:Key="MultiNullableDateToCustomFormatStringConverter" />
     <pcon:NullToBoolConverter x:Key="NullToBoolConverter" />
     <pcon:NullToDependencyPropertyUnsetConverter x:Key="NullToDependencyPropertyUnsetConverter" />
     <pcon:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
     <pcon:ObjectToStringConverter x:Key="ObjectToStringConverter" />
     <pcon:OpacityBoolConverter x:Key="OpacityBoolConverter" />
+    <pcon:ReleaseDateToStringConverter x:Key="ReleaseDateToStringConverter" />
     <pcon:SortingOrderToStringConverter x:Key="SortingOrderToStringConverter" />
     <pcon:StrechToStringConverter x:Key="StrechToStringConverter" />
     <pcon:StringNullOrEmptyToBoolConverter x:Key="StringNullOrEmptyToBoolConverter" />

--- a/source/Playnite.DesktopApp/GlobalResources.xaml
+++ b/source/Playnite.DesktopApp/GlobalResources.xaml
@@ -37,6 +37,7 @@
     <pcon:NegateConverter x:Key="NegateConverter" />
     <pcon:NotificationIconConverter x:Key="NotificationIconConverter" />
     <pcon:NullableDateToStringConverter x:Key="NullableDateToStringConverter" />
+    <pcon:MultiNullableDateToCustomFormatStringConverter x:Key="MultiNullableDateToCustomFormatStringConverter" />
     <pcon:NullToBoolConverter x:Key="NullToBoolConverter" />
     <pcon:NullToDependencyPropertyUnsetConverter x:Key="NullToDependencyPropertyUnsetConverter" />
     <pcon:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />

--- a/source/Playnite.DesktopApp/GlobalResources.xaml
+++ b/source/Playnite.DesktopApp/GlobalResources.xaml
@@ -37,6 +37,7 @@
     <pcon:NegateConverter x:Key="NegateConverter" />
     <pcon:NotificationIconConverter x:Key="NotificationIconConverter" />
     <pcon:NullableDateToStringConverter x:Key="NullableDateToStringConverter" />
+    <pcon:NullableDateToSortableStringConverter x:Key="NullableDateToSortableStringConverter" />
     <pcon:NullToBoolConverter x:Key="NullToBoolConverter" />
     <pcon:NullToDependencyPropertyUnsetConverter x:Key="NullToDependencyPropertyUnsetConverter" />
     <pcon:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />

--- a/source/Playnite.DesktopApp/Themes/Desktop/Default/Views/DetailsViewGameOverview.xaml
+++ b/source/Playnite.DesktopApp/Themes/Desktop/Default/Views/DetailsViewGameOverview.xaml
@@ -118,6 +118,9 @@
                                             <Label Name="PART_ElemLastPlayed" Content="{DynamicResource LOCLastPlayed}" />
                                             <TextBlock Name="PART_TextLastActivity" VerticalAlignment="Center" />
 
+                                            <Label Name="PART_ElemRecentActivity" Content="{DynamicResource LOCRecentActivityLabel}" />
+                                            <TextBlock Name="PART_TextRecentActivity" VerticalAlignment="Center" />
+                                            
                                             <Label Name="PART_ElemCompletionStatus" Content="{DynamicResource LOCCompletionStatus}" />
                                             <Button Name="PART_ButtonCompletionStatus" VerticalAlignment="Center" />
 

--- a/source/Playnite.DesktopApp/ViewModels/GameDetailsViewModel.cs
+++ b/source/Playnite.DesktopApp/ViewModels/GameDetailsViewModel.cs
@@ -133,6 +133,11 @@ namespace Playnite.DesktopApp.ViewModels
             get => (settings.DetailsVisibility.LastPlayed) ? Visibility.Visible : Visibility.Collapsed;
         }
 
+        public Visibility RecentActivityVisibility
+        {
+            get => (settings.DetailsVisibility.RecentActivity && (game.LastActivity != null || game.Added != null)) ? Visibility.Visible : Visibility.Collapsed;
+        }
+
         public Visibility CompletionStatusVisibility
         {
             get => (settings.DetailsVisibility.CompletionStatus && game.CompletionStatus.Id != Guid.Empty) ? Visibility.Visible : Visibility.Collapsed;

--- a/source/Playnite.DesktopApp/ViewModels/SettingsViewModel.cs
+++ b/source/Playnite.DesktopApp/ViewModels/SettingsViewModel.cs
@@ -317,6 +317,14 @@ namespace Playnite.DesktopApp.ViewModels
             });
         }
 
+        public RelayCommand ResetDefaultCustomDateTimeFormatCommand
+        {
+            get => new RelayCommand(() =>
+            {
+                settings.CustomDateTimeFormat = "d";
+            });
+        }
+
         #endregion Commands
 
         public SettingsViewModel(

--- a/source/Playnite.DesktopApp/ViewModels/SettingsViewModel.cs
+++ b/source/Playnite.DesktopApp/ViewModels/SettingsViewModel.cs
@@ -349,6 +349,14 @@ namespace Playnite.DesktopApp.ViewModels
             });
         }
 
+        public RelayCommand ResetDateTimeFormatLastPlayedCommand
+        {
+            get => new RelayCommand(() =>
+            {
+                settings.DateTimeFormatLastPlayed = null;
+            });
+        }
+
         #endregion Commands
 
         public SettingsViewModel(
@@ -368,7 +376,30 @@ namespace Playnite.DesktopApp.ViewModels
             originalSettings = settings;
 
             Settings = settings.GetClone();
-            Settings.PropertyChanged += (s, e) => editedFields.AddMissing(e.PropertyName);
+            Settings.PropertyChanged += (s, e) =>
+            {
+                editedFields.AddMissing(e.PropertyName);
+                switch (e.PropertyName)
+                {
+                    case nameof(settings.DateTimeFormatAdded):
+
+                        break;
+                    case nameof(settings.DateTimeFormatLastPlayed):
+
+                        break;
+                    case nameof(settings.DateTimeFormatModified):
+
+                        break;
+                    case nameof(settings.DateTimeFormatRecentActivity):
+
+                        break;
+                    case nameof(settings.DateTimeFormatReleaseDate):
+
+                        break;
+                    default:
+                        break;
+                }
+            };
 
             AvailableTrayIcons = new List<SelectableTrayIcon>
             {

--- a/source/Playnite.DesktopApp/ViewModels/SettingsViewModel.cs
+++ b/source/Playnite.DesktopApp/ViewModels/SettingsViewModel.cs
@@ -317,11 +317,35 @@ namespace Playnite.DesktopApp.ViewModels
             });
         }
 
-        public RelayCommand ResetDefaultCustomDateTimeFormatCommand
+        public RelayCommand ResetDateTimeFormatAddedCommand
         {
             get => new RelayCommand(() =>
             {
-                settings.CustomDateTimeFormat = Constants.DefaultListViewDateTimeFormat;
+                settings.DateTimeFormatAdded = Constants.DefaultDateTimeFormat;
+            });
+        }
+
+        public RelayCommand ResetDateTimeFormatModifiedCommand
+        {
+            get => new RelayCommand(() =>
+            {
+                settings.DateTimeFormatModified = Constants.DefaultDateTimeFormat;
+            });
+        }
+
+        public RelayCommand ResetDateTimeFormatRecentActivityCommand
+        {
+            get => new RelayCommand(() =>
+            {
+                settings.DateTimeFormatRecentActivity = Constants.DefaultDateTimeFormat;
+            });
+        }
+
+        public RelayCommand ResetDateTimeFormatReleaseDateCommand
+        {
+            get => new RelayCommand(() =>
+            {
+                settings.DateTimeFormatReleaseDate = Constants.DefaultDateTimeFormat;
             });
         }
 

--- a/source/Playnite.DesktopApp/ViewModels/SettingsViewModel.cs
+++ b/source/Playnite.DesktopApp/ViewModels/SettingsViewModel.cs
@@ -321,7 +321,7 @@ namespace Playnite.DesktopApp.ViewModels
         {
             get => new RelayCommand(() =>
             {
-                settings.CustomDateTimeFormat = "d";
+                settings.CustomDateTimeFormat = Constants.DefaultListViewDateTimeFormat;
             });
         }
 

--- a/source/Playnite.FullscreenApp/GlobalResources.xaml
+++ b/source/Playnite.FullscreenApp/GlobalResources.xaml
@@ -42,6 +42,7 @@
     <pcon:NegateConverter x:Key="NegateConverter" />
     <pcon:NotificationIconConverter x:Key="NotificationIconConverter" />
     <pcon:NullableDateToStringConverter x:Key="NullableDateToStringConverter" />
+    <pcon:MultiNullableDateToCustomFormatStringConverter x:Key="MultiNullableDateToCustomFormatStringConverter" />
     <pcon:NullToBoolConverter x:Key="NullToBoolConverter" />
     <pcon:NullToDependencyPropertyUnsetConverter x:Key="NullToDependencyPropertyUnsetConverter" />
     <pcon:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />

--- a/source/Playnite.FullscreenApp/GlobalResources.xaml
+++ b/source/Playnite.FullscreenApp/GlobalResources.xaml
@@ -42,12 +42,12 @@
     <pcon:NegateConverter x:Key="NegateConverter" />
     <pcon:NotificationIconConverter x:Key="NotificationIconConverter" />
     <pcon:NullableDateToStringConverter x:Key="NullableDateToStringConverter" />
-    <pcon:MultiNullableDateToCustomFormatStringConverter x:Key="MultiNullableDateToCustomFormatStringConverter" />
     <pcon:NullToBoolConverter x:Key="NullToBoolConverter" />
     <pcon:NullToDependencyPropertyUnsetConverter x:Key="NullToDependencyPropertyUnsetConverter" />
     <pcon:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
     <pcon:ObjectToStringConverter x:Key="ObjectToStringConverter" />
     <pcon:OpacityBoolConverter x:Key="OpacityBoolConverter" />
+    <pcon:ReleaseDateToStringConverter x:Key="ReleaseDateToStringConverter" />
     <pcon:SortingOrderToStringConverter x:Key="SortingOrderToStringConverter" />
     <pcon:StrechToStringConverter x:Key="StrechToStringConverter" />
     <pcon:StringNullOrEmptyToBoolConverter x:Key="StringNullOrEmptyToBoolConverter" />

--- a/source/Playnite.FullscreenApp/GlobalResources.xaml
+++ b/source/Playnite.FullscreenApp/GlobalResources.xaml
@@ -42,6 +42,7 @@
     <pcon:NegateConverter x:Key="NegateConverter" />
     <pcon:NotificationIconConverter x:Key="NotificationIconConverter" />
     <pcon:NullableDateToStringConverter x:Key="NullableDateToStringConverter" />
+    <pcon:NullableDateToSortableStringConverter x:Key="NullableDateToSortableStringConverter" />
     <pcon:NullToBoolConverter x:Key="NullToBoolConverter" />
     <pcon:NullToDependencyPropertyUnsetConverter x:Key="NullToDependencyPropertyUnsetConverter" />
     <pcon:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />

--- a/source/Playnite.FullscreenApp/GlobalResources.xaml
+++ b/source/Playnite.FullscreenApp/GlobalResources.xaml
@@ -42,7 +42,6 @@
     <pcon:NegateConverter x:Key="NegateConverter" />
     <pcon:NotificationIconConverter x:Key="NotificationIconConverter" />
     <pcon:NullableDateToStringConverter x:Key="NullableDateToStringConverter" />
-    <pcon:NullableDateToSortableStringConverter x:Key="NullableDateToSortableStringConverter" />
     <pcon:NullToBoolConverter x:Key="NullToBoolConverter" />
     <pcon:NullToDependencyPropertyUnsetConverter x:Key="NullToDependencyPropertyUnsetConverter" />
     <pcon:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />

--- a/source/Playnite/Common/Constants.cs
+++ b/source/Playnite/Common/Constants.cs
@@ -9,7 +9,7 @@ namespace Playnite.Common
 {
     public static class Constants
     {
-        public const string DefaultListViewDateTimeFormat = "d";
+        public const string DefaultDateTimeFormat = "d";
         public static string DateUiFormat
         {
             get;

--- a/source/Playnite/Common/Constants.cs
+++ b/source/Playnite/Common/Constants.cs
@@ -9,6 +9,7 @@ namespace Playnite.Common
 {
     public static class Constants
     {
+        public const string DefaultListViewDateTimeFormat = "d";
         public static string DateUiFormat
         {
             get;

--- a/source/Playnite/Common/Constants.cs
+++ b/source/Playnite/Common/Constants.cs
@@ -14,6 +14,11 @@ namespace Playnite.Common
             get;
         } = CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern;
 
+        public static string SortableDateUiFormat
+        {
+            get;
+        } = "yyyy'-'MM'-'dd HH':'mm':'ss";
+
         public static string TimeUiFormat
         {
             get;

--- a/source/Playnite/Common/Constants.cs
+++ b/source/Playnite/Common/Constants.cs
@@ -14,11 +14,6 @@ namespace Playnite.Common
             get;
         } = CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern;
 
-        public static string SortableDateUiFormat
-        {
-            get;
-        } = "yyyy'-'MM'-'dd HH':'mm':'ss";
-
         public static string TimeUiFormat
         {
             get;

--- a/source/Playnite/Converters/DateTimeToLastPlayedConverter.cs
+++ b/source/Playnite/Converters/DateTimeToLastPlayedConverter.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Markup;
 
@@ -19,7 +20,8 @@ namespace Playnite.Converters
             {
                 return ResourceProvider.GetString("LOCNever");
             }
-            else
+
+            if (parameter == null)
             {
                 if (lastPlayed.Value.Date == DateTime.Today)
                 {
@@ -59,6 +61,14 @@ namespace Playnite.Converters
                 {
                     return lastPlayed.Value.ToString(Common.Constants.DateUiFormat);
                 }
+            }
+            else if (parameter is string dateFormat)
+            {
+                return ((DateTime)lastPlayed).ToString(dateFormat);
+            }
+            else
+            {
+                return lastPlayed.Value.ToString(Common.Constants.DateUiFormat);
             }
         }
 

--- a/source/Playnite/Converters/NullableDateToStringConverter.cs
+++ b/source/Playnite/Converters/NullableDateToStringConverter.cs
@@ -101,4 +101,70 @@ namespace Playnite.Converters
             return new ValidationResult(true, null);
         }
     }
+
+    public class MultiNullableDateToCustomFormatStringConverter : MarkupExtension, IMultiValueConverter
+    {
+        public object Convert(object[] values, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            if (values.Count() != 2)
+            {
+                return string.Empty;
+            }
+
+            if (values[0] == null || values[1] == null)
+            {
+                return string.Empty;
+            }
+
+            if (values[0] == DependencyProperty.UnsetValue || values[1] == DependencyProperty.UnsetValue)
+            {
+                return string.Empty;
+            }
+
+            var date = ((DateTime?)values[0]).Value;
+            if (values[1] is string format)
+            {
+                return date.ToString(format);
+            }
+            else
+            {
+                return string.Empty;
+            }
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, System.Globalization.CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            return this;
+        }
+    }
+
+    public class DateTimeFormatToStringValidation : ValidationRule
+    {
+        private const string InvalidFormatInput = "Format does not contain a valid custom format pattern!";
+        private const string InvalidArgumentRangeInput = "The date and time is outside the range of dates supported!";
+        private static DateTime TestDate = DateTime.Now;
+
+        public override ValidationResult Validate(object value, System.Globalization.CultureInfo cultureInfo)
+        {
+            var str = (string)value;
+            try
+            {
+                TestDate.ToString(str);
+                return new ValidationResult(true, null);
+            }
+            catch (FormatException)
+            {
+                return new ValidationResult(false, InvalidFormatInput);
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                return new ValidationResult(false, InvalidArgumentRangeInput);
+            }
+        }
+    }
 }

--- a/source/Playnite/Converters/NullableDateToStringConverter.cs
+++ b/source/Playnite/Converters/NullableDateToStringConverter.cs
@@ -56,47 +56,6 @@ namespace Playnite.Converters
         }
     }
 
-    public class MultiNullableDateToCustomFormatStringConverter : MarkupExtension, IMultiValueConverter
-    {
-        public object Convert(object[] values, Type targetType, object parameter, System.Globalization.CultureInfo culture)
-        {
-            if (values.Count() != 2)
-            {
-                return string.Empty;
-            }
-
-            if (values[0] == null || values[1] == null)
-            {
-                return string.Empty;
-            }
-
-            if (values[0] == DependencyProperty.UnsetValue || values[1] == DependencyProperty.UnsetValue)
-            {
-                return string.Empty;
-            }
-
-            var date = ((DateTime?)values[0]).Value;
-            if (values[1] is string format)
-            {
-                return date.ToString(format);
-            }
-            else
-            {
-                return string.Empty;
-            }
-        }
-
-        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, System.Globalization.CultureInfo culture)
-        {
-            throw new NotImplementedException();
-        }
-
-        public override object ProvideValue(IServiceProvider serviceProvider)
-        {
-            return this;
-        }
-    }
-
     public class ReleaseDateToStringConverter : MarkupExtension, IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)

--- a/source/Playnite/Converters/NullableDateToStringConverter.cs
+++ b/source/Playnite/Converters/NullableDateToStringConverter.cs
@@ -105,7 +105,7 @@ namespace Playnite.Converters
             {
                 if (parameter != null && date.Month != null && date.Day != null)
                 {
-                    return DateTime.ParseExact($"{date.Month}/{date.Day}/{date.Year}" ,"d", CultureInfo.InvariantCulture).ToString((string)parameter);
+                    return date.Date.ToString((string)parameter);
                 }
                 else
                 {

--- a/source/Playnite/Converters/NullableDateToStringConverter.cs
+++ b/source/Playnite/Converters/NullableDateToStringConverter.cs
@@ -49,43 +49,6 @@ namespace Playnite.Converters
         }
     }
 
-    public class NullableDateToSortableStringConverter : MarkupExtension, IValueConverter
-    {
-        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
-        {
-            if (value == null)
-            {
-                return string.Empty;
-            }
-
-            var date = ((DateTime?)value).Value;
-            return date.ToString(Common.Constants.SortableDateUiFormat);
-        }
-
-        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
-        {
-            if (string.IsNullOrEmpty(value as string))
-            {
-                return null;
-            }
-
-            var sucess = DateTime.TryParseExact(value as string, Common.Constants.SortableDateUiFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out var newDate);
-            if (sucess)
-            {
-                return newDate;
-            }
-            else
-            {
-                return DependencyProperty.UnsetValue;
-            }
-        }
-
-        public override object ProvideValue(IServiceProvider serviceProvider)
-        {
-            return this;
-        }
-    }
-
     public class ReleaseDateToStringConverter : MarkupExtension, IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)

--- a/source/Playnite/Converters/NullableDateToStringConverter.cs
+++ b/source/Playnite/Converters/NullableDateToStringConverter.cs
@@ -22,7 +22,14 @@ namespace Playnite.Converters
             }
 
             var date = ((DateTime?)value).Value;
-            return date.ToString(Common.Constants.DateUiFormat);
+            if (parameter == null)
+            {
+                return date.ToString(Common.Constants.DateUiFormat);
+            }
+            else
+            {
+                return date.ToString((string)parameter);
+            }
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
@@ -49,13 +56,61 @@ namespace Playnite.Converters
         }
     }
 
+    public class MultiNullableDateToCustomFormatStringConverter : MarkupExtension, IMultiValueConverter
+    {
+        public object Convert(object[] values, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            if (values.Count() != 2)
+            {
+                return string.Empty;
+            }
+
+            if (values[0] == null || values[1] == null)
+            {
+                return string.Empty;
+            }
+
+            if (values[0] == DependencyProperty.UnsetValue || values[1] == DependencyProperty.UnsetValue)
+            {
+                return string.Empty;
+            }
+
+            var date = ((DateTime?)values[0]).Value;
+            if (values[1] is string format)
+            {
+                return date.ToString(format);
+            }
+            else
+            {
+                return string.Empty;
+            }
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, System.Globalization.CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            return this;
+        }
+    }
+
     public class ReleaseDateToStringConverter : MarkupExtension, IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
             if (value is ReleaseDate date)
             {
-                return date.Serialize();
+                if (parameter != null && date.Month != null && date.Day != null)
+                {
+                    return DateTime.ParseExact($"{date.Month}/{date.Day}/{date.Year}" ,"d", CultureInfo.InvariantCulture).ToString((string)parameter);
+                }
+                else
+                {
+                    return date.Serialize();
+                }
             }
             else if (value == null)
             {
@@ -99,47 +154,6 @@ namespace Playnite.Converters
             }
 
             return new ValidationResult(true, null);
-        }
-    }
-
-    public class MultiNullableDateToCustomFormatStringConverter : MarkupExtension, IMultiValueConverter
-    {
-        public object Convert(object[] values, Type targetType, object parameter, System.Globalization.CultureInfo culture)
-        {
-            if (values.Count() != 2)
-            {
-                return string.Empty;
-            }
-
-            if (values[0] == null || values[1] == null)
-            {
-                return string.Empty;
-            }
-
-            if (values[0] == DependencyProperty.UnsetValue || values[1] == DependencyProperty.UnsetValue)
-            {
-                return string.Empty;
-            }
-
-            var date = ((DateTime?)values[0]).Value;
-            if (values[1] is string format)
-            {
-                return date.ToString(format);
-            }
-            else
-            {
-                return string.Empty;
-            }
-        }
-
-        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, System.Globalization.CultureInfo culture)
-        {
-            throw new NotImplementedException();
-        }
-
-        public override object ProvideValue(IServiceProvider serviceProvider)
-        {
-            return this;
         }
     }
 

--- a/source/Playnite/Converters/NullableDateToStringConverter.cs
+++ b/source/Playnite/Converters/NullableDateToStringConverter.cs
@@ -49,6 +49,43 @@ namespace Playnite.Converters
         }
     }
 
+    public class NullableDateToSortableStringConverter : MarkupExtension, IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            if (value == null)
+            {
+                return string.Empty;
+            }
+
+            var date = ((DateTime?)value).Value;
+            return date.ToString(Common.Constants.SortableDateUiFormat);
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            if (string.IsNullOrEmpty(value as string))
+            {
+                return null;
+            }
+
+            var sucess = DateTime.TryParseExact(value as string, Common.Constants.SortableDateUiFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out var newDate);
+            if (sucess)
+            {
+                return newDate;
+            }
+            else
+            {
+                return DependencyProperty.UnsetValue;
+            }
+        }
+
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            return this;
+        }
+    }
+
     public class ReleaseDateToStringConverter : MarkupExtension, IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)

--- a/source/Playnite/GamesCollectionViewEntry.cs
+++ b/source/Playnite/GamesCollectionViewEntry.cs
@@ -80,6 +80,7 @@ namespace Playnite
         public PlaytimeCategory PlaytimeCategory => Game.PlaytimeCategory;
         public InstallationStatus InstallationState => Game.InstallationStatus;
         public char NameGroup => Game.GetNameGroup();
+        public DateTime? RecentActivity => Game.RecentActivity;
         public bool OverrideInstallState => Game.OverrideInstallState;
 
         public List<Guid> CategoryIds => Game.CategoryIds;

--- a/source/Playnite/GamesCollectionViewEntry.cs
+++ b/source/Playnite/GamesCollectionViewEntry.cs
@@ -26,6 +26,7 @@ namespace Playnite
         public static BitmapLoadProperties BackgroundImageProperties { get; private set; }
         public static BitmapLoadProperties FullscreenListCoverProperties { get; private set; }
 
+        public PlayniteSettings Settings => settings;
         public LibraryPlugin LibraryPlugin { get; }
         public Guid Id => Game.Id;
         public Guid PluginId => Game.PluginId;

--- a/source/Playnite/GamesCollectionViewEntry.cs
+++ b/source/Playnite/GamesCollectionViewEntry.cs
@@ -26,7 +26,6 @@ namespace Playnite
         public static BitmapLoadProperties BackgroundImageProperties { get; private set; }
         public static BitmapLoadProperties FullscreenListCoverProperties { get; private set; }
 
-        public PlayniteSettings Settings => settings;
         public LibraryPlugin LibraryPlugin { get; }
         public Guid Id => Game.Id;
         public Guid PluginId => Game.PluginId;

--- a/source/Playnite/Localization/LocSource.xaml
+++ b/source/Playnite/Localization/LocSource.xaml
@@ -544,6 +544,7 @@ If disabled, games that use any item in any filter will be included in the view.
     <sys:String x:Key="LOCRegionsLabel">Regions</sys:String>
     <sys:String x:Key="LOCSourceLabel">Source</sys:String>
     <sys:String x:Key="LOCSourcesLabel">Sources</sys:String>
+    <sys:String x:Key="LOCRecentActivityLabel">Recent Activity</sys:String>
     <!--Errors-->
     <sys:String x:Key="LOCDatabaseErroTitle">Database Error</sys:String>
     <sys:String x:Key="LOCDatabaseOpenError">Failed to open library database.</sys:String>

--- a/source/Playnite/Localization/LocSource.xaml
+++ b/source/Playnite/Localization/LocSource.xaml
@@ -329,7 +329,7 @@ Selecting "add to exclusion list" option will prevent games from being imported 
     <sys:String x:Key="LOCSettingsCloseToTray">Minimize Playnite to system tray when the application window is closed</sys:String>
     <sys:String x:Key="LOCSettingsAfterGameStart">When game starts:</sys:String>
     <sys:String x:Key="LOCSettingsAfterGameClose">After game closes:</sys:String>
-    <sys:String x:Key="LOCSettingsCustomDateTimeFormat">Dates format</sys:String>
+    <sys:String x:Key="LOCSettingsDatesFormatsLabel">Dates formats:</sys:String>
     <sys:String x:Key="LOCSettingsClearCacheWarn">This will log you out of all linked services. Application restart is required, do you want to proceed?</sys:String>
     <sys:String x:Key="LOCSettingsClearCacheTitle">Clear Cache?</sys:String>
     <sys:String x:Key="LOCSettingsSkinChangeRestart">Playnite restart is required to apply new theme</sys:String>

--- a/source/Playnite/Localization/LocSource.xaml
+++ b/source/Playnite/Localization/LocSource.xaml
@@ -136,6 +136,7 @@ Selecting "add to exclusion list" option will prevent games from being imported 
     <sys:String x:Key="LOCCloseLabel">Close</sys:String>
     <sys:String x:Key="LOCCancelLabel">Cancel</sys:String>
     <sys:String x:Key="LOCConfirmLabel">Confirm</sys:String>
+    <sys:String x:Key="LOCResetLabel">Reset</sys:String>
     <sys:String x:Key="LOCYesLabel">Yes</sys:String>
     <sys:String x:Key="LOCNoLabel">No</sys:String>
     <sys:String x:Key="LOCWelcomeLabel">Welcome</sys:String>
@@ -328,6 +329,7 @@ Selecting "add to exclusion list" option will prevent games from being imported 
     <sys:String x:Key="LOCSettingsCloseToTray">Minimize Playnite to system tray when the application window is closed</sys:String>
     <sys:String x:Key="LOCSettingsAfterGameStart">When game starts:</sys:String>
     <sys:String x:Key="LOCSettingsAfterGameClose">After game closes:</sys:String>
+    <sys:String x:Key="LOCSettingsCustomDateTimeFormat">Dates format</sys:String>
     <sys:String x:Key="LOCSettingsClearCacheWarn">This will log you out of all linked services. Application restart is required, do you want to proceed?</sys:String>
     <sys:String x:Key="LOCSettingsClearCacheTitle">Clear Cache?</sys:String>
     <sys:String x:Key="LOCSettingsSkinChangeRestart">Playnite restart is required to apply new theme</sys:String>

--- a/source/Playnite/Settings/DetailsVisibilitySettings.cs
+++ b/source/Playnite/Settings/DetailsVisibilitySettings.cs
@@ -53,6 +53,21 @@ namespace Playnite
             }
         }
 
+        private bool recentActivity = true;
+        public bool RecentActivity
+        {
+            get
+            {
+                return recentActivity;
+            }
+
+            set
+            {
+                recentActivity = value;
+                OnPropertyChanged();
+            }
+        }
+
         private bool completionStatus = false;
         public bool CompletionStatus
         {

--- a/source/Playnite/Settings/PlayniteSettings.cs
+++ b/source/Playnite/Settings/PlayniteSettings.cs
@@ -1907,6 +1907,17 @@ namespace Playnite
             }
         }
 
+        private string customDateTimeFormat = "d";
+        public string CustomDateTimeFormat
+        {
+            get => customDateTimeFormat;
+            set
+            {
+                customDateTimeFormat = value;
+                OnPropertyChanged();
+            }
+        }
+
         private UpdateCheckFrequency checkForProgramUpdates = UpdateCheckFrequency.OnEveryStartup;
         public UpdateCheckFrequency CheckForProgramUpdates
         {

--- a/source/Playnite/Settings/PlayniteSettings.cs
+++ b/source/Playnite/Settings/PlayniteSettings.cs
@@ -1955,6 +1955,18 @@ namespace Playnite
             }
         }
 
+        private string dateTimeFormatLastPlayed = null;
+        [RequiresRestart]
+        public string DateTimeFormatLastPlayed
+        {
+            get => dateTimeFormatLastPlayed;
+            set
+            {
+                dateTimeFormatLastPlayed = value;
+                OnPropertyChanged();
+            }
+        }
+
         private UpdateCheckFrequency checkForProgramUpdates = UpdateCheckFrequency.OnEveryStartup;
         public UpdateCheckFrequency CheckForProgramUpdates
         {

--- a/source/Playnite/Settings/PlayniteSettings.cs
+++ b/source/Playnite/Settings/PlayniteSettings.cs
@@ -1907,13 +1907,50 @@ namespace Playnite
             }
         }
 
-        private string customDateTimeFormat = Constants.DefaultListViewDateTimeFormat;
-        public string CustomDateTimeFormat
+        private string dateTimeFormatAdded = Constants.DefaultDateTimeFormat;
+        [RequiresRestart]
+        public string DateTimeFormatAdded
         {
-            get => customDateTimeFormat;
+            get => dateTimeFormatAdded;
             set
             {
-                customDateTimeFormat = value;
+                dateTimeFormatAdded = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private string dateTimeFormatModified = Constants.DefaultDateTimeFormat;
+        [RequiresRestart]
+        public string DateTimeFormatModified
+        {
+            get => dateTimeFormatModified;
+            set
+            {
+                dateTimeFormatModified = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private string dateTimeFormatRecentActivity = Constants.DefaultDateTimeFormat;
+        [RequiresRestart]
+        public string DateTimeFormatRecentActivity
+        {
+            get => dateTimeFormatRecentActivity;
+            set
+            {
+                dateTimeFormatRecentActivity = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private string dateTimeFormatReleaseDate = Constants.DefaultDateTimeFormat;
+        [RequiresRestart]
+        public string DateTimeFormatReleaseDate
+        {
+            get => dateTimeFormatReleaseDate;
+            set
+            {
+                dateTimeFormatReleaseDate = value;
                 OnPropertyChanged();
             }
         }

--- a/source/Playnite/Settings/PlayniteSettings.cs
+++ b/source/Playnite/Settings/PlayniteSettings.cs
@@ -1907,7 +1907,7 @@ namespace Playnite
             }
         }
 
-        private string customDateTimeFormat = "d";
+        private string customDateTimeFormat = Constants.DefaultListViewDateTimeFormat;
         public string CustomDateTimeFormat
         {
             get => customDateTimeFormat;

--- a/source/Playnite/Settings/ViewProperties.cs
+++ b/source/Playnite/Settings/ViewProperties.cs
@@ -186,6 +186,21 @@ namespace Playnite
             }
         }
 
+        private ListViewColumnProperty recentActivity = new ListViewColumnProperty(GameField.RecentActivity);
+        public ListViewColumnProperty RecentActivity
+        {
+            get
+            {
+                return recentActivity;
+            }
+
+            set
+            {
+                recentActivity = value;
+                OnPropertyChanged();
+            }
+        }
+
         private ListViewColumnProperty isInstalled = new ListViewColumnProperty(GameField.IsInstalled);
         public ListViewColumnProperty IsInstalled
         {

--- a/source/PlayniteSDK/Models/FilterPreset.cs
+++ b/source/PlayniteSDK/Models/FilterPreset.cs
@@ -37,7 +37,8 @@ namespace Playnite.SDK.Models
         [Description("LOCGameHiddenTitle")] Hidden = 24,
         [Description("LOCGameFavoriteTitle")] Favorite = 25,
         [Description("LOCGameInstallDirTitle")] InstallDirectory = 26,
-        [Description("LOCFeatureLabel")] Features = 27
+        [Description("LOCFeatureLabel")] Features = 27,
+        [Description("LOCRecentActivityLabel")] RecentActivity = 28
     }
 
     public enum SortOrderDirection : int

--- a/source/PlayniteSDK/Models/Game.cs
+++ b/source/PlayniteSDK/Models/Game.cs
@@ -171,7 +171,9 @@ namespace Playnite.SDK.Models
         ///
         CompletionStatusId = 87,
         ///
-        OverrideInstallState = 88
+        OverrideInstallState = 88,
+        ///
+        RecentActivity = 89
     }
 
     /// <summary>
@@ -360,6 +362,7 @@ namespace Playnite.SDK.Models
                 lastActivity = value;
                 OnPropertyChanged();
                 OnPropertyChanged(nameof(LastActivitySegment));
+                OnPropertyChanged(nameof(RecentActivity));
             }
         }
 
@@ -742,6 +745,7 @@ namespace Playnite.SDK.Models
                 added = value;
                 OnPropertyChanged();
                 OnPropertyChanged(nameof(AddedSegment));
+                OnPropertyChanged(nameof(RecentActivity));
             }
         }
 
@@ -1264,6 +1268,15 @@ namespace Playnite.SDK.Models
         }
 
         /// <summary>
+        /// Gets the most recent date between the last played and added dates.
+        /// </summary>
+        [DontSerialize]
+        public DateTime? RecentActivity
+        {
+            get => GetGameRecentActivity();
+        }
+
+        /// <summary>
         /// Gets game's user score rating.
         /// </summary>
         [DontSerialize]
@@ -1372,6 +1385,26 @@ namespace Playnite.SDK.Models
         }
 
         #endregion Expanded
+
+        /// <summary>
+        /// Gets the most recent date between the last played and added dates.
+        /// </summary>
+        /// <returns></returns>
+        public DateTime? GetGameRecentActivity()
+        {
+            if (lastActivity == null)
+            {
+                return added;
+            }
+            else if (added == null || lastActivity > added)
+            {
+                return lastActivity;
+            }
+            else
+            {
+                return added;
+            }
+        }
 
         /// <summary>
         /// Gets play time category.

--- a/source/PlayniteSDK/Models/ReleaseDate.cs
+++ b/source/PlayniteSDK/Models/ReleaseDate.cs
@@ -15,7 +15,10 @@ namespace Playnite.SDK.Models
     public struct ReleaseDate : IComparable, IComparable<ReleaseDate>, IEquatable<ReleaseDate>, ISerializable
     {
         private static readonly char[] serSplitter = new char[] { '-' };
-        private readonly DateTime date;
+        /// <summary>
+        /// Gets DateTime representation of release date.
+        /// </summary>
+        public readonly DateTime Date;
 
         /// <summary>
         /// Gets empty representation of release date.
@@ -45,14 +48,14 @@ namespace Playnite.SDK.Models
                 Year = default(int);
                 Month = default(int?);
                 Day = default(int?);
-                date = default(DateTime);
+                Date = default(DateTime);
             }
             else
             {
                 Year = year;
                 Day = null;
                 Month = null;
-                date = new DateTime(year, 1, 1);
+                Date = new DateTime(year, 1, 1);
             }
         }
 
@@ -66,7 +69,7 @@ namespace Playnite.SDK.Models
             Year = year;
             Month = month;
             Day = null;
-            date = new DateTime(year, month, 1);
+            Date = new DateTime(year, month, 1);
         }
 
         /// <summary>
@@ -80,7 +83,7 @@ namespace Playnite.SDK.Models
             Year = year;
             Month = month;
             Day = day;
-            date = new DateTime(year, month, day);
+            Date = new DateTime(year, month, day);
         }
 
         /// <summary>
@@ -104,11 +107,11 @@ namespace Playnite.SDK.Models
             Day = serDate.Day;
             if (Year == default(int))
             {
-                date = default(DateTime);
+                Date = default(DateTime);
             }
             else
             {
-                date = new DateTime(Year, Month ?? 1, Day ?? 1);
+                Date = new DateTime(Year, Month ?? 1, Day ?? 1);
             }
         }
 
@@ -128,7 +131,7 @@ namespace Playnite.SDK.Models
         /// <inheritdoc/>
         public int CompareTo(ReleaseDate other)
         {
-            return date.CompareTo(other.date);
+            return Date.CompareTo(other.Date);
         }
 
         /// <inheritdoc/>
@@ -272,11 +275,11 @@ namespace Playnite.SDK.Models
         {
             if (Day != null)
             {
-                return date.ToString(CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern);
+                return Date.ToString(CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern);
             }
             else if (Month != null)
             {
-                return date.ToString(CultureInfo.CurrentCulture.DateTimeFormat.YearMonthPattern);
+                return Date.ToString(CultureInfo.CurrentCulture.DateTimeFormat.YearMonthPattern);
             }
             else
             {


### PR DESCRIPTION
I have verified that:
- [x] These changes work, by building the application and testing them.
- [x] Pull request is targeting `devel` branch.
- [x] I added myself into [contributors file](https://github.com/JosefNemec/Playnite/blob/devel/source/Playnite.DesktopApp/Resources/contributors.txt) if I want to receive contribution credit in the application itself.

Implements:
- Adds support to sort by "RecentActivity". This value is determined by getting the newer date between the `LastActivity` and `Added` game values (Closes https://github.com/JosefNemec/Playnite/issues/1612)

- Adds support to show recent activity on game details view

- Adds support to use custom string formats for dates for `Added`, `Modified`, `RecentActivity` and `ReleaseDate` properties in views (Closes my disappointment in Crow)

Default format is `d`, which uses [Short date pattern](https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings#table-of-format-specifiers) that Playnite currently uses
### Screenshots

![image](https://user-images.githubusercontent.com/1389286/185770387-98a1a6ca-504e-4bd6-b8da-58d4a0247898.png)

![image](https://user-images.githubusercontent.com/1389286/185770391-46bf3603-a867-4e94-a031-a4a661361584.png)

![image](https://user-images.githubusercontent.com/1389286/185770399-737e76e7-8aec-42da-a7d5-b41a42972f6e.png)

### Demo

https://user-images.githubusercontent.com/1389286/185770619-826c73dc-26ee-40bc-b551-9549c9cb298f.mp4

