### PR TITLE
Add support to filter by InstallSize and RecentActivity. Group by RecentActivity

### DIFF
--- a/source/Playnite.DesktopApp/Controls/Views/FilterPanel.cs
+++ b/source/Playnite.DesktopApp/Controls/Views/FilterPanel.cs
@@ -197,6 +197,9 @@ namespace Playnite.DesktopApp.Controls.Views
             SetLabelTag(nameof(FilterSettings.LastActivity), LOC.GameLastActivityTitle);
             SetFilterEnumSelectionBoxFilter(nameof(FilterSettings.LastActivity), typeof(PastTimeSegment));
 
+            SetLabelTag(nameof(FilterSettings.RecentActivity), LOC.RecentActivityLabel);
+            SetFilterEnumSelectionBoxFilter(nameof(FilterSettings.RecentActivity), typeof(PastTimeSegment));
+
             SetLabelTag(nameof(FilterSettings.Added), LOC.DateAddedLabel);
             SetFilterEnumSelectionBoxFilter(nameof(FilterSettings.Added), typeof(PastTimeSegment));
 

--- a/source/Playnite.DesktopApp/Controls/Views/FilterPanel.cs
+++ b/source/Playnite.DesktopApp/Controls/Views/FilterPanel.cs
@@ -164,6 +164,9 @@ namespace Playnite.DesktopApp.Controls.Views
             SetLabelTag(nameof(FilterSettings.PlayTime), LOC.TimePlayed);
             SetFilterEnumSelectionBoxFilter(nameof(FilterSettings.PlayTime), typeof(PlaytimeCategory));
 
+            SetLabelTag(nameof(FilterSettings.InstallSize), LOC.InstallSizeLabel);
+            SetFilterEnumSelectionBoxFilter(nameof(FilterSettings.InstallSize), typeof(InstallSizeGroup));
+
             SetLabelTag(nameof(FilterSettings.CompletionStatuses), LOC.CompletionStatus);
             SetFilterSelectionBoxFilter(nameof(DatabaseFilter.CompletionStatuses), nameof(FilterSettings.CompletionStatuses));
 

--- a/source/Playnite.DesktopApp/DesktopCollectionView.cs
+++ b/source/Playnite.DesktopApp/DesktopCollectionView.cs
@@ -44,6 +44,7 @@ namespace Playnite.DesktopApp
             { GroupableField.CommunityScore, nameof(GamesCollectionViewEntry.CommunityScoreGroup) },
             { GroupableField.CriticScore, nameof(GamesCollectionViewEntry.CriticScoreGroup) },
             { GroupableField.LastActivity, nameof(GamesCollectionViewEntry.LastActivitySegment) },
+            { GroupableField.RecentActivity, nameof(GamesCollectionViewEntry.RecentActivitySegment) },
             { GroupableField.Added, nameof(GamesCollectionViewEntry.AddedSegment) },
             { GroupableField.Modified, nameof(GamesCollectionViewEntry.ModifiedSegment) },
             { GroupableField.PlayTime, nameof(GamesCollectionViewEntry.PlaytimeCategory) },
@@ -191,6 +192,7 @@ namespace Playnite.DesktopApp
                 case GroupableField.CriticScore:
                 case GroupableField.CommunityScore:
                 case GroupableField.LastActivity:
+                case GroupableField.RecentActivity:
                 case GroupableField.Added:
                 case GroupableField.Modified:
                 case GroupableField.PlayTime:
@@ -489,6 +491,8 @@ namespace Playnite.DesktopApp
                     return oldData.CommunityScore != newData.CommunityScore;
                 case GroupableField.LastActivity:
                     return oldData.LastActivity != newData.LastActivity;
+                case GroupableField.RecentActivity:
+                    return oldData.RecentActivity != newData.RecentActivity;
                 case GroupableField.Added:
                     return oldData.Added != newData.Added;
                 case GroupableField.Modified:

--- a/source/Playnite.FullscreenApp/Controls/Views/FiltersAdditional.cs
+++ b/source/Playnite.FullscreenApp/Controls/Views/FiltersAdditional.cs
@@ -108,6 +108,7 @@ namespace Playnite.FullscreenApp.Controls.Views
                     AssignFilter("LOCFeatureLabel", "PART_ButtonFeature", GameField.Features, nameof(FilterSettings.Feature));
                     AssignFilter("LOCTagLabel", "PART_ButtonTag", GameField.Tags, nameof(FilterSettings.Tag));
                     AssignFilter("LOCTimePlayed", "PART_ButtonPlayTime", GameField.Playtime, nameof(FilterSettings.PlayTime));
