### PR TITLE
Update importGames.ps1 to support portable install and relative path

### DIFF
--- a/source/Playnite/Emulation/Emulators/ScummVM/importGames.ps1
+++ b/source/Playnite/Emulation/Emulators/ScummVM/importGames.ps1
@@ -38,7 +38,7 @@ function Get-IniContent()
 $scummvmConfig = Join-Path $ImportArgs.ScanDirectory "scummvm.ini" #Import Directory
 if (!(Test-Path $scummvmConfig))
 {
-	$scummvmConfig = Join-Path $env:APPDATA "ScummVM\scummvm.ini" #Default (appdata) directory
+    $scummvmConfig = Join-Path $env:APPDATA "ScummVM\scummvm.ini" #Default (appdata) directory
     if (!(Test-Path $scummvmConfig))
     {
         $ImportArgs.PlayniteApi.Dialogs.ShowErrorMessage("Couldn't find ScummVM config file at $scummvmConfig", "") | Out-Null
@@ -51,14 +51,13 @@ foreach ($key in $config.Keys)
 {
     if ($config[$key].gameid)
     {
-		$romPath = Join-Path $config[$key].path $key
+        $romPath = Join-Path $config[$key].path $key
         if (-not [System.IO.Path]::IsPathRooted($romPath)) # Check if it's a relative path
         {
             $romPath = Join-Path $ImportArgs.ScanDirectory $romPath
         }
 		
-		$anyFunc = [Func[string,bool]]{ param($a) [System.IO.Path]::GetFullPath($a) -ieq [System.IO.Path]::GetFullPath($romPath) }
-		
+        $anyFunc = [Func[string,bool]]{ param($a) [System.IO.Path]::GetFullPath($a) -ieq [System.IO.Path]::GetFullPath($romPath) }	
         if ([System.Linq.Enumerable]::Any($ImportArgs.ImportedFiles, $anyFunc))
         {
             continue

--- a/source/Playnite/Emulation/Emulators/ScummVM/importGames.ps1
+++ b/source/Playnite/Emulation/Emulators/ScummVM/importGames.ps1
@@ -34,10 +34,11 @@ function Get-IniContent()
     return $ini
 }
 
-$scummvmConfig = Join-Path $env:APPDATA "ScummVM\scummvm.ini"
+#switch the below $scummvmConfig lines to change the default and fallback scan directories.
+$scummvmConfig = Join-Path $ImportArgs.ScanDirectory "scummvm.ini" #Import Directory
 if (!(Test-Path $scummvmConfig))
 {
-    $scummvmConfig = Join-Path $ImportArgs.ScanDirectory "scummvm.ini"
+	$scummvmConfig = Join-Path $env:APPDATA "ScummVM\scummvm.ini" #Default (appdata) directory
     if (!(Test-Path $scummvmConfig))
     {
         $ImportArgs.PlayniteApi.Dialogs.ShowErrorMessage("Couldn't find ScummVM config file at $scummvmConfig", "") | Out-Null
@@ -50,8 +51,14 @@ foreach ($key in $config.Keys)
 {
     if ($config[$key].gameid)
     {
-        $romPath = Join-Path $config[$key].path $key        
-        $anyFunc = [Func[string,bool]]{ param($a) $a.Equals($romPath, 'OrdinalIgnoreCase') }
+		$romPath = Join-Path $config[$key].path $key
+        if (-not [System.IO.Path]::IsPathRooted($romPath)) # Check if it's a relative path
+        {
+            $romPath = Join-Path $ImportArgs.ScanDirectory $romPath
+        }
+		
+		$anyFunc = [Func[string,bool]]{ param($a) [System.IO.Path]::GetFullPath($a) -ieq [System.IO.Path]::GetFullPath($romPath) }
+		
         if ([System.Linq.Enumerable]::Any($ImportArgs.ImportedFiles, $anyFunc))
         {
             continue


### PR DESCRIPTION
Two changes:

1) Search for scummvm.ini in the scan directory first, then search appdata if not found.

2) Updated the $rompath construction to support relative paths in the scummvm.ini file. $anyFunc also had to be updated to properly identify games already imported using relative paths.

**Code contributions (pull requests) are currently not being accepted while majority of code base is being rewritten for Playnite 11.**

**Please wait with any pull requests after P11 is at least in beta state.**