### PR TITLE
Scan install size when updating emulation libraries

### DIFF
--- a/source/Playnite/Localization/LocSource.xaml
+++ b/source/Playnite/Localization/LocSource.xaml
@@ -222,6 +222,7 @@ Selecting "add to exclusion list" option will prevent games from being imported 
     <sys:String x:Key="LOCProgressImportinEmulatedGames">Importing emulated games from {0}…</sys:String>
     <sys:String x:Key="LOCProgressLibraryGames">Downloading library updates…</sys:String>
     <sys:String x:Key="LOCProgressScanningGamesInstallSize">Scanning size of games in library…</sys:String>
+    <sys:String x:Key="LOCProgressScanningEmulatedGamesInstallSize">Scanning size of imported emulated games…</sys:String>
     <sys:String x:Key="LOCProgressLibImportFinish">Library update finished</sys:String>
     <sys:String x:Key="LOCProgressReleasingResources">Releasing resources…</sys:String>
     <!--Menu-->

--- a/source/Playnite/Localization/LocSource.xaml
+++ b/source/Playnite/Localization/LocSource.xaml
@@ -222,7 +222,7 @@ Selecting "add to exclusion list" option will prevent games from being imported 
     <sys:String x:Key="LOCProgressImportinEmulatedGames">Importing emulated games from {0}…</sys:String>
     <sys:String x:Key="LOCProgressLibraryGames">Downloading library updates…</sys:String>
     <sys:String x:Key="LOCProgressScanningGamesInstallSize">Scanning size of games in library…</sys:String>
-    <sys:String x:Key="LOCProgressScanningEmulatedGamesInstallSize">Scanning size of imported emulated games…</sys:String>
+    <sys:String x:Key="LOCProgressScanningImportedGamesInstallSize">Scanning size of imported games…</sys:String>
     <sys:String x:Key="LOCProgressLibImportFinish">Library update finished</sys:String>
     <sys:String x:Key="LOCProgressReleasingResources">Releasing resources…</sys:String>
     <!--Menu-->

--- a/source/Playnite/Localization/LocalizationKeys.cs
+++ b/source/Playnite/Localization/LocalizationKeys.cs
@@ -794,9 +794,9 @@ namespace Playnite
         /// </summary>
         public const string ProgressScanningGamesInstallSize = "LOCProgressScanningGamesInstallSize";
         /// <summary>
-        /// Scanning size of imported emulated games…
+        /// Scanning size of imported games…
         /// </summary>
-        public const string ProgressScanningEmulatedGamesInstallSize = "LOCProgressScanningEmulatedGamesInstallSize";
+        public const string ProgressScanningImportedGamesInstallSize = "LOCProgressScanningImportedGamesInstallSize";
         /// <summary>
         /// Library update finished
         /// </summary>

--- a/source/Playnite/Localization/LocalizationKeys.cs
+++ b/source/Playnite/Localization/LocalizationKeys.cs
@@ -794,6 +794,10 @@ namespace Playnite
         /// </summary>
         public const string ProgressScanningGamesInstallSize = "LOCProgressScanningGamesInstallSize";
         /// <summary>
+        /// Scanning size of imported emulated games…
+        /// </summary>
+        public const string ProgressScanningEmulatedGamesInstallSize = "LOCProgressScanningEmulatedGamesInstallSize";
+        /// <summary>
         /// Library update finished
         /// </summary>
         public const string ProgressLibImportFinish = "LOCProgressLibImportFinish";

--- a/source/Playnite/ViewModels/MainViewModelBase.cs
+++ b/source/Playnite/ViewModels/MainViewModelBase.cs
@@ -567,7 +567,7 @@ namespace Playnite.ViewModels
 
                 if (AppSettings.ScanLibInstallSizeOnLibUpdate)
                 {
-                    UpdateLibraryInstallSizes(token);
+                    UpdateGamesInstallSizes(token, Database.Games.ToList());
                 }
 
                 return addedGames;
@@ -586,20 +586,20 @@ namespace Playnite.ViewModels
                 var addedGames = ImportLibraryGames(plugin, token);
                 if (AppSettings.ScanLibInstallSizeOnLibUpdate)
                 {
-                    UpdateLibraryInstallSizes(token);
+                    UpdateGamesInstallSizes(token, Database.Games.ToList());
                 }
 
                 return addedGames;
             }, AppSettings.DownloadMetadataOnImport);
         }
 
