### PR TITLE
Fix incorrect GridEx RowCount in details views

### DIFF
--- a/source/Playnite.DesktopApp/Themes/Desktop/Default/Views/DetailsViewGameOverview.xaml
+++ b/source/Playnite.DesktopApp/Themes/Desktop/Default/Views/DetailsViewGameOverview.xaml
@@ -107,7 +107,7 @@
                                             
                                         <GridEx Margin="0,5,0,10"
                                                 ColumnCount="2" StarColumns="1"
-                                                RowCount="23" AutoLayoutColumns="2">
+                                                RowCount="24" AutoLayoutColumns="2">
                                             <Grid.Resources>
                                                 <Style TargetType="TextBlock" BasedOn="{StaticResource BaseTextBlockStyle}" />
                                             </Grid.Resources>

--- a/source/Playnite.DesktopApp/Themes/Desktop/Default/Views/GridViewGameOverview.xaml
+++ b/source/Playnite.DesktopApp/Themes/Desktop/Default/Views/GridViewGameOverview.xaml
@@ -116,7 +116,7 @@
 
                                             <GridEx Margin="0,5,0,10"
                                                     ColumnCount="2" StarColumns="1"
-                                                    RowCount="23" AutoLayoutColumns="2">
+                                                    RowCount="24" AutoLayoutColumns="2">
                                                 <Grid.Resources>
                                                     <Style TargetType="TextBlock" BasedOn="{StaticResource BaseTextBlockStyle}" />
                                                 </Grid.Resources>


### PR DESCRIPTION
I have verified that:
- [x] These changes work, by building the application and testing them.
- [x] Pull request is targeting `devel` branch.
- [x] I added myself into [contributors file](https://github.com/JosefNemec/Playnite/blob/devel/source/Playnite.DesktopApp/Resources/contributors.txt) if I want to receive contribution credit in the application itself.

From https://github.com/JosefNemec/Playnite/commit/0ca9176b09fb6768e9025356fa0e66411d53e64d

It seems I overlooked increasing the GridEx RowCount for the new elements in details...

![image](https://user-images.githubusercontent.com/1389286/191626440-b55c8d25-5328-42ed-8712-6c998ea35e87.png)
