### PR TITLE
Allow users to upload a custom launch video for fullscreen mode

### DIFF
--- a/source/Playnite.DesktopApp/Controls/SettingsSections/AppearanceIntros.xaml
+++ b/source/Playnite.DesktopApp/Controls/SettingsSections/AppearanceIntros.xaml
@@ -1,0 +1,25 @@
+﻿<UserControl x:Class="Playnite.DesktopApp.Controls.SettingsSections.AppearanceIntros"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:Playnite.DesktopApp.Controls.SettingsSections"
+             xmlns:pctrls="clr-namespace:Playnite.DesktopApp.Controls"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <StackPanel Margin="20">
+        <StackPanel Orientation="Horizontal">
+            <TextBlock Text="{DynamicResource LOCSettingsUploadFullscreenIntroVideo}" VerticalAlignment="Center"/>
+            <Button Content="{DynamicResource LOCSettingsBrowseVideo}" Command="{Binding UploadFullscreenIntroVideoCommand}" Margin="5,0,0,0"/>
+            <Button Content="{DynamicResource LOCSettingsClearVideo}" Command="{Binding ClearIntroVideoCommand}" Margin="5,0,0,0"/>
+        </StackPanel>
+        <TextBlock Text="{DynamicResource LOCSettingsPreviewIntroVideo}" Margin="0,30,0,0"/>
+        <Border BorderBrush="{DynamicResource PopupBorderBrush}" BorderThickness="1" Margin="0,5,0,0">
+            <pctrls:VideoClip Source="{Binding Settings.TemporaryFullscreenIntroUri, Mode=TwoWay}"/>
+        </Border>
+        <CheckBox IsChecked="{Binding Settings.EnableFullscreenIntro}"
+              Content="{DynamicResource LOCSettingsEnableFullscreenIntroVideo}"
+              Margin="0,10,0,0"/>
+    </StackPanel>
+
+</UserControl>

