### PR TITLE
Show game name in the confirmation dialog before removing game

### DIFF
--- a/source/Playnite/GamesEditor.cs
+++ b/source/Playnite/GamesEditor.cs
@@ -859,7 +859,7 @@ namespace Playnite
                 {
                     addToExclusionList = true;
                 }
-                else if (result == options[2])
+                else if (result == null || result == options[2])
                 {
                     return;
                 }

--- a/source/Playnite/GamesEditor.cs
+++ b/source/Playnite/GamesEditor.cs
@@ -27,6 +27,7 @@ using System.Collections.ObjectModel;
 using Playnite.Scripting.PowerShell;
 using Playnite.Windows;
 using System.Windows.Input;
+using System.Security.Cryptography;
 
 namespace Playnite
 {
@@ -833,7 +834,7 @@ namespace Playnite
             if (game.IsCustomGame)
             {
                 if (Dialogs.ShowMessage(
-                    "LOCGameRemoveAskMessage",
+                    string.Format(resources.GetString("LOCGameRemoveAskMessage"), game.Name),
                     "LOCGameRemoveAskTitle",
                     MessageBoxButton.YesNo,
                     MessageBoxImage.Question) != MessageBoxResult.Yes)
@@ -850,7 +851,7 @@ namespace Playnite
                     new MessageBoxOption("LOCNoLabel", false, true)
                 };
                 var result = Dialogs.ShowMessage(
-                    "LOCGameRemoveAskMessageIgnoreOption",
+                    string.Format(resources.GetString("LOCGameRemoveAskMessageIgnoreOption"), game.Name),
                     "LOCGameRemoveAskTitle",
                     MessageBoxImage.Question,
                     options);

--- a/source/Playnite/Localization/LocSource.xaml
+++ b/source/Playnite/Localization/LocSource.xaml
@@ -60,9 +60,9 @@ If you want to help us fix this issue, please send diagnostic information. Thank
     <sys:String x:Key="LOCGameRemoveAskTitle">Remove Game(s)?</sys:String>
     <sys:String x:Key="LOCGameRemoveRunningError">Cannot remove - Game or installer is running. </sys:String>
     <sys:String x:Key="LOCGameUninstallRunningError">Cannot uninstall - Game is running.</sys:String>
-    <sys:String x:Key="LOCGameRemoveAskMessage" xml:space="preserve">Are you sure you want to remove this game?</sys:String>
+    <sys:String x:Key="LOCGameRemoveAskMessage" xml:space="preserve">Are you sure you want to remove {0}?</sys:String>
     <sys:String x:Key="LOCGamesRemoveAskMessage" xml:space="preserve">Are you sure you want to remove {0} games?</sys:String>
-    <sys:String x:Key="LOCGameRemoveAskMessageIgnoreOption" xml:space="preserve">Are you sure you want to remove this game?
+    <sys:String x:Key="LOCGameRemoveAskMessageIgnoreOption" xml:space="preserve">Are you sure you want to remove {0}?
 
 Selecting "add to exclusion list" option will prevent game from being imported again next time library is updated.</sys:String>
     <sys:String x:Key="LOCGamesRemoveAskMessageIgnoreOption" xml:space="preserve">Are you sure you want to remove {0} games?


### PR DESCRIPTION
I have verified that:
- [x] These changes work, by building the application and testing them.
- [x] Pull request is targeting `devel` branch.
- [x] I added myself into [contributors file](https://github.com/JosefNemec/Playnite/blob/devel/source/Playnite.DesktopApp/Resources/contributors.txt) if I want to receive contribution credit in the application itself.

**Description**
Shows the game name in the confirmation dialog before it is removed. This addresses https://github.com/JosefNemec/Playnite/issues/2983
<img width="444" alt="image" src="https://user-images.githubusercontent.com/6503344/221102587-9afa834e-053d-4a02-a6d7-e7a5b0ba25f3.png">

**Testing Performed**
Tested with a steam game and an emulator game (they use different strings)