### PR TITLE
Fix "Enable HDR Support" not working when multiple adapter.

### DIFF
--- a/source/Playnite/HdrUtilities.cs
+++ b/source/Playnite/HdrUtilities.cs
@@ -149,7 +149,8 @@ namespace Playnite
                  .FirstOrDefault(IsPrimaryDisplayMode);
 
             var targetInfo =
-                paths.FirstOrDefault(p => p.sourceInfo.id == primaryDisplayMode.id)
+                paths.FirstOrDefault(p => p.sourceInfo.id == primaryDisplayMode.id &&
+                                          p.sourceInfo.adapterId.Equals(primaryDisplayMode.adapterId))
                 .targetInfo;
 
             return targetInfo;


### PR DESCRIPTION
Fix an issue where Enable HDR Support would not work if multiple adapter(GPU, Virtual Display Driver, etc).

Maybe Fixes #3754

The problem was that the sourceInfo.Id is based on the adapter and could be identical for 2 different adapter. (Ex.: AdapterId 1/Id 0 and Adapter 2/Id 0). So in my case, instead of returning the targetInfo of my VirtualDisplay, it would return the targetInfo of the same Id of the one connected on my GPU. And thus trying to turn on HDR on my non HDR display.

I tried my fix with a local build and now my HDR turn on and off as expected.