### PR TITLE
Fix LastActivity not being updated to existing game on library update

### DIFF
--- a/source/Playnite/Database/GameDatabase.cs
+++ b/source/Playnite/Database/GameDatabase.cs
@@ -1279,7 +1279,11 @@ namespace Playnite.Database
                                     existingGameUpdated = true;
                                 }
 
-                                if (existingGame.LastActivity == null && newGame.LastActivity != null)
+                                // The LastActivity value of the newGame is only applied if newer than
+                                // the existing game, to prevent cases of DRM free games being launched without
+                                // the client or offline, which would prevent the date from being updated in the service
+                                if (newGame.LastActivity != null && 
+                                    (existingGame.LastActivity == null || newGame.LastActivity > existingGame.LastActivity))
                                 {
                                     existingGame.LastActivity = newGame.LastActivity;
                                     existingGameUpdated = true;


### PR DESCRIPTION
I have verified that:
- [x] These changes work, by building the application and testing them.
- [x] Pull request is targeting `devel` branch.
- [x] I added myself into [contributors file](https://github.com/JosefNemec/Playnite/blob/devel/source/Playnite.DesktopApp/Resources/contributors.txt) if I want to receive contribution credit in the application itself.

Current behavior: Only updates LastActivity if
- Existing game LastActivity is null

New behavior: Updates LastActivity if:
- Existing game LastActivity is null
- New game LastActivity is newer