### PR TITLE
Fix process handle leak when opening Explorer windows

### DIFF
--- a/source/Playnite/Commands/GlobalCommands.cs
+++ b/source/Playnite/Commands/GlobalCommands.cs
@@ -43,12 +43,12 @@ namespace Playnite.Commands
                     catch (Exception e)
                     {
                         logger.Error(e, "Failed to open directory using custom command.");
-                        Process.Start(path);
+                        Process.Start(path)?.Dispose();
                     }
                 }
                 else
                 {
-                    ProcessStarter.StartProcess("explorer.exe", $"\"{path}\"");
+                    ProcessStarter.StartProcess("explorer.exe", $"\"{path}\"")?.Dispose();
                 }
             }
             catch (Exception e) when (!Debugger.IsAttached)

--- a/source/Playnite/Common/Explorer.cs
+++ b/source/Playnite/Common/Explorer.cs
@@ -10,12 +10,12 @@ namespace Playnite.Common
     {
         public static void NavigateToFileSystemEntry(string path)
         {
-            ProcessStarter.StartProcess("explorer.exe", $"/select,\"{path}\"");
+            ProcessStarter.StartProcess("explorer.exe", $"/select,\"{path}\"")?.Dispose();
         }
 
         public static void OpenDirectory(string path)
         {
-            ProcessStarter.StartProcess("explorer.exe", $"\"{path}\"");
+            ProcessStarter.StartProcess("explorer.exe", $"\"{path}\"")?.Dispose();
         }
     }
 }


### PR DESCRIPTION
Fixes #4248

Changes
Dispose `Process` objects after starting Explorer to prevent handle leaks when opening directories.