+                    AssignFilter("LOCInstallSizeLabel", "PART_ButtonInstallSize", GameField.InstallSize, nameof(FilterSettings.InstallSize));
                     AssignFilter("LOCCompletionStatus", "PART_ButtonCompletionStatus", GameField.CompletionStatus, nameof(FilterSettings.CompletionStatuses));
                     AssignFilter("LOCSeriesLabel", "PART_ButtonSeries", GameField.Series, nameof(FilterSettings.Series));
                     AssignFilter("LOCRegionLabel", "PART_ButtonRegion", GameField.Regions, nameof(FilterSettings.Region));

--- a/source/Playnite.FullscreenApp/Controls/Views/FiltersAdditional.cs
+++ b/source/Playnite.FullscreenApp/Controls/Views/FiltersAdditional.cs
@@ -118,6 +118,7 @@ namespace Playnite.FullscreenApp.Controls.Views
                     AssignFilter("LOCCommunityScore", "PART_ButtonCommunityScore", GameField.CommunityScore, nameof(FilterSettings.CommunityScore));
                     AssignFilter("LOCCriticScore", "PART_ButtonCriticScore", GameField.CriticScore, nameof(FilterSettings.CriticScore));
                     AssignFilter("LOCGameLastActivityTitle", "PART_ButtonLastActivity", GameField.LastActivity, nameof(FilterSettings.LastActivity));
+                    AssignFilter("LOCRecentActivityLabel", "PART_ButtonRecentActivity", GameField.RecentActivity, nameof(FilterSettings.RecentActivity));
                     AssignFilter("LOCAddedLabel", "PART_ButtonAdded", GameField.Added, nameof(FilterSettings.Added));
                     AssignFilter("LOCModifiedLabel", "PART_ButtonModified", GameField.Modified, nameof(FilterSettings.Modified));
                 }

--- a/source/Playnite.FullscreenApp/ViewModels/FullscreenAppViewModel_Commands.cs
+++ b/source/Playnite.FullscreenApp/ViewModels/FullscreenAppViewModel_Commands.cs
@@ -159,6 +159,9 @@ namespace Playnite.FullscreenApp.ViewModels
                     case GameField.LastActivity:
                         OpenSubEnumFilter("LOCGameLastActivityTitle", typeof(PastTimeSegment), nameof(FilterSettings.LastActivity));
                         break;
+                    case GameField.RecentActivity:
+                        OpenSubEnumFilter("LOCRecentActivityLabel", typeof(PastTimeSegment), nameof(FilterSettings.RecentActivity));
+                        break;
                     case GameField.Added:
                         OpenSubEnumFilter("LOCAddedLabel", typeof(PastTimeSegment), nameof(FilterSettings.Added));
                         break;

--- a/source/Playnite.FullscreenApp/ViewModels/FullscreenAppViewModel_Commands.cs
+++ b/source/Playnite.FullscreenApp/ViewModels/FullscreenAppViewModel_Commands.cs
@@ -132,6 +132,9 @@ namespace Playnite.FullscreenApp.ViewModels
                     case GameField.Playtime:
                         OpenSubEnumFilter("LOCTimePlayed", typeof(PlaytimeCategory), nameof(FilterSettings.PlayTime));
                         break;
+                    case GameField.InstallSize:
+                        OpenSubEnumFilter("LOCInstallSizeLabel", typeof(InstallSizeGroup), nameof(FilterSettings.InstallSize));
+                        break;
                     case GameField.Series:
                         OpenSubFilter("LOCSeriesLabel", nameof(DatabaseFilter.Series), nameof(FilterSettings.Series));
                         break;

--- a/source/Playnite/Database/DatabaseExplorer.cs
+++ b/source/Playnite/Database/DatabaseExplorer.cs
@@ -46,6 +46,8 @@ namespace Playnite.Database
         Source,
         [Description(LOC.TimePlayed)]
         PlayTime,
