### PR TITLE
Fix: Proton existing in Steam library causes install size scan error

### DIFF
--- a/source/Playnite.DesktopApp/Resources/contributors.txt
+++ b/source/Playnite.DesktopApp/Resources/contributors.txt
@@ -47,3 +47,4 @@ Jeshibu
 UrbanCMC
 WLTD
 LemmusLemmus
+NekuSoul

--- a/source/Playnite/Common/FileSystem.cs
+++ b/source/Playnite/Common/FileSystem.cs
@@ -398,6 +398,14 @@ namespace Playnite.Common
                 return 0;
             }
 
+            // Method will fail when checking a file that's not valid on Windows,
+            // for example files used by Proton containing a colon (:).
+            // 'Directory' will be null when encountering such a file.
+            if (fileInfo.Directory is null)
+            {
+                return 0;
+            }
+
             // From https://stackoverflow.com/a/3751135
             int result = Kernel32.GetDiskFreeSpaceW(fileInfo.Directory.Root.FullName, out uint sectorsPerCluster, out uint bytesPerSector, out _, out _);
             if (result == 0)


### PR DESCRIPTION
I have verified that:
- [ ] These changes work, by building the application and testing them.
- [ ] Pull request is targeting `devel` branch.
- [ ] I added myself into [contributors file](https://github.com/JosefNemec/Playnite/blob/devel/source/Playnite.DesktopApp/Resources/contributors.txt) if I want to receive contribution credit in the application itself.

Fixes #3280

Looks like files that are invalid to Windows will have their directory set to null, so I simply added a check for that:

![image](https://user-images.githubusercontent.com/1763357/216768602-7931c14f-b4ea-4220-ba4e-713f4d68587e.png)

Size scan now completes without errors, including the correct install size for Proton:

![image](https://user-images.githubusercontent.com/1763357/216768771-e9fc565c-93a5-4fe2-8158-bc6d40efe70a.png)
