### PR TITLE
Fix explorer.exe process not terminating after window close

### DIFF
--- a/source/Playnite/Commands/GlobalCommands.cs
+++ b/source/Playnite/Commands/GlobalCommands.cs
@@ -48,7 +48,7 @@ namespace Playnite.Commands
                 }
                 else
                 {
-                    ProcessStarter.StartProcess("explorer.exe", $"\"{path}\"")?.Dispose();
+                    Explorer.OpenDirectory(path);
                 }
             }
             catch (Exception e) when (!Debugger.IsAttached)

--- a/source/Playnite/Common/Explorer.cs
+++ b/source/Playnite/Common/Explorer.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -8,14 +11,39 @@ namespace Playnite.Common
 {
     public class Explorer
     {
+        [DllImport("shell32.dll", SetLastError = true)]
+        private static extern int SHOpenFolderAndSelectItems(IntPtr pidlFolder, uint cidl, [In, MarshalAs(UnmanagedType.LPArray)] IntPtr[] apidl, uint dwFlags);
+
+        [DllImport("shell32.dll", SetLastError = true)]
+        private static extern void SHParseDisplayName([MarshalAs(UnmanagedType.LPWStr)] string name, IntPtr bindingContext, [Out] out IntPtr pidl, uint sfgaoIn, [Out] out uint psfgaoOut);
+
         public static void NavigateToFileSystemEntry(string path)
         {
-            ProcessStarter.StartProcess("explorer.exe", $"/select,\"{path}\"")?.Dispose();
+            var parentFolder = Path.GetDirectoryName(path);
+            if (string.IsNullOrEmpty(parentFolder))
+                return;
+
+            SHParseDisplayName(parentFolder, IntPtr.Zero, out var nativeFolder, 0, out _);
+            if (nativeFolder == IntPtr.Zero)
+                return;
+
+            var itemToSelect = Path.GetFileName(path);
+            SHParseDisplayName(Path.Combine(parentFolder, itemToSelect), IntPtr.Zero, out var nativeFile, 0, out _);
+
+            var fileArray = new[] { nativeFile == IntPtr.Zero ? nativeFolder : nativeFile };
+            SHOpenFolderAndSelectItems(nativeFolder, (uint)fileArray.Length, fileArray, 0);
+
+            Marshal.FreeCoTaskMem(nativeFolder);
+            if (nativeFile != IntPtr.Zero) Marshal.FreeCoTaskMem(nativeFile);
         }
 
         public static void OpenDirectory(string path)
         {
-            ProcessStarter.StartProcess("explorer.exe", $"\"{path}\"")?.Dispose();
+            // Adding trailing backslash ensures the path is treated as a directory
+            // and using UseShellExecute avoids the process hanging issue
+            if (!path.EndsWith("\\"))
+                path += "\\";
+            Process.Start(new ProcessStartInfo(path) { UseShellExecute = true });
         }
     }
 }


### PR DESCRIPTION
Fixes #4248

This PR fixes the issue where `explorer.exe` processes remain hanging after the window is closed.

### Changes
- `Explorer.NavigateToFileSystemEntry`: Replaced `explorer.exe /select,` with Shell32 API (`SHOpenFolderAndSelectItems`)
- `Explorer.OpenDirectory`: Use `ProcessStartInfo` with `UseShellExecute = true` and append trailing backslash to path

### Reference
Based on the fix from EverythingToolbar ([srwi/EverythingToolbar#586](https://github.com/srwi/EverythingToolbar/commit/e612c9e774a54c1a71f722e0ecaeafac56c59f68)), which resolved the same issue.

### Testing
I don't currently have a .NET development environment set up (I primarily develop on Mac), so I haven't been able to build and verify the fix locally yet. I plan to set one up on my Windows machine, though it may take some time.

If you get a chance to test this before then, feedback would be greatly appreciated. Happy to make any adjustments needed. 🙏
