### PR TITLE
Add main menu buttons to restart Playnite

### DIFF
--- a/source/Playnite.DesktopApp/Controls/Menus/MainMenu.cs
+++ b/source/Playnite.DesktopApp/Controls/Menus/MainMenu.cs
@@ -194,6 +194,7 @@ namespace Playnite.DesktopApp.Controls
             AddMenuChild(helpItem.Items, "LOCMenuIssues", mainModel.ReportIssueCommand);
             AddMenuChild(helpItem.Items, "LOCSDKDocumentation", GlobalCommands.NavigateUrlCommand, UrlConstants.SdkDocs);
             helpItem.Items.Add(new Separator());
+            AddMenuChild(helpItem.Items, "LOCCrashRestartPlaynite", mainModel.RestartApp);
             AddMenuChild(helpItem.Items, "LOCCrashRestartSafe", mainModel.RestartInSafeMode);
 
             // Patreon

--- a/source/Playnite.FullscreenApp/Themes/Fullscreen/Default/Views/HelpMenu.xaml
+++ b/source/Playnite.FullscreenApp/Themes/Fullscreen/Default/Views/HelpMenu.xaml
@@ -19,6 +19,10 @@
                    Margin="20,30,40,30" />
     </DataTemplate>
 
+    <DataTemplate x:Key="HelpMenuRestartPlayniteButtonTemplate">
+        <TextBlock Text="{DynamicResource LOCCrashRestartPlaynite}" VerticalAlignment="Center" />
+    </DataTemplate>
+
     <DataTemplate x:Key="HelpMenuSafeModeButtonTemplate">
         <TextBlock Text="{DynamicResource LOCCrashRestartSafe}" VerticalAlignment="Center" />
     </DataTemplate>

--- a/source/Playnite.FullscreenApp/ViewModels/HelpMenuViewModel.cs
+++ b/source/Playnite.FullscreenApp/ViewModels/HelpMenuViewModel.cs
@@ -20,6 +20,7 @@ namespace Playnite.FullscreenApp.ViewModels
 
         public RelayCommand CloseCommand => new RelayCommand(() => Close());
         public RelayCommand SendFeedbackCommand => new RelayCommand(() => SendFeedback());
+        public RelayCommand RestartAppCommand => new RelayCommand(() => RestartApp());
         public RelayCommand RestartInSafeModeCommand => new RelayCommand(() => RestartInSafeMode());
 
         public HelpMenuViewModel(
@@ -44,6 +45,12 @@ namespace Playnite.FullscreenApp.ViewModels
         {
             Close();
             NavigateUrlCommand.Navigate(PlayniteEnvironment.ReleaseChannel == ReleaseChannel.Beta ? UrlConstants.IssuesTesting : UrlConstants.Issues);
+        }
+
+        public void RestartApp()
+        {
+            Close();
+            MainModel.RestartAppSkipLibUpdate();
         }
 
         public void RestartInSafeMode()

--- a/source/Playnite.FullscreenApp/Windows/HelpMenuWindow.xaml
+++ b/source/Playnite.FullscreenApp/Windows/HelpMenuWindow.xaml
@@ -45,10 +45,14 @@
                     <ContentControl ContentTemplate="{DynamicResource HelpMenuHeaderTemplate}"
                                     Focusable="False" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" />
 
-                    <pctrls:ButtonEx x:Name="PART_ButtonPickRandomGame"
-                                     ContentTemplate="{DynamicResource HelpMenuSafeModeButtonTemplate}"
-                                     Command="{Binding RestartInSafeModeCommand}"
+                    <pctrls:ButtonEx x:Name="PART_ButtonRestartPlaynite"
+                                     ContentTemplate="{DynamicResource HelpMenuRestartPlayniteButtonTemplate}"
+                                     Command="{Binding RestartAppCommand}"
                                      pbeh:FocusBahaviors.OnVisibilityFocus="True" />
+
+                    <pctrls:ButtonEx x:Name="PART_ButtonSafeMode"
+                                     ContentTemplate="{DynamicResource HelpMenuSafeModeButtonTemplate}"
+                                     Command="{Binding RestartInSafeModeCommand}" />
 
                     <pctrls:ButtonEx x:Name="PART_ButtonFeedback"
                                      ContentTemplate="{DynamicResource HelpMenuFeedbackButtonTemplate}"

--- a/source/Playnite/ViewModels/MainViewModelBase.cs
+++ b/source/Playnite/ViewModels/MainViewModelBase.cs
@@ -141,6 +141,7 @@ namespace Playnite.ViewModels
         public RelayCommand CancelProgressCommand { get; private set; }
         public RelayCommand<object> OpenUpdatesCommand { get; private set; }
         public RelayCommand StartInteractivePowerShellCommand { get; private set; }
+        public RelayCommand RestartApp { get; private set; }
         public RelayCommand RestartInSafeMode { get; private set; }
         public RelayCommand BackupDataCommand { get; private set; }
         public RelayCommand RestoreDataBackupCommand { get; private set; }
@@ -213,6 +214,7 @@ namespace Playnite.ViewModels
                 }
             });
 
