### PR TITLE
Add close button to Explorer Panel

### DIFF
--- a/source/Playnite.DesktopApp/Controls/Views/ExplorerPanel.cs
+++ b/source/Playnite.DesktopApp/Controls/Views/ExplorerPanel.cs
@@ -20,12 +20,13 @@ namespace Playnite.DesktopApp.Controls.Views
 {
     [TemplatePart(Name = "PART_SelectFields", Type = typeof(Selector))]
     [TemplatePart(Name = "PART_SelectItems", Type = typeof(Selector))]
+    [TemplatePart(Name = "PART_ButtonClose", Type = typeof(ButtonBase))]
     public class ExplorerPanel : Control
     {
         private readonly DesktopAppViewModel mainModel;
         private Selector SelectFields;
         private Selector SelectItems;
-
+        private ButtonBase ButtonClose;
         static ExplorerPanel()
         {
             DefaultStyleKeyProperty.OverrideMetadata(typeof(ExplorerPanel), new FrameworkPropertyMetadata(typeof(ExplorerPanel)));
@@ -78,6 +79,12 @@ namespace Playnite.DesktopApp.Controls.Views
                     Selector.ItemsSourceProperty,
                     mainModel.DatabaseExplorer,
                     nameof(DatabaseExplorer.FieldValues));
+            }
+
+            ButtonClose = Template.FindName("PART_ButtonClose", this) as ButtonBase;
+            if (ButtonClose != null)
+            {
+                ButtonClose.Command = mainModel.ToggleExplorerPanelCommand;
             }
         }
     }

--- a/source/Playnite.DesktopApp/Themes/Desktop/Default/Views/ExplorerPanel.xaml
+++ b/source/Playnite.DesktopApp/Themes/Desktop/Default/Views/ExplorerPanel.xaml
@@ -25,8 +25,15 @@
                             </Style>
                         </Border.Style>
                         <DockPanel Background="{TemplateBinding Background}">
-                            <ComboBox Name="PART_SelectFields" MaxDropDownHeight="Auto"
-                                  DockPanel.Dock="Top" Margin="5,8,5,8" />
+                            <DockPanel DockPanel.Dock="Top" LastChildFill="True"
+                                       Margin="5,8,5,8">
+                                <Button Content="r" FontFamily="Marlett"
+                                        Style="{StaticResource SimpleButton}"
+                                        DockPanel.Dock="Right" Margin="0,0,5,0"
+                                        Name="PART_ButtonClose"/>
+                                <ComboBox Name="PART_SelectFields" MaxDropDownHeight="Auto"
+                                          DockPanel.Dock="Left" Margin="0,0,8,0" />
+                            </DockPanel>
                             <ListBox Name="PART_SelectItems"
                                  DockPanel.Dock="Top" Margin="5,0,5,8"                                      
                                  BorderThickness="0"


### PR DESCRIPTION
**Code contributions (pull requests) are currently not being accepted while majority of code base is being rewritten for Playnite 11.**

**Please wait with any pull requests after P11 is at least in beta state.**

Preview:

![gQHby05OgZ](https://github.com/user-attachments/assets/d7d1a498-2ee3-4093-8eb9-9e7b21f33041)

Another option was to place it above but I didn't like how it left a lot of space unused for this simple button so I discarded the idea:
![GdE8EMWcaw](https://github.com/user-attachments/assets/acb4c781-7b2c-4af5-b3d8-11283d149f2f)

