### PR TITLE
Create jgenesis emulator profile

### DIFF
--- a/source/Playnite/Emulation/Emulators/jgenesis/emulator.yaml
+++ b/source/Playnite/Emulation/Emulators/jgenesis/emulator.yaml
@@ -1,0 +1,57 @@
+Id: jgenesis
+Name: jgenesis
+Website: 'https://github.com/jsgroth/jgenesis'
+Profiles:
+  - Name: Master System
+    StartupExecutable: ^jgenesis-cli\.exe$
+    StartupArguments: '--hardware MasterSystem --fullscreen -f "{ImagePath}"'
+    Platforms: [sega_mastersystem]
+    ImageExtensions: [sms, zip, 7z]
+
+  - Name: Game Gear
+    StartupExecutable: ^jgenesis-cli\.exe$
+    StartupArguments: '--hardware MasterSystem --fullscreen -f "{ImagePath}"'
+    Platforms: [sega_gamegear]
+    ImageExtensions: [gg, zip, 7z]
+
+  - Name: Genesis
+    StartupExecutable: ^jgenesis-cli\.exe$
+    StartupArguments: '--hardware Genesis --fullscreen -f "{ImagePath}"'
+    Platforms: [sega_genesis]
+    ImageExtensions: [gen, md, bin, smd, zip, 7z]
+
+  - Name: Sega CD
+    StartupExecutable: ^jgenesis-cli\.exe$
+    StartupArguments: '--hardware SegaCd --fullscreen -f "{ImagePath}"'
+    Platforms: [sega_cd]
+    ImageExtensions: [cue, chd, zip, 7z]
+
+  - Name: Sega 32X
+    StartupExecutable: ^jgenesis-cli\.exe$
+    StartupArguments: '--hardware Sega32X --fullscreen -f "{ImagePath}"'
+    Platforms: [sega_32x]
+    ImageExtensions: [32x, bin, zip, 7z]
+
+  - Name: NES
+    StartupExecutable: ^jgenesis-cli\.exe$
+    StartupArguments: '--hardware Nes --fullscreen -f "{ImagePath}"'
+    Platforms: [nintendo_nes]
+    ImageExtensions: [nes, zip, 7z]
+
+  - Name: SNES
+    StartupExecutable: ^jgenesis-cli\.exe$
+    StartupArguments: '--hardware Snes --fullscreen -f "{ImagePath}"'
+    Platforms: [nintendo_super_nes]
+    ImageExtensions: [sfc, smc, zip, 7z]
+
+  - Name: Game Boy
+    StartupExecutable: ^jgenesis-cli\.exe$
+    StartupArguments: '--hardware GameBoy --fullscreen -f "{ImagePath}"'
+    Platforms: [nintendo_gameboy]
+    ImageExtensions: [gb, zip, 7z]
+
+  - Name: Game Boy Color
+    StartupExecutable: ^jgenesis-cli\.exe$
+    StartupArguments: '--hardware GameBoy --fullscreen -f "{ImagePath}"'
+    Platforms: [nintendo_gameboycolor]
+    ImageExtensions: [gbc, zip, 7z]

--- a/source/Playnite/Emulation/Platforms.yaml
+++ b/source/Playnite/Emulation/Platforms.yaml
@@ -239,7 +239,7 @@
   Id: nintendo_nes
   IgdbId: 18
   Databases: [Nintendo - Nintendo Entertainment System]
-  Emulators: [ares, bizhawk, fceux, higan, mednafen, mesen, nestopia, punes, retroarch]
+  Emulators: [ares, bizhawk, fceux, higan, jgenesis, mednafen, mesen, nestopia, punes, retroarch]
   
 - Name: Nintendo Family Computer Disk System
   Id: nintendo_famicom_disk
@@ -257,13 +257,13 @@
   Id: nintendo_gameboycolor
   IgdbId: 22
   Databases: [Nintendo - Game Boy Color]
