### PR TITLE
Avoid named pipe conflicts

### DIFF
--- a/source/Playnite/Common.config
+++ b/source/Playnite/Common.config
@@ -8,4 +8,5 @@
   <add key="OfflineMode" value="True" />
   <add key="PipeEndpoint" value="net.pipe://localhost/PlaynitePipe" />
   <add key="AppBranch" value="devel" />
+  <add key="wcf:useBestMatchNamedPipeUri" value="true" />
 </appSettings>


### PR DESCRIPTION
Although Playnite correctly creates its named pipe with a unique base address (`net.pipe://localhost/PlaynitePipe`) along with an additional identifier (`PipeEndpoint`), some "misbehaving" programs may interfere when they use only `net.pipe://localhost` as their base address, even if these programs append a unique segment in the `AddServiceEndpoint` call, they can end up intercepting Playnite's calls.

This issue can lead to "Startup Error"s, displaying the message "Playnite failed to start. Please close all other instances and try again.", in some scenarios, like when launching a game from a Playnite desktop shortcut while Playnite is already running.

To avoid this, I added the configuration `wcf:useBestMatchNamedPipeUri`, which instructs the .NET Framework to select the "best matching" endpoint rather than the "first matching" one.
You can read more about this configuration in this post: https://learn.microsoft.com/en-us/dotnet/framework/whats-new/#code-try-28, just above the linked code block, which is the only official documentation I could find on this.

<br/>

While the ideal solution would be for other programs to configure their bindings in a way that avoids conflicts, I think the `wcf:useBestMatchNamedPipeUri` setting would still be beneficial to improve compatibility.

<br/>

One example of a conflicting app is "EvlWatcher", which, as seen in this line of code: https://github.com/devnulli/EvlWatcher/blob/8ba46b59ba0be93a65e98b3855be15d40a83a1da/Source/EvlWatcher/EvlWatcher/EvlWatcher.cs#L227, binds to localhost. Despite later appending an additional address part in `AddServiceEndpoint`, its binding still ends up capturing Playnite's communications.

<br/>

Initial source of the fix I found: https://stackoverflow.com/a/74371039


Also, another possible conflicting app, "Remoter", was reported some years ago here: https://www.reddit.com/r/playnite/comments/cx434k/startup_error_when_trying_to_launch_a_game_from/
Although I wasn't able to confirm that was indeed the issue of that reddit post (couldn't find the named program).