+        [Description(LOC.InstallSizeLabel)]
+        InstallSize,
         [Description(LOC.CompletionStatus)]
         CompletionStatus,
         [Description(LOC.UserScore)]
@@ -641,6 +643,9 @@ namespace Playnite.Database
                 case ExplorerField.PlayTime:
                     filters.PlayTime = GetEnumFilter(filter);
                     break;
+                case ExplorerField.InstallSize:
+                    filters.InstallSize = GetEnumFilter(filter);
+                    break;
                 case ExplorerField.Feature:
                     filters.Feature = GetIdFilter(filter);
                     break;
@@ -835,6 +840,9 @@ namespace Playnite.Database
                     break;
                 case ExplorerField.PlayTime:
                     values.AddRange(GenerateEnumValues(typeof(PlaytimeCategory)));
+                    break;
+                case ExplorerField.InstallSize:
+                    values.AddRange(GenerateEnumValues(typeof(InstallSizeGroup)));
                     break;
                 case ExplorerField.Feature:
                     values.Add(noneDbObject);

--- a/source/Playnite/Database/DatabaseExplorer.cs
+++ b/source/Playnite/Database/DatabaseExplorer.cs
@@ -26,6 +26,8 @@ namespace Playnite.Database
         Category,
         [Description(LOC.GameLastActivityTitle)]
         LastActivity,
+        [Description(LOC.RecentActivityLabel)]
+        RecentActivity,
         [Description(LOC.GenreLabel)]
         Genre,
         [Description(LOC.GameReleaseYearTitle)]
@@ -634,6 +636,9 @@ namespace Playnite.Database
                 case ExplorerField.LastActivity:
                     filters.LastActivity = GetEnumFilter(filter);
                     break;
+                case ExplorerField.RecentActivity:
+                    filters.RecentActivity = GetEnumFilter(filter);
+                    break;
                 case ExplorerField.Added:
                     filters.Added = GetEnumFilter(filter);
                     break;
@@ -834,6 +839,7 @@ namespace Playnite.Database
                     values.AddRange(GenerateEnumValues(typeof(ScoreGroup)));
                     break;
                 case ExplorerField.LastActivity:
+                case ExplorerField.RecentActivity:
                 case ExplorerField.Added:
                 case ExplorerField.Modified:
                     values.AddRange(GenerateEnumValues(typeof(PastTimeSegment)));

--- a/source/Playnite/GamesCollectionView.cs
+++ b/source/Playnite/GamesCollectionView.cs
@@ -341,6 +341,19 @@ namespace Playnite
                 }
             }
 
+            // ------------------ InstallSize
+            if (filterSettings.InstallSize?.IsSet == true)
+            {
+                if (filterSettings.InstallSize.Values.Count != 1)
+                {
+                    return false;
+                }
+                else if (filterSettings.InstallSize.Values.First() == ((int)game.InstallSizeGroup) == false)
+                {
+                    return false;
+                }
+            }
+
             // ------------------ Version
             if (!filterSettings.Version.IsNullOrEmpty() && game.Version?.Contains(filterSettings.Version, StringComparison.OrdinalIgnoreCase) != true)
             {
@@ -637,6 +650,12 @@ namespace Playnite
 
             // ------------------ Playtime
             if (filterSettings.PlayTime?.IsSet == true && !filterSettings.PlayTime.Values.Contains((int)game.PlaytimeCategory))
+            {
+                return false;
+            }
+
+            // ------------------ InstallSize
+            if (filterSettings.InstallSize?.IsSet == true && !filterSettings.InstallSize.Values.Contains((int)game.InstallSizeGroup))
             {
                 return false;
             }

--- a/source/Playnite/GamesCollectionView.cs
+++ b/source/Playnite/GamesCollectionView.cs
@@ -382,6 +382,19 @@ namespace Playnite
                 }
             }
 
