### PR TITLE
Scan files sizes on disk in parallel

### DIFF
--- a/source/Playnite/Common/FileSystem.cs
+++ b/source/Playnite/Common/FileSystem.cs
@@ -429,6 +429,43 @@ namespace Playnite.Common
             return size;
         }
 
+        public static long GetDirectorySizeOnDiskParallel(string directoryPath)
+        {
+            return GetDirectoryFiles(directoryPath)
+                    .AsParallel()
+                    .Sum(file => GetFileSizeOnDisk(file));
+        }
+
+        private static List<FileInfo> GetDirectoryFiles(string directoryPath)
+        {
+            var filesList = new List<FileInfo>();
+            GetDirectoryFiles(filesList, directoryPath);
+            return filesList;
+        }
+
+        private static void GetDirectoryFiles(List<FileInfo> filesList, string directoryPath)
+        {
+            GetDirectoryFiles(filesList, new DirectoryInfo(Paths.FixPathLength(directoryPath)));
+        }
+
+        private static void GetDirectoryFiles(List<FileInfo> filesList, DirectoryInfo dirInfo)
+        {
+            foreach (FileInfo fileInfo in dirInfo.GetFiles())
+            {
+                filesList.Add(fileInfo);
+            }
+
+            foreach (DirectoryInfo subdirInfo in dirInfo.GetDirectories())
+            {
+                if (!IsDirectorySubdirSafeToRecurse(subdirInfo))
+                {
+                    continue;
+                }
+
+                GetDirectoryFiles(filesList, subdirInfo.FullName);
+            }
+        }
+
         private static bool IsDirectorySubdirSafeToRecurse(DirectoryInfo childDirectory)
         {
             // Whitespace characters can cause confusion in methods, causing them to process

--- a/source/Playnite/GamesEditor.cs
+++ b/source/Playnite/GamesEditor.cs
@@ -586,7 +586,7 @@ namespace Playnite
 
                 if (AppSettings.InstallSizeScanUseSizeOnDisk)
                 {
-                    size = FileSystem.GetDirectorySizeOnDisk(expandedGame.InstallDirectory);
+                    size = FileSystem.GetDirectorySizeOnDiskParallel(expandedGame.InstallDirectory);
                 }
                 else
                 {


### PR DESCRIPTION
I have verified that:
- [x] These changes work, by building the application and testing them.
- [ ] Pull request is targeting `devel` branch. (Targeting `master`)
- [x] I added myself into [contributors file](https://github.com/JosefNemec/Playnite/blob/devel/source/Playnite.DesktopApp/Resources/contributors.txt) if I want to receive contribution credit in the application itself.

## Implements
- Makes files sizes to be scanned in parallel while scanning size on disk

According to my tests, doing it in parallel improves processing speed depending on the scenario

Test 1: SSD Drive

- Current method: 48.17 seconds
- Parallel: 15.38 (33~ seconds less, +213% performance increase)
![image](https://user-images.githubusercontent.com/1389286/192220029-b445b420-266d-420c-8782-6cbe42a75a78.png)

Test 2: HDD Drive
- Current method: 30.09 seconds
- Parallel: 11.16 (19~ seconds less, +169% performance increase)
![image](https://user-images.githubusercontent.com/1389286/192220743-93eda23c-c0a0-4c98-93e1-6148b4eb853f.png)


Test 3: HDD Drive (Xcom 2, over 70k files)
- Current method: 253.97 seconds
- Parallel:  55.81 (198~ seconds less, +355% performance increase)

![image](https://user-images.githubusercontent.com/1389286/192221058-c6658611-37aa-49a4-9e7e-a31ffc44ca42.png)

Test 4: All my Steam library

Note: C drive is a SSD. G drive is a HDD.
- Current method: 14 minutes 45 seconds

```
26-09 02:15:27.343|INFO |MainViewModelBase:Starting Library Install Size scan
26-09 02:30:12.927|INFO |MainViewModelBase:Finished Library Install Size scan
```

- Parallel:  10 minutes 44 seconds (4 minutes and 1 seconds less, +37% performance increase)

```
26-09 01:57:34.832|INFO |MainViewModelBase:Starting Library Install Size scan
26-09 02:08:18.705|INFO |MainViewModelBase:Finished Library Install Size scan
```


![image](https://user-images.githubusercontent.com/1389286/192221593-f200ac20-f400-43e1-aea4-f012a4352a4c.png)