--- a/source/Playnite.DesktopApp/Controls/SettingsSections/AppearanceIntros.xaml.cs
+++ b/source/Playnite.DesktopApp/Controls/SettingsSections/AppearanceIntros.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace Playnite.DesktopApp.Controls.SettingsSections
+{
+    /// <summary>
+    /// Interaction logic for AppearanceIntros.xaml
+    /// </summary>
+    public partial class AppearanceIntros : UserControl
+    {
+        public AppearanceIntros()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/source/Playnite.DesktopApp/Controls/VideoClip.xaml
+++ b/source/Playnite.DesktopApp/Controls/VideoClip.xaml
@@ -1,0 +1,89 @@
+﻿<UserControl x:Class="Playnite.DesktopApp.Controls.VideoClip"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800"
+             x:Name="Video">
+    <UserControl.Resources>
+        <Style x:Key="VideoIconPanelStyle" TargetType="StackPanel">
+            <Setter Property="Orientation" Value="Horizontal"/>
+            <Setter Property="HorizontalAlignment" Value="Center"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
+            <Setter Property="Visibility" Value="Collapsed"/>
+            <Style.Triggers>
+                <MultiDataTrigger>
+                    <MultiDataTrigger.Conditions>
+                        <Condition Binding="{Binding IsValid, ElementName=Video}" Value="True"/>
+                        <Condition Binding="{Binding IsMouseOver, ElementName=Video}" Value="True"/>
+                    </MultiDataTrigger.Conditions>
+                    <Setter Property="Visibility" Value="Visible"/>
+                </MultiDataTrigger>
+            </Style.Triggers>
+        </Style>
+        <Style x:Key="VideoIconStyle" TargetType="ContentControl">
+            <Setter Property="Margin" Value="5,0,5,0"/>
+            <Setter Property="FontSize" Value="48"/>
+            <Setter Property="Opacity" Value="0.5"/>
+            <Style.Triggers>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter Property="Opacity" Value="1"/>
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+
+        <Style x:Key="NoVideoTextBlockStyle" TargetType="TextBlock" BasedOn="{StaticResource BaseTextBlockStyle}">
+            <Setter Property="VerticalAlignment" Value="Center"/>
+            <Setter Property="HorizontalAlignment" Value="Center"/>
+            <Setter Property="Margin" Value="40"/>
+            <Setter Property="FontSize" Value="24"/>
+            <Setter Property="Visibility" Value="Collapsed"/>
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding IsValid, ElementName=Video}" Value="False">
+                    <Setter Property="Visibility" Value="Visible"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+    </UserControl.Resources>
+    
+    <Grid>
+        <MediaElement x:Name="Media"
+                      Source="{Binding Source, ElementName=Video}"
+                      LoadedBehavior="Manual"
+                      Loaded="OnMediaLoaded"
+                      MediaEnded="OnMediaEnded"
+                      MediaFailed="OnMediaFailed"/>
+
+        <TextBlock Text="{DynamicResource LOCSettingsNoVideoLoaded}" Style="{StaticResource NoVideoTextBlockStyle}"/>
+
+        <StackPanel x:Name="ButtonPanel" Style="{StaticResource VideoIconPanelStyle}">
+            <Button Command="{Binding PlayCommand, ElementName=Video}"
+                    Visibility="{Binding IsPlaying, ElementName=Video, Converter={StaticResource InvertableBooleanToVisibilityConverter}, ConverterParameter=Inverted}">
+                <Button.Template>
+                    <ControlTemplate TargetType="Button">
+                        <ContentControl ContentTemplate="{StaticResource PlayVideoIconTemplate}"
+                                        Style="{StaticResource VideoIconStyle}"/>
+                    </ControlTemplate>
+                </Button.Template>
+            </Button>
+            <Button Command="{Binding PauseCommand, ElementName=Video}"
+                    Visibility="{Binding IsPlaying, ElementName=Video, Converter={StaticResource InvertableBooleanToVisibilityConverter}, ConverterParameter=Normal}">
+                <Button.Template>
+                    <ControlTemplate TargetType="Button">
+                        <ContentControl ContentTemplate="{StaticResource PauseVideoIconTemplate}"
+                                        Style="{StaticResource VideoIconStyle}"/>
+                    </ControlTemplate>
+                </Button.Template>
+            </Button>
+            <Button Command="{Binding StopCommand, ElementName=Video}">
+                <Button.Template>
+                    <ControlTemplate TargetType="Button">
+                        <ContentControl ContentTemplate="{StaticResource StopVideoIconTemplate}"
+                                        Style="{StaticResource VideoIconStyle}"/>
+                    </ControlTemplate>
+                </Button.Template>
+            </Button>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/source/Playnite.DesktopApp/Controls/VideoClip.xaml.cs
+++ b/source/Playnite.DesktopApp/Controls/VideoClip.xaml.cs
@@ -1,0 +1,101 @@
+﻿using Playnite.SDK;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace Playnite.DesktopApp.Controls
+{
+    /// <summary>
+    /// Interaction logic for VideoClip.xaml
+    /// </summary>
+    public partial class VideoClip : UserControl, INotifyPropertyChanged
+    {
+        public VideoClip()
+        {
+            InitializeComponent();
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        private bool isPlaying;
+        public bool IsPlaying
+        {
+            get => isPlaying;
+            private set
+            {
+                if (isPlaying != value)
+                {
+                    isPlaying = value;
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsPlaying)));
+                }
+            }
+        }
+
+        public static readonly DependencyProperty SourceProperty = DependencyProperty.Register(
+            nameof(Source), typeof(Uri), typeof(VideoClip), new PropertyMetadata(OnSourceChanged));
+
+        private static void OnSourceChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (sender is VideoClip videoClip)
+            {
+                videoClip.PropertyChanged?.Invoke(videoClip, new PropertyChangedEventArgs(nameof(IsValid)));
+            }
+        }
+
+        public Uri Source
+        {
+            get => (Uri)GetValue(SourceProperty);
+            set => SetValue(SourceProperty, value);
+        }
+
+        public bool IsValid => Source != null;
+
+        public ICommand PlayCommand => new RelayCommand(Play);
+        public ICommand PauseCommand => new RelayCommand(Pause);
+        public ICommand StopCommand => new RelayCommand(Stop);
+
+        private void Stop()
+        {
+            Media.Stop();
+            IsPlaying = false;
+        }
+
+        private void Pause()
+        {
+            Media.Pause();
+            IsPlaying = false;
+        }
+
+        private void Play()
+        {
+            Media.Play();
+            IsPlaying = true;
+        }
+        private void OnMediaLoaded(object sender, RoutedEventArgs e)
+        {
+            Pause();
+        }
+
+        private void OnMediaEnded(object sender, RoutedEventArgs e)
+        {
+            Stop();
+        }
+
+        private void OnMediaFailed(object sender, ExceptionRoutedEventArgs e)
+        {
+            Source = null;
+        }
+    }
+}