+            // ------------------ Recent Activity
+            if (filterSettings.RecentActivity?.IsSet == true)
+            {
+                if (filterSettings.RecentActivity.Values.Count != 1)
+                {
+                    return false;
+                }
+                else if (!filterSettings.RecentActivity.Values.Contains((int)game.RecentActivitySegment))
+                {
+                    return false;
+                }
+            }
+
             // ------------------ Added
             if (filterSettings.Added?.IsSet == true)
             {
@@ -677,6 +690,12 @@ namespace Playnite
 
             // ------------------ Last Activity
             if (filterSettings.LastActivity?.IsSet == true && !filterSettings.LastActivity.Values.Contains((int)game.LastActivitySegment))
+            {
+                return false;
+            }
+
+            // ------------------ Recent Activity
+            if (filterSettings.RecentActivity?.IsSet == true && !filterSettings.RecentActivity.Values.Contains((int)game.RecentActivitySegment))
             {
                 return false;
             }

--- a/source/Playnite/GamesCollectionViewEntry.cs
+++ b/source/Playnite/GamesCollectionViewEntry.cs
@@ -78,6 +78,7 @@ namespace Playnite
         public PastTimeSegment LastActivitySegment => Game.LastActivitySegment;
         public PastTimeSegment AddedSegment => Game.AddedSegment;
         public PastTimeSegment ModifiedSegment => Game.ModifiedSegment;
+        public PastTimeSegment RecentActivitySegment => Game.RecentActivitySegment;
         public PlaytimeCategory PlaytimeCategory => Game.PlaytimeCategory;
         public InstallationStatus InstallationState => Game.InstallationStatus;
         public char NameGroup => Game.GetNameGroup();

--- a/source/Playnite/Localization/LocalizationKeys.cs
+++ b/source/Playnite/Localization/LocalizationKeys.cs
@@ -2042,6 +2042,10 @@ namespace Playnite
         /// </summary>
         public const string SourcesLabel = "LOCSourcesLabel";
         /// <summary>
+        /// Recent Activity
+        /// </summary>
+        public const string RecentActivityLabel = "LOCRecentActivityLabel";
+        /// <summary>
         /// Database Error
         /// </summary>
         public const string DatabaseErroTitle = "LOCDatabaseErroTitle";

--- a/source/Playnite/Settings/FilterSettings.cs
+++ b/source/Playnite/Settings/FilterSettings.cs
@@ -347,6 +347,7 @@ namespace Playnite
                     CriticScore?.IsSet == true ||
                     CommunityScore?.IsSet == true ||
                     LastActivity?.IsSet == true ||
+                    RecentActivity?.IsSet == true ||
                     Added?.IsSet == true ||
                     Modified?.IsSet == true ||
                     ReleaseYear?.IsSet == true ||
@@ -814,6 +815,25 @@ namespace Playnite
             }
         }
 
+        private EnumFilterItemProperties recentActivity;
+        public EnumFilterItemProperties RecentActivity
+        {
+            get
+            {
+                return recentActivity;
+            }
+
+            set
+            {
+                if (recentActivity != value)
+                {
+                    recentActivity = value;
+                    OnPropertyChanged();
+                    OnFilterChanged(nameof(RecentActivity));
+                }
+            }
+        }
+
         private EnumFilterItemProperties added;
         public EnumFilterItemProperties Added
         {
@@ -1082,6 +1102,12 @@ namespace Playnite
                 filterChanges.Add(nameof(LastActivity));
             }
 
+            if (RecentActivity != null)
+            {
+                RecentActivity = null;
+                filterChanges.Add(nameof(RecentActivity));
+            }
+
             if (Added != null)
             {
                 Added = null;
@@ -1148,6 +1174,7 @@ namespace Playnite
                 CriticScore = CriticScore?.ToSdkModel(),
                 CommunityScore = CommunityScore?.ToSdkModel(),
                 LastActivity = LastActivity?.ToSdkModel(),
+                RecentActivity = RecentActivity?.ToSdkModel(),
                 Added = Added?.ToSdkModel(),
                 Modified = Modified?.ToSdkModel(),
                 PlayTime = PlayTime?.ToSdkModel(),
@@ -1301,6 +1328,12 @@ namespace Playnite
             {
                 LastActivity = EnumFilterItemProperties.FromSdkModel(settings.LastActivity);
                 filterChanges.Add(nameof(LastActivity));
+            }
+
+            if (RecentActivity?.Equals(settings.RecentActivity) != true)
+            {
+                RecentActivity = EnumFilterItemProperties.FromSdkModel(settings.RecentActivity);
+                filterChanges.Add(nameof(RecentActivity));
             }
 
             if (Added?.Equals(settings.Added) != true)
@@ -1486,6 +1519,12 @@ namespace Playnite
                 filterChanges.Add(nameof(LastActivity));
             }
 
