### PR TITLE
Fix window restoration in Fullscreen mode

### DIFF
--- a/source/Playnite/Native/winuser.cs
+++ b/source/Playnite/Native/winuser.cs
@@ -339,7 +339,7 @@ namespace Playnite.Native
         SHOWWINDOW = 0x0040,
         TOPMOST = NOACTIVATE | NOOWNERZORDER | NOSIZE | NOMOVE | NOREDRAW | NOSENDCHANGING
     }
-    
+
     public enum MonitorOptions : uint
     {
         MONITOR_DEFAULTTONULL = 0x00000000,


### PR DESCRIPTION
### Summary

Enforced windows restoration in Fullscreen when games exit by directly calling RestoreWindow on the Window.

### Case

In my installation, admittedly modified with many addons (though not that many, and only the most popular ones), Playnite Fullscreen window doesn't get restored after I close a game, staying minimized. This degrades the experience when playing with a gamepad, especially when streaming (i.e. via Apollo + Sunshine) when Alt+Tab or a mouse pointer are hardly available.

As far as I can tell, no issue directly mentioning this behaviour with a more traditional setup like mine exists. There is #3795, and this fix may or may not help with that issue as well.

### Proposed fix

Change `FullscreenAppViewModel.RestoreWindow()` to directly call `Window.RestoreWindow()` instead of relying on global window tracking. This should cover for more cases of window configurations, addons and other software potentially interfering.

### Demo

A build of Playnite with these changes was tested with same configuration and on the same setup, alongside the current release. The modified build shows successful Fullscreen window restoration under same conditions, allowing for seamless gamepad usage after game exit back in Playnite. Tested on Windows 11 on a latest update. Only the gamepad was used during these tests, with a mouse once to restore the window manually in the release version.

#### Before:

https://github.com/user-attachments/assets/6ecdbd1b-afd6-4b67-8e47-d716d8d23546

#### After:

https://github.com/user-attachments/assets/18d36866-148c-449d-818b-bfe31875e13b