-  Emulators: [ares, bgb, bizhawk, gambatte, gbe+, higan, mednafen, mesen, mgba, retroarch, sameboy, visualboyadvance, visualboyadvance-m]
+  Emulators: [ares, bgb, bizhawk, gambatte, gbe+, higan, jgenesis, mednafen, mesen, mgba, retroarch, sameboy, visualboyadvance, visualboyadvance-m]
   
 - Name: Nintendo Game Boy
   Id: nintendo_gameboy
   IgdbId: 33
   Databases: [Nintendo - Game Boy]
-  Emulators: [ares, bgb, bizhawk, gambatte, gbe+, higan, mednafen, mesen, mgba, retroarch, sameboy, visualboyadvance, visualboyadvance-m]
+  Emulators: [ares, bgb, bizhawk, gambatte, gbe+, higan, jgenesis, mednafen, mesen, mgba, retroarch, sameboy, visualboyadvance, visualboyadvance-m]
   
 - Name: Nintendo GameCube
   Id: nintendo_gamecube
@@ -275,7 +275,7 @@
   Id: nintendo_super_nes
   IgdbId: 19
   Databases: [Nintendo - Super Nintendo Entertainment System]
-  Emulators: [ares, bizhawk, bsnes, bsnes-hd, bsnes-mt, higan, mednafen, mesen, mesen-s, retroarch, snes9x, zsnes]
+  Emulators: [ares, bizhawk, bsnes, bsnes-hd, bsnes-mt, higan, jgenesis, mednafen, mesen, mesen-s, retroarch, snes9x, zsnes]
   
 - Name: Nintendo Switch
   Id: nintendo_switch
@@ -322,13 +322,13 @@
   Id: sega_32x
   IgdbId: 30
   Databases: [Sega - 32X]
-  Emulators: [ares, kegafusion, retroarch]
+  Emulators: [ares, jgenesis, kegafusion, retroarch]
   
 - Name: Sega CD
   Id: sega_cd
   IgdbId: 78
   Databases: [Sega - Mega-CD - Sega CD]
-  Emulators: [ares, kegafusion, retroarch]
+  Emulators: [ares, jgenesis, kegafusion, retroarch]
   
 - Name: Sega Dreamcast
   Id: sega_dreamcast
@@ -340,19 +340,19 @@
   Id: sega_gamegear
   IgdbId: 35
   Databases: [Sega - Game Gear]
-  Emulators: [ares, bizhawk, higan, kegafusion, mednafen, retroarch]
+  Emulators: [ares, bizhawk, higan, jgenesis, kegafusion, mednafen, retroarch]
   
 - Name: Sega Genesis
   Id: sega_genesis
   IgdbId: 29
   Databases: [Sega - Mega Drive - Genesis]
-  Emulators: [bizhawk, blastem, higan, kegafusion, mednafen, retroarch, ares]
+  Emulators: [bizhawk, blastem, higan, jgenesis, kegafusion, mednafen, retroarch, ares]
   
 - Name: Sega Master System
   Id: sega_mastersystem
   IgdbId: 64
   Databases: [Sega - Master System - Mark III]
-  Emulators: [ares, bizhawk, higan, kegafusion, mednafen, retroarch]
+  Emulators: [ares, bizhawk, higan, jgenesis, kegafusion, mednafen, retroarch]
   
 - Name: Sega Saturn
   Id: sega_saturn


### PR DESCRIPTION
Just as a note in case you are wondering why some profiles share the same hardware in command line, it's not an error and it's because they use the same hardware internally in the emulator. Profiles are defined per system, and follows the command line systems:

- https://github.com/jsgroth/jgenesis/blob/d16262b57d37b5c9ff70134c9e3a77166661dd78/frontend/jgenesis-native-driver/src/extensions.rs#L12-L20
- https://github.com/jsgroth/jgenesis/blob/d16262b57d37b5c9ff70134c9e3a77166661dd78/frontend/jgenesis-cli/src/main.rs#L29-L37