--- a/source/Playnite.DesktopApp/DesktopApplication.cs
+++ b/source/Playnite.DesktopApp/DesktopApplication.cs
@@ -74,7 +74,7 @@ namespace Playnite.DesktopApp
             Playnite.Dialogs.SetHandler(Dialogs);
         }
 
-        public override bool Startup()
+        public override async Task<bool> Startup()
         {
             if (!ConfigureApplication())
             {
@@ -85,14 +85,14 @@ namespace Playnite.DesktopApp
             AppUriHandler = MainModel.ProcessUriRequest;
             var isFirstStart = ProcessStartupWizard();
             MigrateDatabase();
-            OpenMainViewAsync(isFirstStart);
+            Task openViewTask = OpenMainViewAsync(isFirstStart);
             LoadTrayIcon();
 #pragma warning disable CS4014
             StartUpdateCheckerAsync();
             SendUsageDataAsync();
 #pragma warning restore CS4014
             ProcessArguments();
-            splashScreen?.Close(new TimeSpan(0));
+            await openViewTask;
             return true;
         }
 
@@ -180,7 +180,7 @@ namespace Playnite.DesktopApp
             }
         }
 
-        private async void OpenMainViewAsync(bool isFirstStart)
+        private async Task OpenMainViewAsync(bool isFirstStart)
         {
             if (!isFirstStart)
             {
@@ -207,6 +207,11 @@ namespace Playnite.DesktopApp
 
             MainModel.OpenView();
             CurrentNative.MainWindow = MainModel.Window.Window;
+
+            splashScreen?.Close(new TimeSpan(0));
+
+            CheckAndShowNahimicServicesWarning();
+            CheckAndShowElevatedRightsWarning();
 
             if (isFirstStart)
             {

--- a/source/Playnite.DesktopApp/Playnite.DesktopApp.csproj
+++ b/source/Playnite.DesktopApp/Playnite.DesktopApp.csproj
@@ -169,6 +169,9 @@
     <Compile Include="Controls\NumericDoubleBox.cs" />
     <Compile Include="Controls\LongNumericBox.cs" />
     <Compile Include="Controls\PathSelectionBox.cs" />
+    <Compile Include="Controls\SettingsSections\AppearanceIntros.xaml.cs">
+      <DependentUpon>AppearanceIntros.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Controls\SettingsSections\AppearanceListView.xaml.cs">
       <DependentUpon>AppearanceListView.xaml</DependentUpon>
     </Compile>
@@ -257,6 +260,9 @@
     <Compile Include="Controls\Menus\TrayContextMenu.cs" />
     <Compile Include="Controls\Menus\ViewSettingsMenu.cs" />
     <Compile Include="Controls\Menus\MainMenu.cs" />
+    <Compile Include="Controls\VideoClip.xaml.cs">
+      <DependentUpon>VideoClip.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Controls\Views\ExplorerPanel.cs" />
     <Compile Include="Controls\Views\Library.cs" />
     <Compile Include="Controls\Views\GameOverview.cs" />
@@ -592,6 +598,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="Controls\SettingsSections\AppearanceIntros.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Controls\SettingsSections\AppearanceListView.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
@@ -695,6 +705,10 @@
     <Page Include="Controls\SliderWithPopup.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Controls\VideoClip.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="GlobalResources.xaml">
       <Generator>MSBuild:Compile</Generator>

--- a/source/Playnite.DesktopApp/Resources/contributors.txt
+++ b/source/Playnite.DesktopApp/Resources/contributors.txt
@@ -49,3 +49,4 @@ WLTD
 LemmusLemmus
 Rioluu
 NekuSoul
+Liam Scholte

--- a/source/Playnite.DesktopApp/Themes/Desktop/Default/Media.xaml
+++ b/source/Playnite.DesktopApp/Themes/Desktop/Default/Media.xaml
@@ -30,6 +30,16 @@
     <TextBlock x:Key="BackupIcon" Text="&#xeea5;" FontFamily="{DynamicResource FontIcoFont}" />
     <TextBlock x:Key="RestoreBackupIcon" Text="&#xefd1;" FontFamily="{DynamicResource FontIcoFont}" />
 
+    <DataTemplate x:Key="PlayVideoIconTemplate">
+        <TextBlock Text="&#xeca6;" FontFamily="{DynamicResource FontIcoFont}" Foreground="{DynamicResource TextBrush}" FontWeight="Light"/>
+    </DataTemplate>
+    <DataTemplate x:Key="PauseVideoIconTemplate">
+        <TextBlock Text="&#xeca5;" FontFamily="{DynamicResource FontIcoFont}" Foreground="{DynamicResource TextBrush}" FontWeight="Light"/>
+    </DataTemplate>
+    <DataTemplate x:Key="StopVideoIconTemplate">
+        <TextBlock Text="&#xecb1;" FontFamily="{DynamicResource FontIcoFont}" Foreground="{DynamicResource TextBrush}" FontWeight="Light"/>
+    </DataTemplate>
+
     <TextBlock x:Key="ClearTextIcon" Text="&#xef00;" FontFamily="{DynamicResource FontIcoFont}"/>
     <TextBlock x:Key="SearchTextIcon" Text="&#xed11;" FontFamily="{DynamicResource FontIcoFont}" />
 

--- a/source/Playnite.DesktopApp/Windows/SettingsWindow.xaml
+++ b/source/Playnite.DesktopApp/Windows/SettingsWindow.xaml
@@ -60,6 +60,7 @@
                     <TreeViewItem Header="{DynamicResource LOCListViewLabel}" Tag="{x:Static p:DesktopSettingsPage.AppearanceListView}" />
                     <TreeViewItem Header="{DynamicResource LOCSettingsLayoutLabel}" Tag="{x:Static p:DesktopSettingsPage.AppearanceLayout}" />
                     <TreeViewItem Header="{DynamicResource LOCSettingsTopPanelLabel}" Tag="{x:Static p:DesktopSettingsPage.AppearanceTopPanel}" />
+                    <TreeViewItem Header="{DynamicResource LOCSettingsIntroLabel}" Tag="{x:Static p:DesktopSettingsPage.AppearanceIntros}" />
                 </TreeViewItem>
                 <TreeViewItem Header="{DynamicResource LOCSettingsSearch}" Tag="{x:Static p:DesktopSettingsPage.Search}" />
                 <TreeViewItem Header="{DynamicResource LOCSettingsUpdating}" Tag="{x:Static p:DesktopSettingsPage.Updates}" />

--- a/source/Playnite.FullscreenApp/Playnite.FullscreenApp.csproj
+++ b/source/Playnite.FullscreenApp/Playnite.FullscreenApp.csproj
@@ -184,6 +184,9 @@
     <Compile Include="ViewModels\NotificationsViewModel.cs" />
     <Compile Include="ViewModels\MainMenuViewModel.cs" />
     <Compile Include="ViewModels\SettingsViewModel.cs" />
+    <Compile Include="Windows\IntroWindow.xaml.cs">
+      <DependentUpon>IntroWindow.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Windows\MultiItemSelectionWindow.xaml.cs">
       <DependentUpon>MultiItemSelectionWindow.xaml</DependentUpon>
     </Compile>
@@ -462,6 +465,10 @@
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Page Include="Windows\IntroWindow.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Windows\MultiItemSelectionWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/source/Playnite.FullscreenApp/Windows/IntroWindow.xaml
+++ b/source/Playnite.FullscreenApp/Windows/IntroWindow.xaml
@@ -1,0 +1,21 @@
+﻿<Window x:Class="Playnite.FullscreenApp.Windows.IntroWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:Playnite.FullscreenApp.Windows"
+        mc:Ignorable="d"
+        Title="Playnite"
+        Background="Black"
+        WindowStyle="None"
+        x:Name="Window">
+    <Grid>
+        <MediaElement x:Name="Media"
+                      Source="{Binding Source, ElementName=Window}"
+                      MediaEnded="Media_MediaEnded"
+                      MediaFailed="Media_MediaEnded"
+                      Stretch="UniformToFill"
+                      VerticalAlignment="Center"
+                      HorizontalAlignment="Center"/>
+    </Grid>
+</Window>

--- a/source/Playnite.FullscreenApp/Windows/IntroWindow.xaml.cs
+++ b/source/Playnite.FullscreenApp/Windows/IntroWindow.xaml.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Configuration;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+
+namespace Playnite.FullscreenApp.Windows
+{
+    /// <summary>
+    /// Interaction logic for IntroWindow.xaml
+    /// </summary>
+    public partial class IntroWindow : Window
+    {
+        public event EventHandler IntroEnded;
+        public IntroWindow()
+        {
+            Loaded += OnLoaded;
+            InitializeComponent();
+        }
+
+        public static readonly DependencyProperty SourceProperty = DependencyProperty.Register(
+           nameof(Source), typeof(Uri), typeof(IntroWindow));
+
+
+        public Uri Source
+        {
+            get => (Uri)GetValue(SourceProperty);
+            set => SetValue(SourceProperty, value);
+        }
+
+        private void Media_MediaEnded(object sender, RoutedEventArgs e)
+        {
+            IntroEnded?.Invoke(this, EventArgs.Empty);
+        }
+
+        private void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            //This is a small hack to prevent an annoying white flash when opening a WPF window.
+            //Basically start the window in minimized state then maximize it after it is loaded.
+            Activate();
+            WindowState = WindowState.Maximized;
+        }
+    }
+}

--- a/source/Playnite/Localization/LocSource.xaml
+++ b/source/Playnite/Localization/LocSource.xaml
@@ -291,6 +291,7 @@ Selecting "add to exclusion list" option will prevent games from being imported 
     <sys:String x:Key="LOCSettingsLabel">Settings</sys:String>
     <sys:String x:Key="LOCSettingsGeneralLabel">General</sys:String>
     <sys:String x:Key="LOCSettingsTopPanelLabel">Top panel</sys:String>
+    <sys:String x:Key="LOCSettingsIntroLabel">Launch Video</sys:String>
     <sys:String x:Key="LOCSettingsAppearanceLabel">Appearance</sys:String>
     <sys:String x:Key="LOCSettingsGameDetailsLabel">Game Details</sys:String>
     <sys:String x:Key="LOCSettingsLayoutLabel">Layout</sys:String>
@@ -299,6 +300,13 @@ Selecting "add to exclusion list" option will prevent games from being imported 
     <sys:String x:Key="LOCSettingsInputLabel">Input</sys:String>
     <sys:String x:Key="LOCSettingsPerformanceLabel">Performance</sys:String>
     <sys:String x:Key="LOCSettingsMetadataLabel">Metadata</sys:String>
+    <sys:String x:Key="LOCSettingsUploadFullscreenIntroVideo">Upload fullscreen launch video</sys:String>
+    <sys:String x:Key="LOCSettingsEnableFullscreenIntroVideo">Play video when launching fullscreen</sys:String>
+    <sys:String x:Key="LOCSettingsFullscreenIntroVideoError">Failed to set fullscreen intro video.</sys:String>
+    <sys:String x:Key="LOCSettingsPreviewIntroVideo">Preview</sys:String>
+    <sys:String x:Key="LOCSettingsNoVideoLoaded">No video loaded</sys:String>
+    <sys:String x:Key="LOCSettingsBrowseVideo">Browse</sys:String>
+    <sys:String x:Key="LOCSettingsClearVideo">Clear</sys:String>
     <sys:String x:Key="LOCSettingsUpdating">Updating</sys:String>
     <sys:String x:Key="LOCSettingsSearch">Search</sys:String>
     <sys:String x:Key="LOCSettingsBackup">Backup</sys:String>

--- a/source/Playnite/Localization/LocalizationKeys.cs
+++ b/source/Playnite/Localization/LocalizationKeys.cs
@@ -1062,6 +1062,10 @@ namespace Playnite
         /// </summary>
         public const string SettingsTopPanelLabel = "LOCSettingsTopPanelLabel";
         /// <summary>
+        /// Launch Video
+        /// </summary>
+        public const string SettingsIntroLabel = "LOCSettingsIntroLabel";
+        /// <summary>
         /// Appearance
         /// </summary>
         public const string SettingsAppearanceLabel = "LOCSettingsAppearanceLabel";
@@ -1093,6 +1097,34 @@ namespace Playnite
         /// Metadata
         /// </summary>
         public const string SettingsMetadataLabel = "LOCSettingsMetadataLabel";
+        /// <summary>
+        /// Upload fullscreen launch video
+        /// </summary>
+        public const string SettingsUploadFullscreenIntroVideo = "LOCSettingsUploadFullscreenIntroVideo";
+        /// <summary>
+        /// Play video when launching fullscreen
+        /// </summary>
+        public const string SettingsEnableFullscreenIntroVideo = "LOCSettingsEnableFullscreenIntroVideo";
+        /// <summary>
+        /// Failed to set fullscreen intro video.
+        /// </summary>
+        public const string SettingsFullscreenIntroVideoError = "LOCSettingsFullscreenIntroVideoError";
+        /// <summary>
+        /// Preview
+        /// </summary>
+        public const string SettingsPreviewIntroVideo = "LOCSettingsPreviewIntroVideo";
+        /// <summary>
+        /// No video loaded
+        /// </summary>
+        public const string SettingsNoVideoLoaded = "LOCSettingsNoVideoLoaded";
+        /// <summary>
+        /// Browse
+        /// </summary>
+        public const string SettingsBrowseVideo = "LOCSettingsBrowseVideo";
+        /// <summary>
+        /// Clear
+        /// </summary>
+        public const string SettingsClearVideo = "LOCSettingsClearVideo";
         /// <summary>
         /// Updating
         /// </summary>
@@ -4185,6 +4217,14 @@ namespace Playnite
         /// When disabled, commands won't be included in default search until # prefix is used.
         /// </summary>
         public const string SearchIncludeCommandsInDefaultTooltip = "LOCSearchIncludeCommandsInDefaultTooltip";
+        /// <summary>
+        /// Support search using acronyms for name filter
+        /// </summary>
+        public const string NameFilterSearchWithAcronyms = "NameFilterSearchWithAcronyms";
+        /// <summary>
+        /// When enabled, search results will include items whose acronym matches the search term.
+        /// </summary>
+        public const string NameFilterSearchWithAcronymsTooltip = "NameFilterSearchWithAcronymsTooltip";
         /// <summary>
         /// Fields to be displayed for game results:
         /// </summary>

--- a/source/Playnite/Settings/PlaynitePaths.cs
+++ b/source/Playnite/Settings/PlaynitePaths.cs
@@ -28,6 +28,7 @@ namespace Playnite
         public const string FullscreenConfigFileName = "fullscreenConfig.json";
         public const string WindowPositionsFileName = "windowPositions.json";
         public const string LocalizationsDirName = "Localization";
+        public const string IntrosDirName = "Intros";
 
         public static string UserProgramDataPath { get; }
         public static string ProgramPath { get; }
@@ -64,6 +65,9 @@ namespace Playnite
         public static string SafeStartupFlagFile { get; }
         public static string BackupActionFile { get; }
         public static string RestoreBackupActionFile { get; }
+
+        public static string IntrosPath { get; }
+        public static string FullscreenIntroFilePath { get; }
 
         public static bool IsPortable { get; }
 
@@ -106,6 +110,9 @@ namespace Playnite
             SafeStartupFlagFile = Path.Combine(ConfigRootPath, "safestart.flag");
             BackupActionFile = Path.Combine(ConfigRootPath, "backup.json");
             RestoreBackupActionFile = Path.Combine(ConfigRootPath, "restoreBackup.json");
+
+            IntrosPath = Path.Combine(ConfigRootPath, IntrosDirName);
+            FullscreenIntroFilePath = Path.Combine(IntrosPath, "FullscreenIntro.mp4");
         }
 
         public static string ExpandVariables(string inputString, string emulatorDir = null, bool fixSeparators = false)

--- a/source/Playnite/Settings/PlayniteSettings.cs
+++ b/source/Playnite/Settings/PlayniteSettings.cs
@@ -48,7 +48,8 @@ namespace Playnite
         Updates = 22,
         AppearanceListView = 23,
         Search = 24,
-        Backup = 25
+        Backup = 25,
+        AppearanceIntros = 26
     }
 
     public enum AccessibilityInterfaceOptions
