### PR TITLE
Fix: Initialize collections in Game constructor and GetCopy

### DIFF
--- a/source/PlayniteSDK/Models/Game.cs
+++ b/source/PlayniteSDK/Models/Game.cs
@@ -1663,6 +1663,9 @@ namespace Playnite.SDK.Models
         public Game() : base()
         {
             GameId = Guid.NewGuid().ToString();
+            GameActions = new ObservableCollection<GameAction>();
+            Links = new ObservableCollection<Link>();
+            Roms = new ObservableCollection<GameRom>();
         }
 
         /// <summary>
@@ -1740,9 +1743,9 @@ namespace Playnite.SDK.Models
                 Manual = Manual,
                 IncludeLibraryPluginAction = IncludeLibraryPluginAction,
                 OverrideInstallState = OverrideInstallState,
-                GameActions = GameActions?.Select(a => a.GetCopy()).ToObservable(),
-                Links = Links?.Select(a => a.GetCopy()).ToObservable(),
-                Roms = Roms?.Select(a => a.GetCopy()).ToObservable(),
+                GameActions = GameActions == null ? new ObservableCollection<GameAction>() : GameActions.Select(a => a.GetCopy()).ToObservable(),
+                Links = Links == null ? new ObservableCollection<Link>() : Links.Select(a => a.GetCopy()).ToObservable(),
+                Roms = Roms == null ? new ObservableCollection<GameRom>() : Roms.Select(a => a.GetCopy()).ToObservable(),
             };
         }
 

--- a/source/Tests/Playnite.Tests/Models/CopyDiffToTest.cs
+++ b/source/Tests/Playnite.Tests/Models/CopyDiffToTest.cs
@@ -182,5 +182,18 @@ namespace Playnite.Tests.Models
             var emulator = GenerateObject<Emulator>(random, true);
             Assert.AreEqual(Serialization.ToJson(emulator), Serialization.ToJson(emulator.GetCopy()));
         }
+
+        [Test]
+        public void NullCollectionCopyTest()
+        {
+            var game = new Game();
+            game.GameActions = null;
+            game.Links = null;
+            game.Roms = null;
+            var copy = game.GetCopy();
+            Assert.IsNotNull(copy.GameActions);
+            Assert.IsNotNull(copy.Links);
+            Assert.IsNotNull(copy.Roms);
+        }
     }
 }


### PR DESCRIPTION
Initializes GameActions, Links, and Roms collections in the Game constructor to prevent null reference exceptions.

Also updates the GetCopy method to handle cases where these collections might be null, ensuring that the copied object always has initialized collections.

Added a new test case to verify that GetCopy correctly handles null collections.