+            if (RecentActivity?.Equals(settings.RecentActivity) != true)
+            {
+                RecentActivity = settings.RecentActivity;
+                filterChanges.Add(nameof(RecentActivity));
+            }
+
             if (Added?.Equals(settings.Added) != true)
             {
                 Added = settings.Added;
@@ -1615,6 +1654,11 @@ namespace Playnite
         public bool ShouldSerializeLastActivity()
         {
             return LastActivity?.IsSet == true;
+        }
+
+        public bool ShouldSerializeRecentActivity()
+        {
+            return RecentActivity?.IsSet == true;
         }
 
         public bool ShouldSerializeAdded()

--- a/source/Playnite/Settings/FilterSettings.cs
+++ b/source/Playnite/Settings/FilterSettings.cs
@@ -351,6 +351,7 @@ namespace Playnite
                     Modified?.IsSet == true ||
                     ReleaseYear?.IsSet == true ||
                     PlayTime?.IsSet == true ||
+                    InstallSize?.IsSet == true ||
                     Feature?.IsSet == true;
             }
         }
@@ -870,6 +871,25 @@ namespace Playnite
             }
         }
 
+        private EnumFilterItemProperties installSize;
+        public EnumFilterItemProperties InstallSize
+        {
+            get
+            {
+                return installSize;
+            }
+
+            set
+            {
+                if (installSize != value)
+                {
+                    installSize = value;
+                    OnPropertyChanged();
+                    OnFilterChanged(nameof(InstallSize));
+                }
+            }
+        }
+
         private IdItemFilterItemProperties feature;
         public IdItemFilterItemProperties Feature
         {
@@ -1080,6 +1100,12 @@ namespace Playnite
                 filterChanges.Add(nameof(PlayTime));
             }
 
+            if (InstallSize != null)
+            {
+                InstallSize = null;
+                filterChanges.Add(nameof(InstallSize));
+            }
+
             if (Feature?.IsSet == true)
             {
                 Feature = null;
@@ -1124,7 +1150,8 @@ namespace Playnite
                 LastActivity = LastActivity?.ToSdkModel(),
                 Added = Added?.ToSdkModel(),
                 Modified = Modified?.ToSdkModel(),
-                PlayTime = PlayTime?.ToSdkModel()
+                PlayTime = PlayTime?.ToSdkModel(),
+                InstallSize = InstallSize?.ToSdkModel()
             };
         }
 
@@ -1292,6 +1319,12 @@ namespace Playnite
             {
                 PlayTime = EnumFilterItemProperties.FromSdkModel(settings.PlayTime);
                 filterChanges.Add(nameof(PlayTime));
+            }
+
+            if (InstallSize?.Equals(settings.InstallSize) != true)
+            {
+                InstallSize = EnumFilterItemProperties.FromSdkModel(settings.InstallSize);
+                filterChanges.Add(nameof(InstallSize));
             }
 
             if (Feature?.Equals(settings.Feature) != true)
@@ -1471,6 +1504,12 @@ namespace Playnite
                 filterChanges.Add(nameof(PlayTime));
             }
 
+            if (InstallSize?.Equals(settings.InstallSize) != true)
+            {
+                InstallSize = settings.InstallSize;
+                filterChanges.Add(nameof(InstallSize));
+            }
+
             if (Feature?.Equals(settings.Feature) != true)
             {
                 Feature = settings.Feature;
@@ -1591,6 +1630,11 @@ namespace Playnite
         public bool ShouldSerializePlayTime()
         {
             return PlayTime?.IsSet == true;
+        }
+
+        public bool ShouldSerializeInstallSize()
+        {
+            return InstallSize?.IsSet == true;
         }
 
         public bool ShouldSerializeFeature()

--- a/source/PlayniteSDK/Models/FilterPreset.cs
+++ b/source/PlayniteSDK/Models/FilterPreset.cs
@@ -105,6 +105,7 @@ namespace Playnite.SDK.Models
         public EnumFilterItemProperties CriticScore { get; set; }
         public EnumFilterItemProperties CommunityScore { get; set; }
         public EnumFilterItemProperties LastActivity { get; set; }
+        public EnumFilterItemProperties RecentActivity { get; set; }
         public EnumFilterItemProperties Added { get; set; }
         public EnumFilterItemProperties Modified { get; set; }
         public EnumFilterItemProperties PlayTime { get; set; }

--- a/source/PlayniteSDK/Models/FilterPreset.cs
+++ b/source/PlayniteSDK/Models/FilterPreset.cs
@@ -108,6 +108,7 @@ namespace Playnite.SDK.Models
         public EnumFilterItemProperties Added { get; set; }
         public EnumFilterItemProperties Modified { get; set; }
         public EnumFilterItemProperties PlayTime { get; set; }
+        public EnumFilterItemProperties InstallSize { get; set; }
     }
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 