-        public void UpdateLibraryInstallSizes(CancellationToken token)
+        public void UpdateGamesInstallSizes(CancellationToken token, List<Game> games)
         {
             try
             {
                 ProgressActive = true;
                 ProgressValue = 0;
-                ProgressTotal = Database.Games.Count + 1;
+                ProgressTotal = games.Count + 1;
 
                 Logger.Info($"Starting Library Install Size scan");
                 ProgressStatus = Resources.GetString(LOC.ProgressScanningGamesInstallSize);
@@ -607,7 +607,7 @@ namespace Playnite.ViewModels
                 var errorsCount = 0;
                 using (Database.Games.BufferedUpdate())
                 {
-                    foreach (var game in Database.Games)
+                    foreach (var game in games)
                     {
                         if (token.IsCancellationRequested)
                         {
@@ -720,7 +720,13 @@ namespace Playnite.ViewModels
         {
             await UpdateLibraryData((token) =>
             {
-                return ImportEmulatedGames(config, token);
+                var addedGames = ImportEmulatedGames(config, token);
+                if (AppSettings.ScanLibInstallSizeOnLibUpdate)
+                {
+                    UpdateGamesInstallSizes(token, addedGames);
+                }
+
+                return addedGames;
             }, AppSettings.DownloadMetadataOnImport);
         }
 
@@ -732,6 +738,11 @@ namespace Playnite.ViewModels
                 foreach (var scanConfig in Database.GameScanners.Where(a => a.InGlobalUpdate))
                 {
                     addedGames.AddRange(ImportEmulatedGames(scanConfig, token));
+                }
+
+                if (AppSettings.ScanLibInstallSizeOnLibUpdate)
+                {
+                    UpdateGamesInstallSizes(token, addedGames);
                 }
 
                 return addedGames;

--- a/source/Playnite/ViewModels/MainViewModelBase.cs
+++ b/source/Playnite/ViewModels/MainViewModelBase.cs
@@ -723,7 +723,7 @@ namespace Playnite.ViewModels
                 var addedGames = ImportEmulatedGames(config, token);
                 if (AppSettings.ScanLibInstallSizeOnLibUpdate)
                 {
-                    UpdateGamesInstallSizes(token, addedGames, LOC.ProgressScanningEmulatedGamesInstallSize);
+                    UpdateGamesInstallSizes(token, addedGames, LOC.ProgressScanningImportedGamesInstallSize);
                 }
 
                 return addedGames;
@@ -742,7 +742,7 @@ namespace Playnite.ViewModels
 
                 if (AppSettings.ScanLibInstallSizeOnLibUpdate)
                 {
-                    UpdateGamesInstallSizes(token, addedGames, LOC.ProgressScanningEmulatedGamesInstallSize);
+                    UpdateGamesInstallSizes(token, addedGames, LOC.ProgressScanningImportedGamesInstallSize);
                 }
 
                 return addedGames;

--- a/source/Playnite/ViewModels/MainViewModelBase.cs
+++ b/source/Playnite/ViewModels/MainViewModelBase.cs
@@ -567,7 +567,7 @@ namespace Playnite.ViewModels
 
                 if (AppSettings.ScanLibInstallSizeOnLibUpdate)
                 {
-                    UpdateGamesInstallSizes(token, Database.Games.ToList());
+                    UpdateGamesInstallSizes(token, Database.Games.ToList(), LOC.ProgressScanningGamesInstallSize);
                 }
 
                 return addedGames;
@@ -586,14 +586,14 @@ namespace Playnite.ViewModels
                 var addedGames = ImportLibraryGames(plugin, token);
                 if (AppSettings.ScanLibInstallSizeOnLibUpdate)
                 {
-                    UpdateGamesInstallSizes(token, Database.Games.ToList());
+                    UpdateGamesInstallSizes(token, Database.Games.ToList(), LOC.ProgressScanningGamesInstallSize);
                 }
 
                 return addedGames;
             }, AppSettings.DownloadMetadataOnImport);
         }
 
-        public void UpdateGamesInstallSizes(CancellationToken token, List<Game> games)
+        public void UpdateGamesInstallSizes(CancellationToken token, List<Game> games, string progressMessageLocKey)
         {
             try
             {
@@ -602,7 +602,7 @@ namespace Playnite.ViewModels
                 ProgressTotal = games.Count + 1;
 
                 Logger.Info($"Starting Library Install Size scan");
-                ProgressStatus = Resources.GetString(LOC.ProgressScanningGamesInstallSize);
+                ProgressStatus = Resources.GetString(progressMessageLocKey);
                 var errorStrings = new List<string>();
                 var errorsCount = 0;
                 using (Database.Games.BufferedUpdate())
@@ -723,7 +723,7 @@ namespace Playnite.ViewModels
                 var addedGames = ImportEmulatedGames(config, token);
                 if (AppSettings.ScanLibInstallSizeOnLibUpdate)
                 {
-                    UpdateGamesInstallSizes(token, addedGames);
+                    UpdateGamesInstallSizes(token, addedGames, LOC.ProgressScanningEmulatedGamesInstallSize);
                 }
 
                 return addedGames;
@@ -742,7 +742,7 @@ namespace Playnite.ViewModels
 
                 if (AppSettings.ScanLibInstallSizeOnLibUpdate)
                 {
-                    UpdateGamesInstallSizes(token, addedGames);
+                    UpdateGamesInstallSizes(token, addedGames, LOC.ProgressScanningEmulatedGamesInstallSize);
                 }
 
                 return addedGames;

--- a/source/Playnite/ViewModels/MainViewModelBase.cs
+++ b/source/Playnite/ViewModels/MainViewModelBase.cs
@@ -567,7 +567,7 @@ namespace Playnite.ViewModels
 
                 if (AppSettings.ScanLibInstallSizeOnLibUpdate)
                 {
-                    UpdateGamesInstallSizes(token, Database.Games.ToList(), LOC.ProgressScanningGamesInstallSize);
+                    UpdateGamesInstallSizes(token, Database.Games, LOC.ProgressScanningGamesInstallSize);
                 }
 
                 return addedGames;
@@ -586,20 +586,20 @@ namespace Playnite.ViewModels
                 var addedGames = ImportLibraryGames(plugin, token);
                 if (AppSettings.ScanLibInstallSizeOnLibUpdate)
                 {
-                    UpdateGamesInstallSizes(token, Database.Games.ToList(), LOC.ProgressScanningGamesInstallSize);
+                    UpdateGamesInstallSizes(token, Database.Games, LOC.ProgressScanningGamesInstallSize);
                 }
 
                 return addedGames;
             }, AppSettings.DownloadMetadataOnImport);
         }
 
-        public void UpdateGamesInstallSizes(CancellationToken token, List<Game> games, string progressMessageLocKey)
+        public void UpdateGamesInstallSizes(CancellationToken token, IEnumerable<Game> games, string progressMessageLocKey)
         {
             try
             {
                 ProgressActive = true;
                 ProgressValue = 0;
-                ProgressTotal = games.Count + 1;
+                ProgressTotal = games.Count() + 1;
 
                 Logger.Info($"Starting Library Install Size scan");
                 ProgressStatus = Resources.GetString(progressMessageLocKey);

--- a/source/Playnite/ViewModels/MainViewModelBase.cs
+++ b/source/Playnite/ViewModels/MainViewModelBase.cs
@@ -595,6 +595,11 @@ namespace Playnite.ViewModels
 
         public void UpdateGamesInstallSizes(CancellationToken token, IEnumerable<Game> games, string progressMessageLocKey)
         {
+            if (token.IsCancellationRequested)
+            {
+                return;
+            }
+
             try
             {
                 ProgressActive = true;


### PR DESCRIPTION
I have verified that:
- [x] These changes work, by building the application and testing them.
- [ ] Pull request is targeting `devel` branch. (Targeting `master`)
- [x] I added myself into [contributors file](https://github.com/JosefNemec/Playnite/blob/devel/source/Playnite.DesktopApp/Resources/contributors.txt) if I want to receive contribution credit in the application itself.

Scans size of game of imported by scanners during library update

![image](https://user-images.githubusercontent.com/1389286/192156125-65b8aff4-d55c-45de-9862-7286b5e45e8d.png)

Note: Doesn't include scan for games on MainMenu -> Added. That's for another PR...