### PR TITLE
Add info for switching active theme

### DIFF
--- a/doc/tutorials/themes/installing.md
+++ b/doc/tutorials/themes/installing.md
@@ -15,3 +15,14 @@ Copy theme folder into `%AppData%\Playnite\Themes\Desktop|Fullscreen` directory.
 ### Portable Playnite installation
 
 Copy theme folder into `\Themes\Desktop|Fullscreen` folder inside Playnite's installation directory.
+
+Change active theme
+---------------------
+
+### Desktop view
+
+While in desktop view, go into **Settings > Appearance > Theme** & choose an installed theme via the dropdown
+
+### Fullscreen view
+
+While in fullscreen view, go into **Settings > Visuals > Theme** & choose an installed theme via the dropdown


### PR DESCRIPTION
This info for setting your active theme should really/also be on the "How to: Themes" page but I couldn't figure out how to edit that. 
https://github.com/JosefNemec/Playnite/wiki/How-to:-Themes

Info on how to change your active/applied theme isn't available anywhere that I could find. I could only find a reddit post with someone else asking the same question. We both assumed you could toggle a theme active in the Addons>Installed>Themes window (like how Firefox etc does it). _[That would also be a nice addition to the program.]_ 
My next guess was that in the main dropdown menu there was a Theme submenu, or View>Theme or Add-ons>Theme or Extensions>Theme or something where I could select my active theme. I was wrong again so I had to look through help docs and then just do an internet search.

It is also not intuitive that you have to activate Fullscreen mode separately before you can choose the theme for that view in settings (it would be helpful to show 2 options in the regular settings, one for Desktop Theme and one for Fullscreen Theme. I do see that there's a completely different Settings UI in fullscreen mode though so it's probably fine to leave that side as is). _[As a sidenote, I also assumed there would be a fullscreen button on the top-right like the steam big picture mode button in the steam ui.]_

Anyway, thanks for your work on this great program!

I have verified that:
- [x] These changes work, by building the application and testing them. [Not sure if this applies to docs but I did preview]
- [x] Pull request is targeting `devel` branch.
- [not sure if minor additions to docs is significant enough to be called a contributor] I added myself into [contributors file](https://github.com/JosefNemec/Playnite/blob/devel/source/Playnite.DesktopApp/Resources/contributors.txt) if I want to receive contribution credit in the application itself.
