### PR TITLE
Properly close Playnite before system shutdown

### DIFF
--- a/source/Playnite.FullscreenApp/ViewModels/MainMenuViewModel.cs
+++ b/source/Playnite.FullscreenApp/ViewModels/MainMenuViewModel.cs
@@ -51,6 +51,12 @@ namespace Playnite.FullscreenApp.ViewModels
             this.MainModel = mainModel;
         }
 
+        private void QuitApplication()
+        {
+            MainModel.CloseView();
+            MainModel.App.Quit();
+        }
+
         public bool? OpenView()
         {
             return window.CreateAndOpenDialog(this);
@@ -64,8 +70,7 @@ namespace Playnite.FullscreenApp.ViewModels
         public void Shutdown()
         {
             Close();
-            MainModel.CloseView();
-            MainModel.App.Quit();
+            QuitApplication();
         }
 
         public void SwitchToDesktopMode()
@@ -129,17 +134,26 @@ namespace Playnite.FullscreenApp.ViewModels
                 return;
             }
 
-            if (!PlayniteEnvironment.IsDebuggerAttached)
+            // First add a custom Application.Exit event handler which gets called on application exit. This handler performs the comuter shutdown.
+            PlayniteApplication.CurrentNative.Exit += delegate
             {
-                try
+                if (!PlayniteEnvironment.IsDebuggerAttached)
                 {
-                    Computer.Shutdown();
+                    logger.Info("Shutting down computer");
+
+                    try
+                    {
+                        Computer.Shutdown();
+                    }
+                    catch (Exception e)
+                    {
+                        logger.Error(e, "Failed to shutdown the computer.");
+                    }
                 }
-                catch (Exception e)
-                {
-                    Dialogs.ShowErrorMessage(e.Message, "");
-                }
-            }
+            };
+
+            // Then quit Playnite regularly.
+            QuitApplication();
         }
 
         public void HibernateSystem()
@@ -192,17 +206,26 @@ namespace Playnite.FullscreenApp.ViewModels
                 return;
             }
 
-            if (!PlayniteEnvironment.IsDebuggerAttached)
+            // First add a custom Application.Exit event handler which gets called on application exit. This handler performs the comuter restart.
+            PlayniteApplication.CurrentNative.Exit += delegate
             {
-                try
+                if (!PlayniteEnvironment.IsDebuggerAttached)
                 {
-                    Computer.Restart();
+                    logger.Info("Restarting computer");
+
+                    try
+                    {
+                        Computer.Restart();
+                    }
+                    catch (Exception e)
+                    {
+                        logger.Error(e, "Failed to restart the computer.");
+                    }
                 }
-                catch (Exception e)
-                {
-                    Dialogs.ShowErrorMessage(e.Message, "");
-                }
-            }
+            };
+
+            // Then quit Playnite regularly.
+            QuitApplication();
         }
 
         public void LockSystem()


### PR DESCRIPTION
> **Code contributions (pull requests) are currently not being accepted while majority of code base is being rewritten for Playnite 11.**
> **Please wait with any pull requests after P11 is at least in beta state.**

At first excuse me, but I read the above statement too late. Even if this PR will not be accepted, I would be happy to see my changes implemented in version 11 of Playnite.

**PR description:**
With this PR the fullscreen application of Playnite gets properly closed if a system shutdown or restart is requested by the user. The current implementation only runs the Windows `shutdown` command and during the shutdown the Playnite process will be closed by the system.
Now, the Playnite application is closed before the `shutdown` command is called. This ensures especially that any custom scripts that should be run on application exit will be definitely executed.