+            RestartApp = new RelayCommand(() => RestartAppSkipLibUpdate()); 
             RestartInSafeMode = new RelayCommand(() => RestartAppSafe());
             BackupDataCommand = new RelayCommand(() => BackupData());
             RestoreDataBackupCommand = new RelayCommand(() => RestoreDataBackup());
@@ -907,6 +909,12 @@ namespace Playnite.ViewModels
         public void RunShutdowScript()
         {
             RunAppScript(AppSettings.AppShutdownScript, "shutdown");
+        }
+
+        public void RestartAppSkipLibUpdate()
+        {
+            CloseView();
+            App.Restart(new CmdLineOptions { SkipLibUpdate = true });
         }
 
         public void RestartAppSafe()


### PR DESCRIPTION
I have verified that:
- [x] These changes work, by building the application and testing them.
- [x] Pull request is targeting `devel` branch.
- [x] I added myself into [contributors file](https://github.com/JosefNemec/Playnite/blob/devel/source/Playnite.DesktopApp/Resources/contributors.txt) if I want to receive contribution credit in the application itself.

Helps in these cases:

- Addons were updated but user didn't restart when prompted. Currently you have to manually close and open the app again.
- Until https://github.com/JosefNemec/Playnite/issues/1903 is done, there's no easy way to restart if a setting in a plugin requires it but even then, the previous point would apply in this case
- Current UI framework has issues has several issues related to DPI (E.g. https://github.com/JosefNemec/Playnite/issues/2719) , one of them being that Playnite won't properly render to the new DPI when moving it to another screen which results in general blurriness and currently the only way to fix this is by restarting the app so it properly renders in the target screen setup. This is nothing but a workaround but I think it could be an useful unintended temporary fix.

### Screenshots

Menus:

![image](https://user-images.githubusercontent.com/1389286/206963084-2c30401f-0d0d-4a09-8347-f4cf356f2e54.png)


![image](https://user-images.githubusercontent.com/1389286/206963047-abc0610a-12a5-4a68-ab25-3cff609c4ec9.png)

---

Example of blurriness. Original 1920x1080 125%DPI

![image](https://user-images.githubusercontent.com/1389286/206963994-9dcc4a8b-efc2-463c-a511-12ecc8df9c9e.png)

After moving to screen with 1920x1080 100% DPI. Blurriness is most noticeable in text rendering.

![image](https://user-images.githubusercontent.com/1389286/206964077-234ef209-30f9-43d3-bcec-93f70f92eafa.png)

After restarting in new screen blurriness is gone

![image](https://user-images.githubusercontent.com/1389286/206964280-04d7275f-1038-40eb-b8d8-f4c4f9724134.png)