--- a/source/PlayniteSDK/Models/FilterPreset.cs
+++ b/source/PlayniteSDK/Models/FilterPreset.cs
@@ -75,7 +75,8 @@ namespace Playnite.SDK.Models
         [Description("LOCGameInstallationStatus")] InstallationStatus = 22,
         [Description("LOCGameNameTitle")] Name = 23,
         [Description("LOCInstallDriveTitle")] InstallDrive = 24,
-        [Description("LOCInstallSizeLabel")] InstallSize = 25
+        [Description("LOCInstallSizeLabel")] InstallSize = 25,
+        [Description("LOCRecentActivityLabel")] RecentActivity = 26
     }
 
     public class FilterPresetSettings

--- a/source/PlayniteSDK/Models/Game.cs
+++ b/source/PlayniteSDK/Models/Game.cs
@@ -1407,6 +1407,15 @@ namespace Playnite.SDK.Models
         }
 
         /// <summary>
+        /// Gets game's install size group.
+        /// </summary>
+        [DontSerialize]
+        public InstallSizeGroup InstallSizeGroup
+        {
+            get => GetInstallSizeGroup();
+        }
+
+        /// <summary>
         /// Gets value indicating whether the game is custom game.
         /// </summary>
         [DontSerialize]

--- a/source/PlayniteSDK/Models/Game.cs
+++ b/source/PlayniteSDK/Models/Game.cs
@@ -1380,6 +1380,15 @@ namespace Playnite.SDK.Models
         }
 
         /// <summary>
+        /// Gets time segment for games recent activity.
+        /// </summary>
+        [DontSerialize]
+        public PastTimeSegment RecentActivitySegment
+        {
+            get => GetPastTimeSegment(RecentActivity);
+        }
+
+        /// <summary>
         /// Gets time segment for games added date.
         /// </summary>
         [DontSerialize]


### PR DESCRIPTION
I have verified that:
- [x] These changes work, by building the application and testing them.
- [x] Pull request is targeting `devel` branch.
- [x] I added myself into [contributors file](https://github.com/JosefNemec/Playnite/blob/devel/source/Playnite.DesktopApp/Resources/contributors.txt) if I want to receive contribution credit in the application itself.

## Implements:
- Filter support in Filter and Explorer Panels and for Fullscreen Mode for `InstallSize` property (Closes https://github.com/JosefNemec/Playnite/issues/3075)
- Filter support in Filter and Explorer Panels and for Fullscreen Mode for `RecentActivity` property (Closes https://github.com/JosefNemec/Playnite/issues/3075)
- Grouping support for `RecentActivity` property. (Closes https://github.com/JosefNemec/Playnite/issues/3076)


## Screenshots:

### InstallSize
![uKcDP5O670](https://user-images.githubusercontent.com/1389286/191603607-0ae7bf0b-cf70-42e8-afbf-b0251db985b4.png)

![9sRMoFCK4c](https://user-images.githubusercontent.com/1389286/191603579-cf29b892-6ed2-4566-a7cb-eba8233b3c20.png)

### RecentActivity

![image](https://user-images.githubusercontent.com/1389286/191608786-ce69aade-c7bd-4c0d-b9fe-fdb79a4b7abe.png)

![u3dUpW6Pak](https://user-images.githubusercontent.com/1389286/191608649-bacc0f4b-49a2-441f-94a4-fa8a9d81aae6.png)

![image](https://user-images.githubusercontent.com/1389286/191637978-5807fbf1-d437-488c-95b0-c33807220bf3.png)
