### PR TITLE
Use {InstallDir} as default path when adding new ROM

### DIFF
--- a/source/Playnite.DesktopApp/ViewModels/GameEditViewModel.cs
+++ b/source/Playnite.DesktopApp/ViewModels/GameEditViewModel.cs
@@ -659,7 +659,7 @@ namespace Playnite.DesktopApp.ViewModels
             var sortableNameConverter = appSettings.GameSortingNameAutofill
                 ? new SortableNameConverter(appSettings.GameSortingNameRemovedArticles, IsMultiGameEdit)
                 : null;
-            
+
             database.Games.BeginBufferUpdate();
             foreach (var game in gamesToUpdate)
             {
@@ -1235,7 +1235,7 @@ namespace Playnite.DesktopApp.ViewModels
                 EditingGame.Roms.CollectionChanged += Roms_CollectionChanged;
             }
 
-            var newRom = new GameRom("NewRom", "NewPath");
+            var newRom = new GameRom("NewRom", "{InstallDir}");
             newRom.PropertyChanged += Rom_PropertyChanged;
             EditingGame.Roms.Add(newRom);
         }


### PR DESCRIPTION
Change the default ROM path from "NewPath" to "{InstallDir}"

When adding a new ROM, the default path is now set to "{InstallDir}" 
instead of "NewPath". This provides a more practical starting point 
that encourages users to organize ROMs within the game's install 
directory rather than using arbitrary custom paths for each game.

This improves the default user experience by promoting better 
organization of ROM files.
- Encourages better organization by keeping ROMs within the game's 
  install directory
- Reduces the need for custom paths on every ROM
- Makes the path variable system more discoverable and easier to access