@@ -1134,6 +1135,29 @@ namespace Playnite
         public string InstallInstanceId
         {
             get; set;
+        }
+
+        private Uri temporaryFullscreenIntroUri;
+        [JsonIgnore]
+        public Uri TemporaryFullscreenIntroUri
+        {
+            get => temporaryFullscreenIntroUri;
+            set
+            {
+                temporaryFullscreenIntroUri = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private bool enableFullscreenIntro;
+        public bool EnableFullscreenIntro
+        {
+            get => enableFullscreenIntro;
+            set
+            {
+                enableFullscreenIntro = value;
+                OnPropertyChanged();
+            }
         }
 
         private List<string> disabledPlugins = new List<string>();
@@ -2247,6 +2271,8 @@ namespace Playnite
             InstallInstanceId = Guid.NewGuid().ToString();
             ItemSpacingMargin = GetItemSpacingMargin();
             FullscreenItemSpacingMargin = GetFullscreenItemSpacingMargin();
+
+            TemporaryFullscreenIntroUri = new Uri(PlaynitePaths.FullscreenIntroFilePath);
             UpdateGridItemHeight();
         }
 


### PR DESCRIPTION
I have verified that:
- [x] These changes work, by building the application and testing them.
- [x] Pull request is targeting `devel` branch.
- [x] I added myself into [contributors file](https://github.com/JosefNemec/Playnite/blob/devel/source/Playnite.DesktopApp/Resources/contributors.txt) if I want to receive contribution credit in the application itself.

**Description**
Note: I am not aware of a feature request on Github for this, but I can create one if needed.

This allows users to set a custom launch video when launching fullscreen Playnite. This will allow users to create a more console-like experience if they desire.

See https://drive.google.com/file/d/1Tz0OFakTwRsSJOGSaef78xnfjFu03JWx/view?usp=sharing for a demo.  The video files I tested with were pulled from https://playnite.link/forum/thread-686.html, so thank you to whoever created those. Although they aren't part of my PR. I was just testing with them.

**Implementation Notes**
Upon saving out of the settings page, the uploaded video will be saved to a specific location in the playnite's config location. When launching fullscreen mode, the launch video is retrieved from that location.

There are some modifications to the Playnite initialization code. In particular the addition of some `await` calls. In doing so, I moved a couple of warning dialogs (specifically the administrator permission warning and the Nahilic services warning) because with the addition of awaits, those warnings would have appeared after the library updating is completed which is a non-deterministic time for it to appear and may randomly interrupt a user. Moving it ensures that it shows up immediately once the main Playnite window opens.

Video is being played by a MediaElement in WPF. I am not actually sure what formats this supports, but I know it has been working with MP4 for me.

**Outstanding Issues**
I have realized that Windows Media Pack and/or Windows Media Player (which are optional features installed with Windows) must be installed for this to work correctly. I'm going to explore this a bit more and ensure graceful handling for when this feature is not present. The current behaviour in this situation is as if you uploaded an invalid video, which is effectively the same as clearing the video (shown in the demo). There are certain installations of Windows (namely "N" versions of Windows) that don't have this installed by default, so I think it might be worth adding a note on the settings page about this dependency.

Would probably be good for this to also be included in the backup/restore feature, but currently it is not.

**Testing performed**
* Tested with different intro videos -- some with sound, some without sound
* Tested with launch video enabled but no video is uploaded
* Tested with launch video uploaded but launch video is disabled
* Tested with and without the splash screen enabled (I intend to use without the splash screen)
* Tested that Playnite's fullscreen audio is not playing alongside the launch video
*  * This is a big reason why I even went out of my way to do this feature. Because otherwise with some clever scripting, you could accomplish this. Or could probably do the same with an extension to get a similar UI to what I built, but I'd expect the same sound problem.
