### PR TITLE
add almost all changes from Extra Emulator Profiles

### DIFF
--- a/source/Playnite/Emulation/Emulators/Azahar/emulator.yaml
+++ b/source/Playnite/Emulation/Emulators/Azahar/emulator.yaml
@@ -1,0 +1,9 @@
+Id: azahar
+Name: Azahar
+Website: 'https://azahar-emu.org/'
+Profiles:
+  - Name: Default
+    StartupArguments: '"{ImagePath}"'
+    Platforms: [nintendo_3ds]
+    ImageExtensions: [3ds, 3dsx, cci, zcci, cxi, elf, cia]
+    StartupExecutable: ^azahar\.exe$

--- a/source/Playnite/Emulation/Emulators/BizHawk/emulator.yaml
+++ b/source/Playnite/Emulation/Emulators/BizHawk/emulator.yaml
@@ -62,6 +62,12 @@ Profiles:
     ImageExtensions: [int, bin, rom, zip, rar, 7z, gz]
     StartupExecutable: ^EmuHawk\.exe$
 
+  - Name: NEC PC-FX
+    StartupArguments: '"{ImagePath}" --fullscreen'
+    Platforms: [nec_pcfx]
+    ImageExtensions: [ccd, chd, cue, toc]
+    StartupExecutable: ^EmuHawk\.exe$
+    
   - Name: NEC TurboGrafx 16
     StartupArguments: '"{ImagePath}" --fullscreen'
     Platforms: [nec_turbografx_16]
@@ -109,6 +115,12 @@ Profiles:
     Platforms: [nintendo_virtualboy]
     ImageExtensions: [vb, zip, rar, 7z, gz]
     StartupExecutable: ^EmuHawk\.exe$
+    
+  - Name: Nintendo 3DS
+    StartupArguments: '"{ImagePath}" --fullscreen'
+    Platforms: [nintendo_3ds]
+    ImageExtensions: [3ds, 3dsx, cia, cxi]
+    StartupExecutable: ^EmuHawk\.exe$
 
   - Name: Nintendo 64
     StartupArguments: '"{ImagePath}" --fullscreen'
@@ -127,11 +139,29 @@ Profiles:
     Platforms: [sega_gamegear]
     ImageExtensions: [gg, zip, rar, 7z, gz]
     StartupExecutable: ^EmuHawk\.exe$
+    
+  - Name: SG-1000
+    StartupArguments: '"{ImagePath}" --fullscreen'
+    Platforms: [sega_sg1000]
+    ImageExtensions: [sg1000, sg, zip]
+    StartupExecutable: ^EmuHawk\.exe$
 
   - Name: Sega Genesis
     StartupArguments: '"{ImagePath}" --fullscreen'
     Platforms: [sega_genesis]
     ImageExtensions: [gen, md, smd, 32x, bin, cue, ccd, zip, rar, 7z, gz]
+    StartupExecutable: ^EmuHawk\.exe$
+    
+  - Name: Sega 32X
+    StartupArguments: '"{ImagePath}" --fullscreen'
+    Platforms: [sega_32x]
+    ImageExtensions: [32x]
+    StartupExecutable: ^EmuHawk\.exe$
+    
+  - Name: Sega CD
+    StartupArguments: '"{ImagePath}" --fullscreen'
+    Platforms: [sega_cd]
+    ImageExtensions: [chd, cue, ccd]
     StartupExecutable: ^EmuHawk\.exe$
 
   - Name: Sega Master System

--- a/source/Playnite/Emulation/Emulators/Borked3DS/emulator.yaml
+++ b/source/Playnite/Emulation/Emulators/Borked3DS/emulator.yaml
@@ -1,0 +1,9 @@
+Id: borked3ds
+Name: Borked3DS
+Website: 'https://github.com/Borked3DS/Borked3DS'
+Profiles:
+  - Name: Default
+    StartupArguments: '"{ImagePath}"'
+    Platforms: [nintendo_3ds]
+    ImageExtensions: [3ds, 3dsx, cci, cxi, elf, cia]
+    StartupExecutable: ^borked3ds\.exe$

--- a/source/Playnite/Emulation/Emulators/Citron/emulator.yaml
+++ b/source/Playnite/Emulation/Emulators/Citron/emulator.yaml
@@ -1,0 +1,9 @@
+Id: citron
+Name: Citron
+Website: 'https://citron-emu.org/'
+Profiles:
+  - Name: Default
+    StartupArguments: '"{ImagePath}"'
+    Platforms: [nintendo_switch]
+    ImageExtensions: [nso, nro, nca, xci, nsp]
+    StartupExecutable: ^citron\.exe$

--- a/source/Playnite/Emulation/Emulators/Eden/emulator.yaml
+++ b/source/Playnite/Emulation/Emulators/Eden/emulator.yaml
@@ -1,0 +1,9 @@
+Id: eden
+Name: Eden
+Website: 'https://eden-emu.dev/'
+Profiles:
+  - Name: Default
+    StartupArguments: '"{ImagePath}"'
+    Platforms: [nintendo_switch]
+    ImageExtensions: [nso, nro, nca, xci, nsp]
+    StartupExecutable: ^eden\.exe$

--- a/source/Playnite/Emulation/Emulators/FinalBurnNeo/emulator.yaml
+++ b/source/Playnite/Emulation/Emulators/FinalBurnNeo/emulator.yaml
@@ -1,0 +1,14 @@
+Id: fbneo
+Name: FinalBurn Neo
+Website: 'https://github.com/finalburnneo/FBNeo'
+Profiles:
+  - Name: Default 64bit
+    StartupArguments: '"{ImageNameNoExt}"'
+    Platforms: [arcade, fairchild_channelf, coleco_vision, microsoft_msx, nec_supergrafx, nec_turbografx_16, nintendo_nes, nintendo_famicom_disk, nintendo_super_nes, sega_gamegear, sega_genesis, sega_mastersystem, sega_sg1000, snk_neogeo_cd, snk_neogeopocket, sinclair_zxspectrum]
+    ImageExtensions: [7z, zip]
+    StartupExecutable: ^fbneo64\.exe$
+  - Name: Default 32bit
+    StartupArguments: '"{ImageNameNoExt}"'
+    Platforms: [arcade, fairchild_channelf, coleco_vision, microsoft_msx, nec_supergrafx, nec_turbografx_16, nintendo_nes, nintendo_famicom_disk, nintendo_super_nes, sega_gamegear, sega_genesis, sega_mastersystem, sega_sg1000, snk_neogeo_cd, snk_neogeopocket, sinclair_zxspectrum]
+    ImageExtensions: [7z, zip]
+    StartupExecutable: ^fbneo\.exe$

--- a/source/Playnite/Emulation/Emulators/Flycast/emulator.yaml
+++ b/source/Playnite/Emulation/Emulators/Flycast/emulator.yaml
@@ -4,6 +4,6 @@ Website: 'https://github.com/flyinghead/flycast'
 Profiles:
   - Name: Default
     StartupArguments: '"{ImagePath}"'
-    Platforms: [sega_dreamcast]
-    ImageExtensions: [gdi, cdi, chd, zip]
+    Platforms: [sega_dreamcast, arcade]
+    ImageExtensions: [gdi, cdi, chd, cue, zip, 7z, dat, lst]
     StartupExecutable: ^flycast\.exe$

--- a/source/Playnite/Emulation/Emulators/Mame/emulator.yaml
+++ b/source/Playnite/Emulation/Emulators/Mame/emulator.yaml
@@ -1,0 +1,9 @@
+Id:  mame
+Name: MAME
+Website: 'https://www.mamedev.org/'
+Profiles:
+  - Name: Default
+    StartupArguments: '{ImageNameNoExt}'
+    Platforms: [arcade]
+    ImageExtensions: [zip]
+    StartupExecutable: ^mame\.exe$

--- a/source/Playnite/Emulation/Emulators/Model2Emulator/emulator.yaml
+++ b/source/Playnite/Emulation/Emulators/Model2Emulator/emulator.yaml
@@ -1,0 +1,9 @@
+Id: model2emulator
+Name: Model 2 Emulator
+Website: 'https://segaretro.org/Model_2_Emulator'
+Profiles:
+  - Name: Default
+    StartupArguments: '{ImageNameNoExt}'
+    Platforms: [arcade]
+    ImageExtensions: [zip]
+    StartupExecutable: ^emulator_multicpu\.exe$

--- a/source/Playnite/Emulation/Emulators/RALibRetro/emulator.yaml
+++ b/source/Playnite/Emulation/Emulators/RALibRetro/emulator.yaml
@@ -1,0 +1,1151 @@
+Id: ralibretro
+Name: RALibRetro
+Website: "https://retroachievements.org/download.php#ralibretro"
+Profiles:
+  - Name: EightyOne
+    StartupArguments: '--core 81_libretro --system 31 --game "{ImagePath}"'
+    Platforms: [sinclair_zx81]
+    ImageExtensions: [7z, p, t81, tzx, zip]
+    ProfileFiles: ['cores\81_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Arduous
+    StartupArguments: '--core arduous_libretro --system 71 --game "{ImagePath}"'
+    Platforms: [arduboy]
+    ImageExtensions: [hex, arduboy]
+    ProfileFiles: ['cores\arduous_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Atari800
+    StartupArguments: '--core atari800_libretro --system 50 --game "{ImagePath}"'
+    Platforms: [atari_5200, atari_8bit]
+    ImageExtensions: [7z, a52, atr, atx, bin, car, cas, cdm, com, xex, xfd, zip]
+    ProfileFiles: ['cores\atari800_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: BlastEm
+    StartupArguments: '--core blastem_libretro --system 1 --game "{ImagePath}"'
+    Platforms: [sega_genesis]
+    ImageExtensions: [68k, 7z, bin, gen, md, sgd, smd, zip]
+    ProfileFiles: ['cores\blastem_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: blueMSX
+    StartupArguments: '--core bluemsx_libretro --system 44 --game "{ImagePath}"'
+    Platforms: [coleco_vision]
+    ImageExtensions: [col, rom]
+    ProfileFiles: ['cores\bluemsx_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: blueMSX
+    StartupArguments: '--core bluemsx_libretro --system 33 --game "{ImagePath}"'
+    Platforms: [sega_sg1000]
+    ImageExtensions: [sg]
+    ProfileFiles: ['cores\bluemsx_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: blueMSX
+    StartupArguments: '--core bluemsx_libretro --system 29 --game "{ImagePath}"'
+    Platforms: [microsoft_msx]
+    ImageExtensions: [dsk, cas, mx1, mx2, rom, ri, m3u]
+    ProfileFiles: ['cores\bluemsx_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: bsnes 2014 (Accuracy)
+    StartupArguments: '--core bsnes2014_accuracy_libretro --system 3 --game "{ImagePath}"'
+    Platforms: [nintendo_super_nes]
+    ImageExtensions: [7z, bml, sfc, smc, zip]
+    ProfileFiles: ['cores\bsnes2014_accuracy_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: bsnes 2014 (Balanced)
+    StartupArguments: '--core bsnes2014_balanced_libretro --system 3 --game "{ImagePath}"'
+    Platforms: [nintendo_super_nes]
+    ImageExtensions: [7z, bml, sfc, smc, zip]
+    ProfileFiles: ['cores\bsnes2014_balanced_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: bsnes 2014 (Performance)
+    StartupArguments: '--core bsnes2014_performance_libretro --system 3 --game "{ImagePath}"'
+    Platforms: [nintendo_super_nes]
+    ImageExtensions: [7z, bml, sfc, smc, zip]
+    ProfileFiles: ['cores\bsnes2014_performance_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: bsnes C++98 (v085)
+    StartupArguments: '--core bsnes_cplusplus98_libretro --system 3 --game "{ImagePath}"'
+    Platforms: [nintendo_super_nes]
+    ImageExtensions: [7z, sfc, smc, zip]
+    ProfileFiles: ['cores\bsnes_cplusplus98_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: bsnes-mercury (Accuracy)
+    StartupArguments: '--core bsnes_mercury_accuracy_libretro --system 3 --game "{ImagePath}"'
+    Platforms: [nintendo_super_nes]
+    ImageExtensions: [7z, bml, sfc, smc, zip]
+    ProfileFiles: ['cores\bsnes_mercury_accuracy_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: bsnes-mercury (Balanced)
+    StartupArguments: '--core bsnes_mercury_balanced_libretro --system 3 --game "{ImagePath}"'
+    Platforms: [nintendo_super_nes]
+    ImageExtensions: [7z, bml, sfc, smc, zip]
+    ProfileFiles: ['cores\bsnes_mercury_balanced_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: bsnes-mercury (Performance)
+    StartupArguments: '--core bsnes_mercury_performance_libretro --system 3 --game "{ImagePath}"'
+    Platforms: [nintendo_super_nes]
+    ImageExtensions: [7z, bml, sfc, smc, zip]
+    ProfileFiles: ['cores\bsnes_mercury_performance_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: bsnes
+    StartupArguments: '--core bsnes_libretro --system 3 --game "{ImagePath}"'
+    Platforms: [nintendo_super_nes]
+    ImageExtensions: [sfc, smc]
+    ProfileFiles: ['cores\bsnes_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: bsnes
+    StartupArguments: '--core bsnes_libretro --system 4 --game "{ImagePath}"'
+    Platforms: [nintendo_gameboy]
+    ImageExtensions: [gb]
+    ProfileFiles: ['cores\bsnes_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: bsnes
+    StartupArguments: '--core bsnes_libretro --system 6 --game "{ImagePath}"'
+    Platforms: [nintendo_gameboycolor]
+    ImageExtensions: [gbc]
+    ProfileFiles: ['cores\bsnes_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: bsnes-hd beta
+    StartupArguments: '--core bsnes_hd_beta_libretro --system 3 --game "{ImagePath}"'
+    Platforms: [nintendo_super_nes]
+    ImageExtensions: [sfc, smc]
+    ProfileFiles: ['cores\bsnes_hd_beta_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: bsnes-hd beta
+    StartupArguments: '--core bsnes_hd_beta_libretro --system 4 --game "{ImagePath}"'
+    Platforms: [nintendo_gameboy]
+    ImageExtensions: [gb]
+    ProfileFiles: ['cores\bsnes_hd_beta_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: bsnes-hd beta
+    StartupArguments: '--core bsnes_hd_beta_libretro --system 6 --game "{ImagePath}"'
+    Platforms: [nintendo_gameboycolor]
+    ImageExtensions: [gbc]
+    ProfileFiles: ['cores\bsnes_hd_beta_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Caprice32
+    StartupArguments: '--core cap32_libretro --system 37 --game "{ImagePath}"'
+    Platforms: [amstrad_cpc]
+    ImageExtensions: [7z, cdt, cpr, dsk, m3u, sna, tap, voc, zip]
+    ProfileFiles: ['cores\cap32_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Citra
+    StartupArguments: '--core citra_libretro --system 62 --game "{ImagePath}"'
+    Platforms: [nintendo_3ds]
+    ImageExtensions: [3ds, 3dsx, 7z, app, axf, cci, cxi, elf, zip]
+    ProfileFiles: ['cores\citra_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Citra 2018
+    StartupArguments: '--core citra2018_libretro --system 62 --game "{ImagePath}"'
+    Platforms: [nintendo_3ds]
+    ImageExtensions: [3ds, 3dsx, 7z, app, axf, cci, cxi, elf, zip]
+    ProfileFiles: ['cores\citra2018_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: CrocoDS
+    StartupArguments: '--core crocods_libretro --system 37 --game "{ImagePath}"'
+    Platforms: [amstrad_cpc]
+    ImageExtensions: [7z, dsk, kcr, sna, zip]
+    ProfileFiles: ['cores\crocods_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: DeSmuME 2015
+    StartupArguments: '--core desmume2015_libretro --system 18 --game "{ImagePath}"'
+    Platforms: [nintendo_ds]
+    ImageExtensions: [7z, bin, nds, zip]
+    ProfileFiles: ['cores\desmume2015_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: DeSmuME
+    StartupArguments: '--core desmume_libretro --system 18 --game "{ImagePath}"'
+    Platforms: [nintendo_ds]
+    ImageExtensions: [7z, bin, nds, zip]
+    ProfileFiles: ['cores\desmume_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Dolphin (Gamecube)
+    StartupArguments: '--core dolphin_libretro --system 16 --game "{ImagePath}"'
+    Platforms: [nintendo_gamecube]
+    ImageExtensions: [iso, m3u]
+    ProfileFiles: ['cores\dolphin_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Dolphin (Wii)
+    StartupArguments: '--core dolphin_libretro --system 19 --game "{ImagePath}"'
+    Platforms: [nintendo_wii]
+    ImageExtensions: [iso, m3u]
+    ProfileFiles: ['cores\dolphin_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: DOSBox Pure
+    StartupArguments: '--core dosbox_pure_libretro --system 26 --game "{ImagePath}"'
+    Platforms: [pc_dos]
+    ImageExtensions: [dosz]
+    ProfileFiles: ['cores\dosbox_pure_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: DuckStation
+    StartupArguments: '--core duckstation_libretro --system 12 --game "{ImagePath}"'
+    Platforms: [sony_playstation]
+    ImageExtensions: [m3u, cue, chd]
+    ProfileFiles: ['cores\duckstation_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: FB Alpha
+    StartupArguments: '--core fbalpha_libretro --system 27 --game "{ImagePath}"'
+    Platforms: [arcade]
+    ImageExtensions: [zip]
+    ProfileFiles: ['cores\fbalpha_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: FinalBurn Neo
+    StartupArguments: '--core fbneo_libretro --system 27 --game "{ImagePath}"'
+    Platforms: [arcade]
+    ImageExtensions: [zip, 7z]
+    ProfileFiles: ['cores\fbneo_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: FCEUmm
+    StartupArguments: '--core fceumm_libretro --system 7 --game "{ImagePath}"'
+    Platforms: [nintendo_nes]
+    ImageExtensions: [7z, fds, nes, unf, unif, zip]
+    ProfileFiles: ['cores\fceumm_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Flycast
+    StartupArguments: '--core flycast_libretro --system 27 --game "{ImagePath}"'
+    Platforms: [arcade]
+    ImageExtensions: [zip, 7z]
+    ProfileFiles: ['cores\flycast_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Flycast
+    StartupArguments: '--core flycast_libretro --system 40 --game "{ImagePath}"'
+    Platforms: [sega_dreamcast]
+    ImageExtensions: [gdi, cue, m3u, chd]
+    ProfileFiles: ['cores\flycast_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: fMSX
+    StartupArguments: '--core fmsx_libretro --system 29 --game "{ImagePath}"'
+    Platforms: [microsoft_msx]
+    ImageExtensions: [7z, cas, dsk, mx1, mx2, rom, zip]
+    ProfileFiles: ['cores\fmsx_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: FreeChaF
+    StartupArguments: '--core freechaf_libretro --system 57 --game "{ImagePath}"'
+    Platforms: [fairchild_channelf]
+    ImageExtensions: [bin]
+    ProfileFiles: ['cores\freechaf_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: FreeIntV
+    StartupArguments: '--core freeintv_libretro --system 45 --game "{ImagePath}"'
+    Platforms: [mattel_intellivision]
+    ImageExtensions: [7z, bin, int, rom, zip]
+    ProfileFiles: ['cores\freeintv_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Frodo
+    StartupArguments: '--core frodo_libretro --system 30 --game "{ImagePath}"'
+    Platforms: [commodore_64]
+    ImageExtensions: [7z, d64, lnx, p00, t64, x64, zip]
+    ProfileFiles: ['cores\frodo_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Fuse
+    StartupArguments: '--core fuse_libretro --system 59 --game "{ImagePath}"'
+    Platforms: [sinclair_zxspectrum, sinclair_zxspectrum3]
+    ImageExtensions: [7z, dsk, rzx, scl, tap, trd, tzx, z80, zip]
+    ProfileFiles: ['cores\fuse_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Gambatte
+    StartupArguments: '--core gambatte_libretro --system 4 --game "{ImagePath}"'
+    Platforms: [nintendo_gameboy]
+    ImageExtensions: [gb, dmg]
+    ProfileFiles: ['cores\gambatte_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Gambatte
+    StartupArguments: '--core gambatte_libretro --system 6 --game "{ImagePath}"'
+    Platforms: [nintendo_gameboycolor]
+    ImageExtensions: [gbc]
+    ProfileFiles: ['cores\gambatte_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Gearboy
+    StartupArguments: '--core gearboy_libretro --system 4 --game "{ImagePath}"'
+    Platforms: [nintendo_gameboy]
+    ImageExtensions: [gb, dmg, sgb]
+    ProfileFiles: ['cores\gearboy_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Gearboy
+    StartupArguments: '--core gearboy_libretro --system 6 --game "{ImagePath}"'
+    Platforms: [nintendo_gameboycolor]
+    ImageExtensions: [gbc, cgb]
+    ProfileFiles: ['cores\gearboy_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Gearsystem
+    StartupArguments: '--core gearsystem_libretro --system 11 --game "{ImagePath}"'
+    Platforms: [sega_mas]
+    ImageExtensions: [bin, sms, rom]
+    ProfileFiles: ['cores\gearsystem_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Gearsystem
+    StartupArguments: '--core gearsystem_libretro --system 15 --game "{ImagePath}"'
+    Platforms: [sega_gamegear]
+    ImageExtensions: [gg]
+    ProfileFiles: ['cores\gearsystem_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Gearsystem
+    StartupArguments: '--core gearsystem_libretro --system 33 --game "{ImagePath}"'
+    Platforms: [sega_sg1000]
+    ImageExtensions: [sg]
+    ProfileFiles: ['cores\gearsystem_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Genesis Plus GX (Sega Genesis)
+    StartupArguments: '--core genesis_plus_gx_libretro --system 1 --game "{ImagePath}"'
+    Platforms: [sega_genesis]
+    ImageExtensions: [bin, gen, smd, md, sms]
+    ProfileFiles: ['cores\genesis_plus_gx_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Genesis Plus GX (Sega Master System)
+    StartupArguments: '--core genesis_plus_gx_libretro --system 11 --game "{ImagePath}"'
+    Platforms: [sega_mastersystem]
+    ImageExtensions: [bin, gen, smd, md, sms]
+    ProfileFiles: ['cores\genesis_plus_gx_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Genesis Plus GX (Sega Game Gear)
+    StartupArguments: '--core genesis_plus_gx_libretro --system 15 --game "{ImagePath}"'
+    Platforms: [sega_gamegear]
+    ImageExtensions: [gg, sg]
+    ProfileFiles: ['cores\genesis_plus_gx_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Genesis Plus GX
+    StartupArguments: '--core genesis_plus_gx_libretro --system 9 --game "{ImagePath}"'
+    Platforms: [sega_cd]
+    ImageExtensions: [cue, iso, m3u, chd]
+    ProfileFiles: ['cores\genesis_plus_gx_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Genesis Plus GX
+    StartupArguments: '--core genesis_plus_gx_libretro --system 33 --game "{ImagePath}"'
+    Platforms: [sega_sg1000]
+    ImageExtensions: [sg]
+    ProfileFiles: ['cores\genesis_plus_gx_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: gpSP
+    StartupArguments: '--core gpsp_libretro --system 5 --game "{ImagePath}"'
+    Platforms: [nintendo_gameboyadvance]
+    ImageExtensions: [7z, bin, gba, zip]
+    ProfileFiles: ['cores\gpsp_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: GW
+    StartupArguments: '--core gw_libretro --system 60 --game "{ImagePath}"'
+    Platforms: [nintendo_gameandwatch]
+    ImageExtensions: [mgw]
+    ProfileFiles: ['cores\gw_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Kronos
+    StartupArguments: '--core kronos_libretro --system 39 --game "{ImagePath}"'
+    Platforms: [sega_saturn]
+    ImageExtensions: [m3u, cue]
+    ProfileFiles: ['cores\kronos_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Handy
+    StartupArguments: '--core handy_libretro --system 13 --game "{ImagePath}"'
+    Platforms: [atari_lynx]
+    ImageExtensions: [7z, lnx, o, zip]
+    ProfileFiles: ['cores\handy_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Hatari
+    StartupArguments: '--core hatari_libretro --system 36 --game "{ImagePath}"'
+    Platforms: [atari_st]
+    ImageExtensions: [7z, dim, ipf, m3u, msa, st, stx, zip]
+    ProfileFiles: ['cores\hatari_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: HBMAME
+    StartupArguments: '--core hbmame_libretro --system 27 --game "{ImagePath}"'
+    Platforms: [arcade]
+    ImageExtensions: []
+    ProfileFiles: ['cores\hbmame_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Higan Accuracy
+    StartupArguments: '--core higan_sfc_libretro --system 3 --game "{ImagePath}"'
+    Platforms: [nintendo_super_nes]
+    ImageExtensions: [sfc, smc]
+    ProfileFiles: ['cores\higan_sfc_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Higan Accuracy
+    StartupArguments: '--core higan_sfc_libretro --system 4 --game "{ImagePath}"'
+    Platforms: [nintendo_gameboy]
+    ImageExtensions: [gb]
+    ProfileFiles: ['cores\higan_sfc_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Higan Accuracy
+    StartupArguments: '--core higan_sfc_libretro --system 6 --game "{ImagePath}"'
+    Platforms: [nintendo_gameboycolor]
+    ImageExtensions: [gbc]
+    ProfileFiles: ['cores\higan_sfc_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: nSide Balanced
+    StartupArguments: '--core higan_sfc_balanced_libretro --system 3 --game "{ImagePath}"'
+    Platforms: [nintendo_super_nes]
+    ImageExtensions: [sfc, smc]
+    ProfileFiles: ['cores\higan_sfc_balanced_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: nSide Balanced
+    StartupArguments: '--core higan_sfc_balanced_libretro --system 4 --game "{ImagePath}"'
+    Platforms: [nintendo_gameboy]
+    ImageExtensions: [gb]
+    ProfileFiles: ['cores\higan_sfc_balanced_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: nSide Balanced
+    StartupArguments: '--core higan_sfc_balanced_libretro --system 6 --game "{ImagePath}"'
+    Platforms: [nintendo_gameboycolor]
+    ImageExtensions: [gbc]
+    ProfileFiles: ['cores\higan_sfc_balanced_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Ishiiruka (Gamecube)
+    StartupArguments: '--core ishiiruka_libretro --system 16 --game "{ImagePath}"'
+    Platforms: [nintendo_gamecube]
+    ImageExtensions: [7z, ciso, dff, dol, elf, gcm, gcz, iso, tgc, wad, wbfs, zip]
+    ProfileFiles: ['cores\ishiiruka_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Ishiiruka (Wii)
+    StartupArguments: '--core ishiiruka_libretro --system 19 --game "{ImagePath}"'
+    Platforms: [nintendo_wii]
+    ImageExtensions: [7z, ciso, dff, dol, elf, gcm, gcz, iso, tgc, wad, wbfs, zip]
+    ProfileFiles: ['cores\ishiiruka_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: MAME 2003
+    StartupArguments: '--core mame2003_libretro --system 27 --game "{ImagePath}"'
+    Platforms: [arcade]
+    ImageExtensions: [zip]
+    ProfileFiles: ['cores\mame2003_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: MAME 2003 Plus
+    StartupArguments: '--core mame2003_plus_libretro --system 27 --game "{ImagePath}"'
+    Platforms: [arcade]
+    ImageExtensions: [zip, chd]
+    ProfileFiles: ['cores\mame2003_plus_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: MAME 2010
+    StartupArguments: '--core mame2010_libretro --system 27 --game "{ImagePath}"'
+    Platforms: [arcade]
+    ImageExtensions: [zip, 7z, chd]
+    ProfileFiles: ['cores\mame2010_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: MAME 2015
+    StartupArguments: '--core mame2015_libretro --system 27 --game "{ImagePath}"'
+    Platforms: [arcade]
+    ImageExtensions: [zip]
+    ProfileFiles: ['cores\mame2015_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: MAME 2016
+    StartupArguments: '--core mame2016_libretro --system 27 --game "{ImagePath}"'
+    Platforms: [arcade]
+    ImageExtensions: [zip]
+    ProfileFiles: ['cores\mame2016_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: MAME
+    StartupArguments: '--core mame_libretro --system 27 --game "{ImagePath}"'
+    Platforms: [arcade]
+    ImageExtensions: [zip]
+    ProfileFiles: ['cores\mame_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Beetle GBA
+    StartupArguments: '--core mednafen_gba_libretro --system 5 --game "{ImagePath}"'
+    Platforms: [nintendo_gameboyadvance]
+    ImageExtensions: [7z, agb, bin, gba, zip]
+    ProfileFiles: ['cores\mednafen_gba_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Beetle Lynx
+    StartupArguments: '--core mednafen_lynx_libretro --system 13 --game "{ImagePath}"'
+    Platforms: [atari_lynx]
+    ImageExtensions: [7z, lnx, o, zip]
+    ProfileFiles: ['cores\mednafen_lynx_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Beetle NeoPop
+    StartupArguments: '--core mednafen_ngp_libretro --system 14 --game "{ImagePath}"'
+    Platforms: [snk_neogeopocket]
+    ImageExtensions: [7z, ngc, ngp, ngpc, npc, zip]
+    ProfileFiles: ['cores\mednafen_ngp_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Beetle PCE
+    StartupArguments: '--core mednafen_pce_libretro --system 8 --game "{ImagePath}"'
+    Platforms: [nec_turbografx_16]
+    ImageExtensions: [pce, sgx]
+    ProfileFiles: ['cores\mednafen_pce_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Beetle PCE
+    StartupArguments: '--core mednafen_pce_libretro --system 76 --game "{ImagePath}"'
+    Platforms: [nec_turbografx_cd]
+    ImageExtensions: [m3u, cue]
+    ProfileFiles: ['cores\mednafen_pce_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Beetle PCE Fast
+    StartupArguments: '--core mednafen_pce_fast_libretro --system 8 --game "{ImagePath}"'
+    Platforms: [nec_turbografx_16]
+    ImageExtensions: [pce]
+    ProfileFiles: ['cores\mednafen_pce_fast_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Beetle PCE Fast
+    StartupArguments: '--core mednafen_pce_fast_libretro --system 76 --game "{ImagePath}"'
+    Platforms: [nec_turbografx_cd]
+    ImageExtensions: [m3u, cue, chd]
+    ProfileFiles: ['cores\mednafen_pce_fast_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Beetle PC-FX
+    StartupArguments: '--core mednafen_pcfx_libretro --system 49 --game "{ImagePath}"'
+    Platforms: [nec_pcfx]
+    ImageExtensions: [m3u, cue, chd]
+    ProfileFiles: ['cores\mednafen_pcfx_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Beetle PSX
+    StartupArguments: '--core mednafen_psx_libretro --system 12 --game "{ImagePath}"'
+    Platforms: [sony_playstation]
+    ImageExtensions: [m3u, cue, chd]
+    ProfileFiles: ['cores\mednafen_psx_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Beetle PSX HW
+    StartupArguments: '--core mednafen_psx_hw_libretro --system 12 --game "{ImagePath}"'
+    Platforms: [sony_playstation]
+    ImageExtensions: [m3u, cue, chd]
+    ProfileFiles: ['cores\mednafen_psx_hw_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Beetle Saturn
+    StartupArguments: '--core mednafen_saturn_libretro --system 39 --game "{ImagePath}"'
+    Platforms: [sega_saturn]
+    ImageExtensions: [m3u, cue]
+    ProfileFiles: ['cores\mednafen_saturn_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Supafaust
+    StartupArguments: '--core mednafen_supafaust_libretro --system 3 --game "{ImagePath}"'
+    Platforms: [nintendo_super_nes]
+    ImageExtensions: [7z, bsx, dx2, fig, gd3, gd7, sfc, smc, swc, zip]
+    ProfileFiles: ['cores\mednafen_supafaust_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Beetle SuperGrafX
+    StartupArguments: '--core mednafen_supergrafx_libretro --system 8 --game "{ImagePath}"'
+    Platforms: [nec_turbografx_16]
+    ImageExtensions: [pce, sgx]
+    ProfileFiles: ['cores\mednafen_supergrafx_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Beetle SuperGrafX
+    StartupArguments: '--core mednafen_supergrafx_libretro --system 76 --game "{ImagePath}"'
+    Platforms: [nec_turbografx_cd]
+    ImageExtensions: [m3u, cue, chd]
+    ProfileFiles: ['cores\mednafen_supergrafx_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Beetle VB
+    StartupArguments: '--core mednafen_vb_libretro --system 28 --game "{ImagePath}"'
+    Platforms: [nintendo_virtualboy]
+    ImageExtensions: [7z, bin, vb, vboy, zip]
+    ProfileFiles: ['cores\mednafen_vb_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Beetle WonderSwan
+    StartupArguments: '--core mednafen_wswan_libretro --system 53 --game "{ImagePath}"'
+    Platforms: [bandai_wonderswan]
+    ImageExtensions: [7z, pc2, ws, wsc, zip]
+    ProfileFiles: ['cores\mednafen_wswan_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: melonDS
+    StartupArguments: '--core melonds_libretro --system 18 --game "{ImagePath}"'
+    Platforms: [nintendo_ds]
+    ImageExtensions: [7z, nds, zip]
+    ProfileFiles: ['cores\melonds_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: melonDS DS
+    StartupArguments: '--core melondsds_libretro --system 18 --game "{ImagePath}"'
+    Platforms: [nintendo_ds]
+    ImageExtensions: [nds, zip]
+    ProfileFiles: ['cores\melondsds_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: melonDS DS
+    StartupArguments: '--core melondsds_libretro --system 78 --game "{ImagePath}"'
+    Platforms: [nintendo_dsi]
+    ImageExtensions: [nds, zip]
+    ProfileFiles: ['cores\melondsds_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Mesen
+    StartupArguments: '--core mesen_libretro --system 7 --game "{ImagePath}"'
+    Platforms: [nintendo_nes]
+    ImageExtensions: [7z, fds, nes, unf, unif, zip]
+    ProfileFiles: ['cores\mesen_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Mesen-S
+    StartupArguments: '--core mesen-s_libretro --system 3 --game "{ImagePath}"'
+    Platforms: [nintendo_super_nes]
+    ImageExtensions: [sfc, smc, swc, fig, bs]
+    ProfileFiles: ['cores\mesen-s_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Mesen-S
+    StartupArguments: '--core mesen-s_libretro --system 4 --game "{ImagePath}"'
+    Platforms: [nintendo_gameboy]
+    ImageExtensions: [gb]
+    ProfileFiles: ['cores\mesen-s_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Mesen-S
+    StartupArguments: '--core mesen-s_libretro --system 6 --game "{ImagePath}"'
+    Platforms: [nintendo_gameboycolor]
+    ImageExtensions: [gbc]
+    ProfileFiles: ['cores\mesen-s_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Meteor
+    StartupArguments: '--core meteor_libretro --system 5 --game "{ImagePath}"'
+    Platforms: [nintendo_gameboyadvance]
+    ImageExtensions: [7z, gba, zip]
+    ProfileFiles: ['cores\meteor_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: mGBA
+    StartupArguments: '--core mgba_libretro --system 4 --game "{ImagePath}"'
+    Platforms: [nintendo_gameboy]
+    ImageExtensions: [gb]
+    ProfileFiles: ['cores\mgba_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: mGBA
+    StartupArguments: '--core mgba_libretro --system 6 --game "{ImagePath}"'
+    Platforms: [nintendo_gameboycolor]
+    ImageExtensions: [gbc]
+    ProfileFiles: ['cores\mgba_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: mGBA
+    StartupArguments: '--core mgba_libretro --system 5 --game "{ImagePath}"'
+    Platforms: [nintendo_gameboyadvance]
+    ImageExtensions: [gba]
+    ProfileFiles: ['cores\mgba_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Mupen64Plus-Next
+    StartupArguments: '--core mupen64plus_next_libretro --system 2 --game "{ImagePath}"'
+    Platforms: [nintendo_64]
+    ImageExtensions: [7z, bin, n64, u1, v64, z64, zip]
+    ProfileFiles: ['cores\mupen64plus_next_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Neko Project II
+    StartupArguments: '--core nekop2_libretro --system 48 --game "{ImagePath}"'
+    Platforms: [nec_pc98]
+    ImageExtensions: [2hd, 7z, 88d, 98d, cmd, d88, d98, dup, fdd, fdi, hdd, hdi, hdm, nhd, tfd, thd, xdf, zip]
+    ProfileFiles: ['cores\nekop2_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: NeoCD
+    StartupArguments: '--core neocd_libretro --system 56 --game "{ImagePath}"'
+    Platforms: [snk_neogeo_cd]
+    ImageExtensions: [7z, chd, cue, zip]
+    ProfileFiles: ['cores\neocd_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Nestopia UE
+    StartupArguments: '--core nestopia_libretro --system 7 --game "{ImagePath}"'
+    Platforms: [nintendo_nes]
+    ImageExtensions: [7z, fds, nes, unf, unif, zip]
+    ProfileFiles: ['cores\nestopia_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Neko Project II Kai
+    StartupArguments: '--core np2kai_libretro --system 48 --game "{ImagePath}"'
+    Platforms: [nec_pc98]
+    ImageExtensions: [2hd, 7z, 88d, 98d, cmd, d88, d98, dup, fdd, fdi, hdd, hdi, hdm, hdn, nhd, tfd, thd, xdf, zip]
+    ProfileFiles: ['cores\np2kai_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: O2EM
+    StartupArguments: '--core o2em_libretro --system 23 --game "{ImagePath}"'
+    Platforms: [magnavox_odyssey_2]
+    ImageExtensions: [bin]
+    ProfileFiles: ['cores\o2em_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Opera
+    StartupArguments: '--core opera_libretro --system 43 --game "{ImagePath}"'
+    Platforms: [3do]
+    ImageExtensions: [7z, bin, chd, cue, iso, zip]
+    ProfileFiles: ['cores\opera_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: ParaLLEl N64
+    StartupArguments: '--core parallel_n64_libretro --system 2 --game "{ImagePath}"'
+    Platforms: [nintendo_64]
+    ImageExtensions: [7z, bin, n64, ndd, u1, v64, z64, zip]
+    ProfileFiles: ['cores\parallel_n64_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: pcsx2
+    StartupArguments: '--core pcsx2_libretro --system 21 --game "{ImagePath}"'
+    Platforms: [sony_playstation2]
+    ImageExtensions: [cue, iso]
+    ProfileFiles: ['cores\pcsx2_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: PCSX-ReARMed
+    StartupArguments: '--core pcsx_rearmed_libretro --system 12 --game "{ImagePath}"'
+    Platforms: [sony_playstation]
+    ImageExtensions: [m3u, cue, chd]
+    ProfileFiles: ['cores\pcsx_rearmed_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: PicoDrive (Sega Genesis)
+    StartupArguments: '--core picodrive_libretro --system 1 --game "{ImagePath}"'
+    Platforms: [sega_genesis]
+    ImageExtensions: [bin, gen, smd, md, sms]
+    ProfileFiles: ['cores\picodrive_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: PicoDrive (Sega Master System)
+    StartupArguments: '--core picodrive_libretro --system 11 --game "{ImagePath}"'
+    Platforms: [sega_mastersystem]
+    ImageExtensions: [bin, gen, smd, md, sms]
+    ProfileFiles: ['cores\picodrive_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: PicoDrive
+    StartupArguments: '--core picodrive_libretro --system 9 --game "{ImagePath}"'
+    Platforms: [sega_cd]
+    ImageExtensions: [cue, m3u, chd]
+    ProfileFiles: ['cores\picodrive_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: PicoDrive
+    StartupArguments: '--core picodrive_libretro --system 10 --game "{ImagePath}"'
+    Platforms: [sega_32x]
+    ImageExtensions: [32x, bin]
+    ProfileFiles: ['cores\picodrive_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: PicoDrive
+    StartupArguments: '--core picodrive_libretro --system 15 --game "{ImagePath}"'
+    Platforms: [sega_gamegear]
+    ImageExtensions: [gg]
+    ProfileFiles: ['cores\picodrive_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Play!
+    StartupArguments: '--core play_libretro --system 21 --game "{ImagePath}"'
+    Platforms: [sony_playstation2]
+    ImageExtensions: [chd, cso, cue, elf, iso, isz]
+    ProfileFiles: ['cores\play_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: PokeMini
+    StartupArguments: '--core pokemini_libretro --system 24 --game "{ImagePath}"'
+    Platforms: [nintendo_pokemonmini]
+    ImageExtensions: [7z, bin, cso, elf, iso, isz, zip]
+    ProfileFiles: ['cores\pokemini_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Potator
+    StartupArguments: '--core potator_libretro --system 63 --game "{ImagePath}"'
+    Platforms: [watara_supervision]
+    ImageExtensions: [7z, bin, sv, zip]
+    ProfileFiles: ['cores\potator_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: PPSSPP
+    StartupArguments: '--core ppsspp_libretro --system 41 --game "{ImagePath}"'
+    Platforms: [sony_psp]
+    ImageExtensions: [iso, chd]
+    ProfileFiles: ['cores\ppsspp_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\\$
+
+  - Name: ProSystem
+    StartupArguments: '--core prosystem_libretro --system 51 --game "{ImagePath}"'
+    Platforms: [atari_7800]
+    ImageExtensions: [7z, a78, bin, zip]
+    ProfileFiles: ['cores\prosystem_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: P-UAE
+    StartupArguments: '--core puae_libretro --system 35 --game "{ImagePath}"'
+    Platforms: [commodore_amiga]
+    ImageExtensions: [7z, adf, adz, ccd, chd, cue, dms, fdi, hdf, hdz, info, ipf, iso, lha, m3u, mds, nrg, rp9, slave, uae, zip]
+    ProfileFiles: ['cores\puae_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: PX68k
+    StartupArguments: '--core px68k_libretro --system 52 --game "{ImagePath}"'
+    Platforms: [sharp_x68000]
+    ImageExtensions: [2hd, 7z, 88d, cmd, d88, dim, dup, hdf, hdm, img, m3u, xdf, zip]
+    ProfileFiles: ['cores\px68k_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: QUASI88
+    StartupArguments: '--core quasi88_libretro --system 47 --game "{ImagePath}"'
+    Platforms: [nec_pc88]
+    ImageExtensions: [d88, u88, m3u]
+    ProfileFiles: ['cores\quasi88_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: QuickNES
+    StartupArguments: '--core quicknes_libretro --system 7 --game "{ImagePath}"'
+    Platforms: [nintendo_nes]
+    ImageExtensions: [7z, nes, zip]
+    ProfileFiles: ['cores\quicknes_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: RACE
+    StartupArguments: '--core race_libretro --system 14 --game "{ImagePath}"'
+    Platforms: [snk_neogeopocket]
+    ImageExtensions: [7z, ngc, ngp, ngpc, npc, zip]
+    ProfileFiles: ['cores\race_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: SameBoy
+    StartupArguments: '--core sameboy_libretro --system 4 --game "{ImagePath}"'
+    Platforms: [nintendo_gameboy]
+    ImageExtensions: [gb]
+    ProfileFiles: ['cores\sameboy_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: SameBoy
+    StartupArguments: '--core sameboy_libretro --system 6 --game "{ImagePath}"'
+    Platforms: [nintendo_gameboycolor]
+    ImageExtensions: [gbc]
+    ProfileFiles: ['cores\sameboy_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: SameDuck
+    StartupArguments: '--core sameduck_libretro --system 69 --game "{ImagePath}"'
+    Platforms: [megaduck]
+    ImageExtensions: [bin]
+    ProfileFiles: ['cores\sameduck_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: SMS Plus GX (Sega Master System)
+    StartupArguments: '--core smsplus_libretro --system 11 --game "{ImagePath}"'
+    Platforms: [sega_mastersystem]
+    ImageExtensions: [7z, bin, col, gg, rom, sg, sms, zip]
+    ProfileFiles: ['cores\smsplus_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: SMS Plus GX (Sega Game Gear)
+    StartupArguments: '--core smsplus_libretro --system 15 --game "{ImagePath}"'
+    Platforms: [sega_gamegear]
+    ImageExtensions: [7z, bin, col, gg, rom, sg, sms, zip]
+    ProfileFiles: ['cores\smsplus_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: SMS Plus GX (Sega SG-1000)
+    StartupArguments: '--core smsplus_libretro --system 33 --game "{ImagePath}"'
+    Platforms: [sega_sg1000]
+    ImageExtensions: [7z, bin, col, gg, rom, sg, sms, zip]
+    ProfileFiles: ['cores\smsplus_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: SMS Plus GX (Colecovision)
+    StartupArguments: '--core smsplus_libretro --system 44 --game "{ImagePath}"'
+    Platforms: [coleco_vision]
+    ImageExtensions: [7z, bin, col, gg, rom, sg, sms, zip]
+    ProfileFiles: ['cores\smsplus_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Snes9x 2002
+    StartupArguments: '--core snes9x2002_libretro --system 3 --game "{ImagePath}"'
+    Platforms: [nintendo_super_nes]
+    ImageExtensions: [7z, bsx, dx2, fig, gd3, gd7, sfc, smc, swc, zip]
+    ProfileFiles: ['cores\snes9x2002_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Snes9x 2005
+    StartupArguments: '--core snes9x2005_libretro --system 3 --game "{ImagePath}"'
+    Platforms: [nintendo_super_nes]
+    ImageExtensions: [7z, bsx, dx2, fig, gd3, gd7, sfc, smc, swc, zip]
+    ProfileFiles: ['cores\snes9x2005_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Snes9x 2005 Plus
+    StartupArguments: '--core snes9x2005_plus_libretro --system 3 --game "{ImagePath}"'
+    Platforms: [nintendo_super_nes]
+    ImageExtensions: [7z, bsx, dx2, fig, gd3, gd7, sfc, smc, swc, zip]
+    ProfileFiles: ['cores\snes9x2005_plus_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Snes9x 2010
+    StartupArguments: '--core snes9x2010_libretro --system 3 --game "{ImagePath}"'
+    Platforms: [nintendo_super_nes]
+    ImageExtensions: [7z, bsx, dx2, fig, gd3, gd7, sfc, smc, swc, zip]
+    ProfileFiles: ['cores\snes9x2010_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Snes9x
+    StartupArguments: '--core snes9x_libretro --system 3 --game "{ImagePath}"'
+    Platforms: [nintendo_super_nes]
+    ImageExtensions: [7z, bs, fig, sfc, smc, st, swc, zip]
+    ProfileFiles: ['cores\snes9x_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Stella 2014
+    StartupArguments: '--core stella2014_libretro --system 25 --game "{ImagePath}"'
+    Platforms: [atari_2600]
+    ImageExtensions: [7z, a26, bin, zip]
+    ProfileFiles: ['cores\stella2014_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Stella
+    StartupArguments: '--core stella_libretro --system 25 --game "{ImagePath}"'
+    Platforms: [atari_2600]
+    ImageExtensions: [7z, a26, bin, zip]
+    ProfileFiles: ['cores\stella_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: SwanStation
+    StartupArguments: '--core swanstation_libretro --system 12 --game "{ImagePath}"'
+    Platforms: [sony_playstation]
+    ImageExtensions: [m3u, cue, chd]
+    ProfileFiles: ['cores\swanstation_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: TGB Dual
+    StartupArguments: '--core tgbdual_libretro --system 4 --game "{ImagePath}"'
+    Platforms: [nintendo_gameboy]
+    ImageExtensions: [gb, sgb]
+    ProfileFiles: ['cores\tgbdual_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: TGB Dual
+    StartupArguments: '--core tgbdual_libretro --system 6 --game "{ImagePath}"'
+    Platforms: [nintendo_gameboycolor]
+    ImageExtensions: [gbc]
+    ProfileFiles: ['cores\tgbdual_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Theodore
+    StartupArguments: '--core theodore_libretro --system 66 --game "{ImagePath}"'
+    Platforms: [thomson_to7]
+    ImageExtensions: [7z, fd, k7, m5, m7, rom, sap, zip]
+    ProfileFiles: ['cores\theodore_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: TIC-80
+    StartupArguments: '--core tic80_libretro --system 65 --game "{ImagePath}"'
+    Platforms: [tic_80]
+    ImageExtensions: [tic]
+    ProfileFiles: ['cores\tic80_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: UME 2015
+    StartupArguments: '--core ume2015_libretro --system 27 --game "{ImagePath}"'
+    Platforms: [arcade]
+    ImageExtensions: []
+    ProfileFiles: ['cores\ume2015_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Uzem
+    StartupArguments: '--core uzem_libretro --system 80 --game "{ImagePath}"'
+    Platforms: [uzebox]
+    ImageExtensions: [uze]
+    ProfileFiles: ['cores\uzem_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: VBA Next
+    StartupArguments: '--core vba_next_libretro --system 5 --game "{ImagePath}"'
+    Platforms: [nintendo_gameboyadvance]
+    ImageExtensions: [7z, gba, zip]
+    ProfileFiles: ['cores\vba_next_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: VBA-M
+    StartupArguments: '--core vbam_libretro --system 4 --game "{ImagePath}"'
+    Platforms: [nintendo_gameboy]
+    ImageExtensions: [gb, dmg, sgb]
+    ProfileFiles: ['cores\vbam_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: VBA-M
+    StartupArguments: '--core vbam_libretro --system 6 --game "{ImagePath}"'
+    Platforms: [nintendo_gameboycolor]
+    ImageExtensions: [gbc, cgb]
+    ProfileFiles: ['cores\vbam_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: VBA-M
+    StartupArguments: '--core vbam_libretro --system 5 --game "{ImagePath}"'
+    Platforms: [nintendo_gameboyadvance]
+    ImageExtensions: [gba]
+    ProfileFiles: ['cores\vbam_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: VecX
+    StartupArguments: '--core vecx_libretro --system 46 --game "{ImagePath}"'
+    Platforms: [vectrex]
+    ImageExtensions: [7z, bin, vec, zip]
+    ProfileFiles: ['cores\vecx_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Vice x128
+    StartupArguments: '--core vice_x128_libretro --system 30 --game "{ImagePath}"'
+    Platforms: [commodore_64]
+    ImageExtensions: [7z, bin, cmd, crt, d2m, d4m, d64, d6z, d71, d7z, d80, d81, d82, d8z, g41, g4z, g64, g6z, gz, m3u, nbz, nib, p00, prg, t64, tap, vfl, vsf, x64, x6z, zip]
+    ProfileFiles: ['cores\vice_x128_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Vice x64
+    StartupArguments: '--core vice_x64_libretro --system 30 --game "{ImagePath}"'
+    Platforms: [commodore_64]
+    ImageExtensions: [7z, bin, cmd, crt, d2m, d4m, d64, d6z, d71, d7z, d80, d81, d82, d8z, g41, g4z, g64, g6z, gz, m3u, nbz, nib, p00, prg, t64, tap, vfl, vsf, x64, x6z, zip]
+    ProfileFiles: ['cores\vice_x64_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Vice x64sc
+    StartupArguments: '--core vice_x64sc_libretro --system 30 --game "{ImagePath}"'
+    Platforms: [commodore_64]
+    ImageExtensions: [7z, bin, cmd, crt, d2m, d4m, d64, d6z, d71, d7z, d80, d81, d82, d8z, g41, g4z, g64, g6z, gz, m3u, nbz, nib, p00, prg, t64, tap, vfl, vsf, x64, x6z, zip]
+    ProfileFiles: ['cores\vice_x64sc_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Vice xcbm2
+    StartupArguments: '--core vice_xcbm2_libretro --system 30 --game "{ImagePath}"'
+    Platforms: [commodore_64]
+    ImageExtensions: [7z, bin, cmd, crt, d2m, d4m, d64, d6z, d71, d7z, d80, d81, d82, d8z, g41, g4z, g64, g6z, gz, m3u, nbz, nib, p00, prg, t64, tap, vfl, vsf, x64, x6z, zip]
+    ProfileFiles: ['cores\vice_xcbm2_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Vice xcbm5x0
+    StartupArguments: '--core vice_xcbm5x0_libretro --system 30 --game "{ImagePath}"'
+    Platforms: [commodore_64]
+    ImageExtensions: [7z, bin, cmd, crt, d2m, d4m, d64, d6z, d71, d7z, d80, d81, d82, d8z, g41, g4z, g64, g6z, gz, m3u, nbz, nib, p00, prg, t64, tap, vfl, vsf, x64, x6z, zip]
+    ProfileFiles: ['cores\vice_xcbm5x0_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Vice xpet
+    StartupArguments: '--core vice_xpet_libretro --system 30 --game "{ImagePath}"'
+    Platforms: [commodore_64]
+    ImageExtensions: [7z, bin, cmd, crt, d2m, d4m, d64, d6z, d71, d7z, d80, d81, d82, d8z, g41, g4z, g64, g6z, gz, m3u, nbz, nib, p00, prg, t64, tap, vfl, vsf, x64, x6z, zip]
+    ProfileFiles: ['cores\vice_xpet_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Vice xplus4
+    StartupArguments: '--core vice_xplus4_libretro --system 30 --game "{ImagePath}"'
+    Platforms: [commodore_64]
+    ImageExtensions: []
+    ProfileFiles: ['cores\vice_xplus4_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Vice xscpu64
+    StartupArguments: '--core vice_xscpu64_libretro --system 30 --game "{ImagePath}"'
+    Platforms: [commodore_64]
+    ImageExtensions: [7z, bin, cmd, crt, d2m, d4m, d64, d6z, d71, d7z, d80, d81, d82, d8z, g41, g4z, g64, g6z, gz, m3u, nbz, nib, p00, prg, t64, tap, vfl, vsf, x64, x6z, zip]
+    ProfileFiles: ['cores\vice_xscpu64_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Vice xvic
+    StartupArguments: '--core vice_xvic_libretro --system 34 --game "{ImagePath}"'
+    Platforms: [commodore_vci20]
+    ImageExtensions: [20, 40, 60, 7z, a0, b0, bin, cmd, crt, d2m, d4m, d64, d6z, d71, d7z, d80, d81, d82, d8z, g41, g4z, g64, g6z, gz, m3u, nbz, nib, p00, prg, rom, t64, tap, vfl, vsf, x64, x6z, zip]
+    ProfileFiles: ['cores\vice_xvic_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Virtual Jaguar
+    StartupArguments: '--core virtualjaguar_libretro --system 17 --game "{ImagePath}"'
+    Platforms: [atari_jaguar]
+    ImageExtensions: [j64, rom]
+    ProfileFiles: ['cores\virtualjaguar_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: WASM-4
+    StartupArguments: '--core wasm4_libretro --system 72 --game "{ImagePath}"'
+    Platforms: [wasm4]
+    ImageExtensions: [wasm]
+    ProfileFiles: ['cores\wasm4_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: X1
+    StartupArguments: '--core x1_libretro --system 64 --game "{ImagePath}"'
+    Platforms: [sharp_x1]
+    ImageExtensions: []
+    ProfileFiles: ['cores\x1_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: YabaSanshiro
+    StartupArguments: '--core yabasanshiro_libretro --system 39 --game "{ImagePath}"'
+    Platforms: [sega_saturn]
+    ImageExtensions: [cue]
+    ProfileFiles: ['cores\yabasanshiro_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe\$
+
+  - Name: Yabause
+    StartupArguments: '--core yabause_libretro --system 39 --game "{ImagePath}"'
+    Platforms: [sega_saturn]
+    ImageExtensions: [cue, m3u, iso]
+    ProfileFiles: ['cores\yabause_libretro.dll']
+    StartupExecutable: ^RALibretro\.exe$

--- a/source/Playnite/Emulation/Emulators/RAProject64/emulator.yaml
+++ b/source/Playnite/Emulation/Emulators/RAProject64/emulator.yaml
@@ -1,0 +1,9 @@
+Id: raproject64
+Name: RAProject64
+Website: 'https://github.com/RetroAchievements/RAProject64'
+Profiles:
+  - Name: Default
+    StartupArguments: '"{ImagePath}"'
+    ImageExtensions: [rom, n64, v64, z64, jap, pal, usa, zip, 7z]
+    Platforms: [nintendo_64]
+    StartupExecutable: ^RAProject64\.exe$

--- a/source/Playnite/Emulation/Emulators/RetroArch/emulator.yaml
+++ b/source/Playnite/Emulation/Emulators/RetroArch/emulator.yaml
@@ -16,6 +16,20 @@ Profiles:
     ProfileFiles: ['cores\a5200_libretro.dll']
     StartupExecutable: ^retroarch\.exe$
 
+  - Name: Ardens
+    StartupArguments: '-L ".\cores\ardens_libretro.dll" "{ImagePath}"'
+    Platforms: [arduboy]
+    ImageExtensions: [hex, arduboy]
+    ProfileFiles: ['cores\ardens_libretro.dll']
+    StartupExecutable: ^retroarch\.exe$
+
+  - Name: Arduous
+    StartupArguments: '-L ".\cores\arduous_libretro.dll" "{ImagePath}"'
+    Platforms: [arduboy]
+    ImageExtensions: [hex]
+    ProfileFiles: ['cores\arduous_libretro.dll']
+    StartupExecutable: ^retroarch\.exe$
+
   - Name: Atari800
     StartupArguments: '-L ".\cores\atari800_libretro.dll" "{ImagePath}"'
     Platforms: [atari_5200, atari_8bit]
@@ -373,6 +387,13 @@ Profiles:
     ProfileFiles: ['cores\fceumm_libretro.dll']
     StartupExecutable: ^retroarch\.exe$
 
+  - Name: FinalBurn Neo
+    StartupArguments: '-L ".\cores\fbneo_libretro.dll" "{ImagePath}"'
+    Platforms: [arcade]
+    ImageExtensions: [zip,7z]
+    ProfileFiles: ['cores\fbneo_libretro.dll']
+    StartupExecutable: ^retroarch\.exe$
+
   - Name: fixGB
     StartupArguments: '-L ".\cores\fixgb_libretro.dll" "{ImagePath}"'
     Platforms: [nintendo_gameboy, nintendo_gameboycolor]
@@ -389,14 +410,14 @@ Profiles:
 
   - Name: Flycast
     StartupArguments: '-L ".\cores\flycast_libretro.dll" "{ImagePath}"'
-    Platforms: [sega_dreamcast]
+    Platforms: [sega_dreamcast, arcade]
     ImageExtensions: [7z, bin, cdi, chd, cue, dat, elf, gdi, lst, m3u, zip]
     ProfileFiles: ['cores\flycast_libretro.dll']
     StartupExecutable: ^retroarch\.exe$
 
   - Name: Flycast GLES2
     StartupArguments: '-L ".\cores\flycast_gles2_libretro.dll" "{ImagePath}"'
-    Platforms: [sega_dreamcast]
+    Platforms: [sega_dreamcast, arcade]
     ImageExtensions: [7z, bin, cdi, chd, cue, dat, elf, gdi, iso, lst, m3u, zip]
     ProfileFiles: ['cores\flycast_gles2_libretro.dll']
     StartupExecutable: ^retroarch\.exe$
@@ -478,6 +499,13 @@ Profiles:
     ProfileFiles: ['cores\genesis_plus_gx_wide_libretro.dll']
     StartupExecutable: ^retroarch\.exe$
 
+  - Name: Geolith
+    StartupArguments: '-L ".\cores\geolith_libretro.dll" "{ImagePath}"'
+    Platforms: [snk_neogeo_aes, arcade]
+    ImageExtensions: [neo]
+    ProfileFiles: ['cores\geolith_libretro.dll']
+    StartupExecutable: ^retroarch\.exe$
+
   - Name: gpSP
     StartupArguments: '-L ".\cores\gpsp_libretro.dll" "{ImagePath}"'
     Platforms: [nintendo_gameboyadvance]
@@ -525,6 +553,20 @@ Profiles:
     Platforms: [sega_saturn]
     ImageExtensions: [7z, ccd, chd, cue, iso, m3u, mds, zip]
     ProfileFiles: ['cores\kronos_libretro.dll']
+    StartupExecutable: ^retroarch\.exe$
+
+  - Name: Mame
+    StartupArguments: '-L ".\cores\mame_libretro.dll" "{ImagePath}"'
+    Platforms: [arcade]
+    ImageExtensions: [zip]
+    ProfileFiles: ['cores\mame_libretro.dll']
+    StartupExecutable: ^retroarch\.exe$
+
+  - Name: Mame 2003 Plus
+    StartupArguments: '-L ".\cores\mame2003_plus_libretro.dll" "{ImagePath}"'
+    Platforms: [arcade]
+    ImageExtensions: [zip, cdh]
+    ProfileFiles: ['cores\mame2003_plus_libretro.dll']
     StartupExecutable: ^retroarch\.exe$
 
   - Name: melonDS
@@ -644,6 +686,13 @@ Profiles:
     Platforms: [nintendo_gameboy, nintendo_gameboycolor, nintendo_super_nes]
     ImageExtensions: [7z, bml, gb, gbc, rom, sfc, smc, zip]
     ProfileFiles: ['cores\higan_sfc_balanced_libretro.dll']
+    StartupExecutable: ^retroarch\.exe$
+
+  - Name: Numero
+    StartupArguments: '-L ".\cores\numero_libretro.dll" "{ImagePath}"'
+    Platforms: [ti_83]
+    ImageExtensions: [8xp, 8xk, 8xg]
+    ProfileFiles: ['cores\numero_libretro.dll']
     StartupExecutable: ^retroarch\.exe$
 
   - Name: Opera
@@ -819,6 +868,13 @@ Profiles:
     Platforms: [nintendo_gameboy, nintendo_gameboycolor]
     ImageExtensions: [7z, gb, gbc, zip]
     ProfileFiles: ['cores\sameboy_libretro.dll']
+    StartupExecutable: ^retroarch\.exe$
+
+  - Name: ScummVM
+    StartupArguments: '-L ".\cores\scummvm_libretro.dll" "{ImagePath}"'
+    Platforms: [pc_dos, pc_windows]
+    ImageExtensions: [scummvm]
+    ProfileFiles: ['cores\scummvm_libretro.dll']
     StartupExecutable: ^retroarch\.exe$
 
   - Name: Sinclair ZX 81

--- a/source/Playnite/Emulation/Emulators/Sudachi/emulator.yaml
+++ b/source/Playnite/Emulation/Emulators/Sudachi/emulator.yaml
@@ -1,0 +1,9 @@
+Id: sudachi
+Name: Sudachi
+Website: 'https://github.com/sudachi-emu/sudachi/'
+Profiles:
+  - Name: Default
+    StartupArguments: '"{ImagePath}"'
+    Platforms: [nintendo_switch]
+    ImageExtensions: [nso, nro, nca, xci, nsp]
+    StartupExecutable: ^sudachi\.exe$

--- a/source/Playnite/Emulation/Emulators/Supermodel/emulator.yaml
+++ b/source/Playnite/Emulation/Emulators/Supermodel/emulator.yaml
@@ -1,0 +1,9 @@
+Id: supermodel
+Name: Supermodel
+Website: 'https://github.com/trzy/Supermodel'
+Profiles:
+  - Name: Default
+    StartupArguments: '"{ImagePath}" -fullscreen'
+    Platforms: [arcade]
+    ImageExtensions: [zip]
+    StartupExecutable: ^supermodel\.exe$

--- a/source/Playnite/Emulation/Emulators/Suyu/emulator.yaml
+++ b/source/Playnite/Emulation/Emulators/Suyu/emulator.yaml
@@ -1,0 +1,9 @@
+Id: suyu
+Name: Suyu
+Website: 'https://suyu.dev/'
+Profiles:
+  - Name: Default
+    StartupArguments: '"{ImagePath}"'
+    Platforms: [nintendo_switch]
+    ImageExtensions: [nso, nro, nca, xci, nsp]
+    StartupExecutable: ^suyu\.exe$

--- a/source/Playnite/Emulation/Emulators/TeknoParrot/emulator.yaml
+++ b/source/Playnite/Emulation/Emulators/TeknoParrot/emulator.yaml
@@ -1,0 +1,9 @@
+Id: teknoparrot
+Name: TeknoParrot
+Website: 'https://teknoparrot.com'
+Profiles:
+  - Name: Default
+    StartupArguments: '--profile={ImageNameNoExt}.xml --startMinimized'
+    Platforms: [arcade]
+    ImageExtensions: [teknoparrot, parrot, zip, game,7z ,xml]
+    StartupExecutable: ^TeknoParrotUi\.exe$

--- a/source/Playnite/Emulation/Emulators/VisualPinballX/emulator.yaml
+++ b/source/Playnite/Emulation/Emulators/VisualPinballX/emulator.yaml
@@ -1,0 +1,9 @@
+Id: visualpinballx
+Name: Visual Pinball X
+Website: ''
+Profiles:
+  - Name: Default 64 bit
+    StartupArguments: '-Minimized -Play "{ImagePath}"'
+    Platforms: [arcade]
+    ImageExtensions: [vpx]
+    StartupExecutable: ^VPinballX64\.exe$

--- a/source/Playnite/Emulation/Emulators/Xenia Edge/emulator.yaml
+++ b/source/Playnite/Emulation/Emulators/Xenia Edge/emulator.yaml
@@ -1,0 +1,9 @@
+Id: xenia_edge
+Name: Xenia Edge
+Website: 'https://github.com/has207/xenia-edge'
+Profiles:
+  - Name: Default
+    StartupArguments: '"{ImagePath}"'
+    Platforms: [xbox360]
+    ImageExtensions: [iso, xex, cci, cxi, elf, zar, <none>]
+    StartupExecutable: ^xenia_edge\.exe$

--- a/source/Playnite/Emulation/Emulators/Xenia/emulator.yaml
+++ b/source/Playnite/Emulation/Emulators/Xenia/emulator.yaml
@@ -12,3 +12,8 @@ Profiles:
     Platforms: [xbox360]
     ImageExtensions: [iso, xex, cci, cxi, elf, zar, <none>]
     StartupExecutable: ^xenia_canary\.exe$
+  - Name: Canary Netplay
+    StartupArguments: '"{ImagePath}"'
+    Platforms: [xbox360]
+    ImageExtensions: [iso, xex, cci, cxi, elf, zar, <none>]
+    StartupExecutable: ^xenia_canary_netplay\.exe$

--- a/source/Playnite/Emulation/Emulators/ares/emulator.yaml
+++ b/source/Playnite/Emulation/Emulators/ares/emulator.yaml
@@ -25,12 +25,12 @@ Profiles:
   - Name: Microsoft - MSX
     StartupArguments: '--system "MSX" "{ImagePath}" --fullscreen'
     Platforms: [microsoft_msx]
-    ImageExtensions: [zip, msx]
+    ImageExtensions: [zip, msx, rom, dsk, m3u]
     StartupExecutable: ^ares\.exe$
   - Name: Microsoft - MSX2
     StartupArguments: '--system "MSX2" "{ImagePath}" --fullscreen'
     Platforms: [microsoft_msx2]
-    ImageExtensions: [zip, msx2]
+    ImageExtensions: [zip, msx2, rom, dsk, m3u]
     StartupExecutable: ^ares\.exe$
   - Name: NEC - PC Engine
     StartupArguments: '--system "PC Engine" "{ImagePath}" --fullscreen'

--- a/source/Playnite/Emulation/Emulators/shadPS4/emulator.yaml
+++ b/source/Playnite/Emulation/Emulators/shadPS4/emulator.yaml
@@ -6,5 +6,5 @@ Profiles:
     Platforms: [sony_playstation4]
     ProfileFiles: ['platforms\qwindows.dll']
     StartupExecutable: ^shadPS4.*\.exe$
-    StartupArguments: '-g "{ImagePath}"'
+    StartupArguments: '-d -g "{ImagePath}"'
     ScriptGameImport: true

--- a/source/Playnite/Emulation/Platforms.yaml
+++ b/source/Playnite/Emulation/Platforms.yaml
@@ -3,17 +3,17 @@
   IgdbId: 50
   Databases: [The 3DO Company - 3DO]
   Emulators: [4do, retroarch]
-
+  
 - Name: Adobe Flash
   Id: adobe_flash
   Emulators: [flashplayerprojector, ruffle]
-
+  
 - Name: Amstrad CPC
   Id: amstrad_cpc
   IgdbId: 25
   Databases: [Amstrad - CPC]
   Emulators: [retroarch]
-
+  
 - Name: Apple II
   Id: apple_2
   IgdbId: 75
@@ -33,58 +33,58 @@
   IgdbId: 59
   Databases: [Atari - 2600]
   Emulators: [ares, bizhawk, retroarch, stella]
-
+  
 - Name: Atari 5200
   Id: atari_5200
   IgdbId: 66
   Databases: [Atari - 5200]
   Emulators: [altirra, atari800, retroarch]
-
+  
 - Name: Atari 7800
   Id: atari_7800
   IgdbId: 60
   Databases: [Atari - 7800]
   Emulators: [bizhawk, retroarch]
-
+  
 - Name: Atari 8-bit
   Id: atari_8bit
   IgdbId: 65
   Emulators: [altirra, atari800, retroarch]
-
+  
 - Name: Atari Falcon030
   Id: atari_falcon030
   Emulators: [retroarch]
-
+  
 - Name: Atari Jaguar
   Id: atari_jaguar
   IgdbId: 62
   Databases: [Atari - Jaguar]
   Emulators: [bizhawk, retroarch, virtualjaguar]
-
+  
 - Name: Atari Lynx
   Id: atari_lynx
   IgdbId: 61
   Databases: [Atari - Lynx]
   Emulators: [bizhawk, mednafen, retroarch]
-
+  
 - Name: Atari ST/STE
   Id: atari_st
   IgdbId: 63
   Databases: [Atari - ST]
   Emulators: [retroarch]
-
+  
 - Name: Bandai WonderSwan Color
   Id: bandai_wonderswan_color
   IgdbId: 123
   Databases: [Bandai - WonderSwan Color]
   Emulators: [ares, bizhawk, higan, mednafen, retroarch]
-
+  
 - Name: Bandai WonderSwan
   Id: bandai_wonderswan
   IgdbId: 57
   Databases: [Bandai - WonderSwan]
   Emulators: [ares, bizhawk, higan, mednafen, retroarch]
-
+  
 - Name: Coleco ColecoVision
   Id: coleco_vision
   IgdbId: 68
@@ -96,40 +96,40 @@
   IgdbId: 15
   Databases: [Commodore - 64, Commodore - 64 (PP), Commodore - 64 (Tapes)]
   Emulators: [bizhawk, retroarch, winvice]
-
+  
 - Name: Commodore Amiga CD32
   Id: commodore_amiga_cd32
   IgdbId: 114
   Databases: [Commodore - Amiga]
   Emulators: [fs-uae, winuae]
-
+  
 - Name: Commodore Amiga
   Id: commodore_amiga
   IgdbId: 16
   Databases: [Commodore - Amiga]
   Emulators: [fs-uae, retroarch, winuae]
-
+  
 - Name: Commodore CBM-5x0
   Id: commodore_cbm5x0
   Databases: [Commodore - CBM-5x0]
   Emulators: [retroarch]
-
+  
 - Name: Commodore CBM-II
   Id: commodore_cbm2
   Databases: [Commodore - CBM-II]
   Emulators: [retroarch]
-
+  
 - Name: Commodore PET
   Id: commodore_pet
   IgdbId: 90
   Emulators: [retroarch, winvice]
-
+  
 - Name: Commodore Plus/4
   Id: commodore_plus4
   IgdbId: 94
   Databases: [Commodore - Plus-4]
   Emulators: [winvice]
-
+  
 - Name: Commodore VIC20
   Id: commodore_vci20
   IgdbId: 71
@@ -145,17 +145,17 @@
   IgdbId: 67
   Databases: [GCE - Vectrex]
   Emulators: [bizhawk, retroarch]
-
+  
 - Name: Macintosh
   Id: macintosh
   IgdbId: 14
-
+  
 - Name: Magnavox Odyssey 2
   Id: magnavox_odyssey_2
   IgdbId: 133
   Databases: [Magnavox - Odyssey2]
   Emulators: [bizhawk]
-
+  
 - Name: Mattel Intellivision
   Id: mattel_intellivision
   IgdbId: 67
@@ -170,28 +170,28 @@
   Id: microsoft_msx
   IgdbId: 27
   Databases: [Microsoft - MSX]
-  Emulators: [ares, bluemsx, retroarch, fbneo]
-
+  Emulators: [ares, bluemsx, retroarch]
+  
 - Name: Microsoft MSX2
   Id: microsoft_msx2
   IgdbId: 53
   Databases: [Microsoft - MSX2]
   Emulators: [ares, bluemsx, retroarch]
-
+  
 - Name: Microsoft Xbox 360
   Id: xbox360
   IgdbId: 12
   Databases: [Microsoft - Xbox 360, Microsoft - XBOX 360 (Digital), Microsoft - XBOX 360 (Games on Demand)]
-  Emulators: [xenia, xenia_edge]
-
+  Emulators: [xenia]
+  
 - Name: Microsoft Xbox One
   Id: xbox_one
   IgdbId: 49
-
+  
 - Name: Microsoft Xbox Series
   Id: xbox_series
   IgdbId: 169
-
+  
 - Name: Microsoft Xbox
   Id: xbox
   IgdbId: 11
@@ -207,7 +207,7 @@
   IgdbId: 149
   Databases: [NEC - PC-98]
   Emulators: [retroarch]
-
+  
 - Name: NEC PC-FX
   Id: nec_pcfx
   IgdbId: 274
@@ -231,7 +231,7 @@
   IgdbId: 150
   Databases: [NEC - PC Engine CD - TurboGrafx-CD]
   Emulators: [ares, bizhawk, higan, mednafen, mesen, retroarch]
-
+  
 - Name: Nintendo 3DS
   Id: nintendo_3ds
   IgdbId: 37
@@ -249,13 +249,13 @@
   IgdbId: 20
   Databases: [Nintendo - Nintendo DS, Nintendo - Nintendo DS (Download Play)]
   Emulators: [bizhawk, desmume, gbe+, melonds, retroarch]
-
+  
 - Name: Nintendo DSi
   Id: nintendo_dsi
   IgdbId: 159
   Databases: [Nintendo - Nintendo DSi, Nintendo - Nintendo DSi (Digital)]
   Emulators: [bizhawk, melonds]
-
+  
 - Name: Nintendo Entertainment System
   Id: nintendo_nes
   IgdbId: 18
@@ -277,25 +277,25 @@
   IgdbId: 24
   Databases: [Nintendo - Game Boy Advance]
   Emulators: [ares, bizhawk, gbe+, higan, mednafen, mgba, nanoboyadvance, retroarch, visualboyadvance, visualboyadvance-m]
-
+  
 - Name: Nintendo Game Boy Color
   Id: nintendo_gameboycolor
   IgdbId: 22
   Databases: [Nintendo - Game Boy Color]
   Emulators: [ares, bgb, bizhawk, gambatte, gbe+, higan, jgenesis, mednafen, mesen, mgba, retroarch, sameboy, visualboyadvance, visualboyadvance-m]
-
+  
 - Name: Nintendo Game Boy
   Id: nintendo_gameboy
   IgdbId: 33
   Databases: [Nintendo - Game Boy]
   Emulators: [ares, bgb, bizhawk, gambatte, gbe+, higan, jgenesis, mednafen, mesen, mgba, retroarch, sameboy, visualboyadvance, visualboyadvance-m]
-
+  
 - Name: Nintendo GameCube
   Id: nintendo_gamecube
   IgdbId: 21
   Databases: [Nintendo - GameCube]
   Emulators: [dolphin, retroarch]
-
+  
 - Name: Nintendo SNES
   Id: nintendo_super_nes
   IgdbId: 19
@@ -310,40 +310,40 @@
 - Name: Nintendo Switch 2
   Id: nintendo_switch2
   IgdbId: 508
-
+  
 - Name: Nintendo Virtual Boy
   Id: nintendo_virtualboy
   IgdbId: 87
   Databases: [Nintendo - Virtual Boy]
   Emulators: [bizhawk, mednafen, retroarch]
-
+  
 - Name: Nintendo Wii U
   Id: nintendo_wiiu
   IgdbId: 41
   Databases: [Nintendo - Wii U, Nintendo - Wii U (Digital)]
   Emulators: [cemu, decaf-emu]
-
+  
 - Name: Nintendo Wii
   Id: nintendo_wii
   IgdbId: 5
   Databases: [Nintendo - Wii, Nintendo - Wii (Digital)]
   Emulators: [dolphin, retroarch]
-
+  
 - Name: PC (DOS)
   Id: pc_dos
   IgdbId: 13
   Databases: [DOS]
   Emulators: [dosbox, pcem, retroarch, scummvm]
-
+  
 - Name: PC (Linux)
   Id: pc_linux
   IgdbId: 3
-
+  
 - Name: PC (Windows)
   Id: pc_windows
   IgdbId: 6
   Emulators: [pcem, scummvm]
-
+  
 - Name: Sega 32X
   Id: sega_32x
   IgdbId: 30
@@ -361,7 +361,7 @@
   IgdbId: 23
   Databases: [Sega - Dreamcast]
   Emulators: [demul, flycast, nulldc, redream, reicast, retroarch]
-
+  
 - Name: Sega Game Gear
   Id: sega_gamegear
   IgdbId: 35
@@ -385,7 +385,7 @@
   IgdbId: 32
   Databases: [Sega - Saturn]
   Emulators: [ares, bizhawk, mednafen, retroarch, yabuse, ymir]
-
+  
 - Name: Sega SG-1000
   Id: sega_sg1000
   IgdbId: 84
@@ -406,7 +406,7 @@
   Id: sinclair_zxspectrum3
   Databases: [Sinclair - ZX Spectrum +3]
   Emulators: [fuse, retroarch]
-
+  
 - Name: Sinclair ZX Spectrum
   Id: sinclair_zxspectrum
   IgdbId: 26
@@ -418,24 +418,24 @@
   IgdbId: 373
   Databases: [Sinclair - ZX 81]
   Emulators: [retroarch]
-
+  
 - Name: SNK Neo Geo AES
   Id: snk_neogeo_aes
   IgdbId: 80
   Emulators: [ares]
-
+  
 - Name: SNK Neo Geo CD
   Id: snk_neogeo_cd
   IgdbId: 136
   Databases: [SNK - Neo Geo CD]
-  Emulators: [fbneo, retroarch]
-
+  Emulators: [retroarch]
+  
 - Name: SNK Neo Geo Pocket Color
   Id: snk_neogeopocket_color
   IgdbId: 120
   Databases: [SNK - Neo Geo Pocket Color]
   Emulators: [ares, bizhawk, mednafen, retroarch]
-
+  
 - Name: SNK Neo Geo Pocket
   Id: snk_neogeopocket
   IgdbId: 119
@@ -447,40 +447,40 @@
   IgdbId: 8
   Databases: [Sony - PlayStation 2]
   Emulators: [pcsx2, retroarch]
-
+  
 - Name: Sony PlayStation 3
   Id: sony_playstation3
   IgdbId: 9
   Databases: [Sony - PlayStation 3, Sony - PlayStation 3 (PSN)]
   Emulators: [rpcs3]
-
+  
 - Name: Sony PlayStation 4
   Id: sony_playstation4
   IgdbId: 48
   Emulators: [shadps4]
-
+  
 - Name: Sony PlayStation 5
   Id: sony_playstation5
   IgdbId: 167
-
+  
 - Name: Sony PlayStation Portable
   Id: sony_psp
   IgdbId: 38
   Databases: [Sony - PlayStation Portable, Sony - PlayStation Portable (PSN), Sony - PlayStation Portable (PSX2PSP)]
   Emulators: [ppsspp, retroarch]
-
+  
 - Name: Sony PlayStation Vita
   Id: sony_vita
   IgdbId: 46
   Databases: [Sony - PlayStation Vita, Sony - PlayStation Vita (PSN)]
   Emulators: [vita3k]
-
+  
 - Name: Sony PlayStation
   Id: sony_playstation
   IgdbId: 7
   Databases: [Sony - PlayStation]
   Emulators: [ares, bizhawk, duckstation, epsxe, mednafen, pcsxr-pgxp, retroarch]
-
+  
 - Name: Texas Instruments TI-83
   Id: ti_83
   Databases: [TIC-80]
@@ -491,16 +491,16 @@
   IgdbId: 156
   Databases: [Thomson - MOTO]
   Emulators: [retroarch]
-
+  
 - Name: Thomson TO7
   Id: thomson_to7
   Databases: [Thomson - MOTO]
   Emulators: [retroarch]
-
+  
 - Name: TIC-80
   Id: tic_80
   Emulators: [bizhawk]
-
+  
 - Name: Uzebox
   Id: uzebox
   Databases: [Uzebox]

--- a/source/Playnite/Emulation/Platforms.yaml
+++ b/source/Playnite/Emulation/Platforms.yaml
@@ -3,478 +3,512 @@
   IgdbId: 50
   Databases: [The 3DO Company - 3DO]
   Emulators: [4do, retroarch]
-  
+
 - Name: Adobe Flash
   Id: adobe_flash
   Emulators: [flashplayerprojector, ruffle]
-  
+
 - Name: Amstrad CPC
   Id: amstrad_cpc
   IgdbId: 25
   Databases: [Amstrad - CPC]
   Emulators: [retroarch]
-  
+
 - Name: Apple II
   Id: apple_2
   IgdbId: 75
   Emulators: [bizhawk, mednafen]
-  
+
+- Name: Arcade
+  Id: arcade
+  IgdbId: 52
+  Emulators: [mame, fbneo, flycast, model2emulator, retroarch, supermodel, teknoparrot, visualpinballx]
+
+- Name: Arduboy
+  Id: arduboy
+  Emulators: [ralibretro, retroarch]
+
 - Name: Atari 2600
   Id: atari_2600
   IgdbId: 59
   Databases: [Atari - 2600]
   Emulators: [ares, bizhawk, retroarch, stella]
-  
+
 - Name: Atari 5200
   Id: atari_5200
   IgdbId: 66
   Databases: [Atari - 5200]
   Emulators: [altirra, atari800, retroarch]
-  
+
 - Name: Atari 7800
   Id: atari_7800
   IgdbId: 60
   Databases: [Atari - 7800]
   Emulators: [bizhawk, retroarch]
-  
+
 - Name: Atari 8-bit
   Id: atari_8bit
   IgdbId: 65
   Emulators: [altirra, atari800, retroarch]
-  
+
 - Name: Atari Falcon030
   Id: atari_falcon030
   Emulators: [retroarch]
-  
+
 - Name: Atari Jaguar
   Id: atari_jaguar
   IgdbId: 62
   Databases: [Atari - Jaguar]
   Emulators: [bizhawk, retroarch, virtualjaguar]
-  
+
 - Name: Atari Lynx
   Id: atari_lynx
   IgdbId: 61
   Databases: [Atari - Lynx]
   Emulators: [bizhawk, mednafen, retroarch]
-  
+
 - Name: Atari ST/STE
   Id: atari_st
   IgdbId: 63
   Databases: [Atari - ST]
   Emulators: [retroarch]
-  
+
 - Name: Bandai WonderSwan Color
   Id: bandai_wonderswan_color
   IgdbId: 123
   Databases: [Bandai - WonderSwan Color]
   Emulators: [ares, bizhawk, higan, mednafen, retroarch]
-  
+
 - Name: Bandai WonderSwan
   Id: bandai_wonderswan
   IgdbId: 57
   Databases: [Bandai - WonderSwan]
   Emulators: [ares, bizhawk, higan, mednafen, retroarch]
-  
+
 - Name: Coleco ColecoVision
   Id: coleco_vision
   IgdbId: 68
   Databases: [Coleco - ColecoVision]
-  Emulators: [ares, bizhawk, bluemsx, fbalpha, retroarch]
-  
+  Emulators: [ares, bizhawk, bluemsx, fbalpha, fbneo, retroarch]
+
 - Name: Commodore 64
   Id: commodore_64
   IgdbId: 15
   Databases: [Commodore - 64, Commodore - 64 (PP), Commodore - 64 (Tapes)]
   Emulators: [bizhawk, retroarch, winvice]
-  
+
 - Name: Commodore Amiga CD32
   Id: commodore_amiga_cd32
   IgdbId: 114
   Databases: [Commodore - Amiga]
   Emulators: [fs-uae, winuae]
-  
+
 - Name: Commodore Amiga
   Id: commodore_amiga
   IgdbId: 16
   Databases: [Commodore - Amiga]
   Emulators: [fs-uae, retroarch, winuae]
-  
+
 - Name: Commodore CBM-5x0
   Id: commodore_cbm5x0
   Databases: [Commodore - CBM-5x0]
   Emulators: [retroarch]
-  
+
 - Name: Commodore CBM-II
   Id: commodore_cbm2
   Databases: [Commodore - CBM-II]
   Emulators: [retroarch]
-  
+
 - Name: Commodore PET
   Id: commodore_pet
   IgdbId: 90
   Emulators: [retroarch, winvice]
-  
+
 - Name: Commodore Plus/4
   Id: commodore_plus4
   IgdbId: 94
   Databases: [Commodore - Plus-4]
   Emulators: [winvice]
-  
+
 - Name: Commodore VIC20
   Id: commodore_vci20
   IgdbId: 71
   Databases: [Commodore - VIC-20]
   Emulators: [retroarch, winvice]
-  
+
+- Name: Fairchild Channel F
+  Id: fairchild_channelf
+  Emulators: [ralibretro, fbneo]
+
 - Name: GCE Vectrex
   Id: vectrex
   IgdbId: 67
   Databases: [GCE - Vectrex]
   Emulators: [bizhawk, retroarch]
-  
+
 - Name: Macintosh
   Id: macintosh
   IgdbId: 14
-  
+
 - Name: Magnavox Odyssey 2
   Id: magnavox_odyssey_2
   IgdbId: 133
   Databases: [Magnavox - Odyssey2]
   Emulators: [bizhawk]
-  
+
 - Name: Mattel Intellivision
   Id: mattel_intellivision
   IgdbId: 67
   Databases: [Mattel - Intellivision]
   Emulators: [bizhawk, retroarch]
-  
+
+- Name: Mega Duck
+  Id: megaduck
+  Emulators: [ralibretro]
+
 - Name: Microsoft MSX
   Id: microsoft_msx
   IgdbId: 27
   Databases: [Microsoft - MSX]
-  Emulators: [ares, bluemsx, retroarch]
-  
+  Emulators: [ares, bluemsx, retroarch, fbneo]
+
 - Name: Microsoft MSX2
   Id: microsoft_msx2
   IgdbId: 53
   Databases: [Microsoft - MSX2]
   Emulators: [ares, bluemsx, retroarch]
-  
+
 - Name: Microsoft Xbox 360
   Id: xbox360
   IgdbId: 12
   Databases: [Microsoft - Xbox 360, Microsoft - XBOX 360 (Digital), Microsoft - XBOX 360 (Games on Demand)]
-  Emulators: [xenia]
-  
+  Emulators: [xenia, xenia_edge]
+
 - Name: Microsoft Xbox One
   Id: xbox_one
   IgdbId: 49
-  
+
 - Name: Microsoft Xbox Series
   Id: xbox_series
   IgdbId: 169
-  
+
 - Name: Microsoft Xbox
   Id: xbox
   IgdbId: 11
   Databases: [Microsoft - Xbox]
   Emulators: [cxbx-reloaded, retroarch, xemu]
-  
+
+- Name: NEC PC-88
+  Id: nec_pc88
+  Emulators: [ralibretro]
+
 - Name: NEC PC-98
   Id: nec_pc98
   IgdbId: 149
   Databases: [NEC - PC-98]
   Emulators: [retroarch]
-  
+
 - Name: NEC PC-FX
   Id: nec_pcfx
   IgdbId: 274
   Databases: [NEC - PC-FX]
-  Emulators: [mednafen, retroarch]
-  
+  Emulators: [bizhawk, mednafen, retroarch]
+
 - Name: NEC SuperGrafx
   Id: nec_supergrafx
   IgdbId: 128
   Databases: [NEC - PC Engine SuperGrafx]
-  Emulators: [ares, bizhawk, higan, mednafen, mesen, retroarch]
-  
+  Emulators: [ares, bizhawk, fbneo, higan, mednafen, mesen, retroarch]
+
 - Name: NEC TurboGrafx 16
   Id: nec_turbografx_16
   IgdbId: 86
   Databases: [NEC - PC Engine - TurboGrafx 16]
-  Emulators: [ares, bizhawk, higan, mednafen, mesen, retroarch]
-  
+  Emulators: [ares, bizhawk, fbneo, higan, mednafen, mesen, retroarch]
+
 - Name: NEC TurboGrafx-CD
   Id: nec_turbografx_cd
   IgdbId: 150
   Databases: [NEC - PC Engine CD - TurboGrafx-CD]
   Emulators: [ares, bizhawk, higan, mednafen, mesen, retroarch]
-  
+
 - Name: Nintendo 3DS
   Id: nintendo_3ds
   IgdbId: 37
   Databases: [Nintendo - Nintendo 3DS, Nintendo - Nintendo 3DS (Digital)]
-  Emulators: [citra, retroarch]
-  
+  Emulators: [azahar, bizhawk, borked3ds, citra, retroarch]
+
 - Name: Nintendo 64
   Id: nintendo_64
   IgdbId: 4
   Databases: [Nintendo - Nintendo 64, Nintendo - Nintendo 64DD]
-  Emulators: [ares, bizhawk, m64p, m64py, project64, retroarch, rosaliesmupengui, simple64, gopher64]
-  
+  Emulators: [ares, bizhawk, m64p, m64py, raproject64, project64, retroarch, rosaliesmupengui, simple64, gopher64]
+
 - Name: Nintendo DS
   Id: nintendo_ds
   IgdbId: 20
   Databases: [Nintendo - Nintendo DS, Nintendo - Nintendo DS (Download Play)]
   Emulators: [bizhawk, desmume, gbe+, melonds, retroarch]
-  
+
 - Name: Nintendo DSi
   Id: nintendo_dsi
   IgdbId: 159
   Databases: [Nintendo - Nintendo DSi, Nintendo - Nintendo DSi (Digital)]
   Emulators: [bizhawk, melonds]
-  
+
 - Name: Nintendo Entertainment System
   Id: nintendo_nes
   IgdbId: 18
   Databases: [Nintendo - Nintendo Entertainment System]
-  Emulators: [ares, bizhawk, fceux, higan, jgenesis, mednafen, mesen, nestopia, punes, retroarch]
-  
+  Emulators: [ares, bizhawk, fbneo, fceux, higan, jgenesis, mednafen, mesen, nestopia, punes, retroarch]
+
 - Name: Nintendo Family Computer Disk System
   Id: nintendo_famicom_disk
   IgdbId: 51
   Databases: [Nintendo - Family Computer Disk System]
-  Emulators: [fceux, retroarch]
-  
+  Emulators: [fbneo, fceux, retroarch]
+
+- Name: Nintendo Game & Watch
+  Id: nintendo_gameandwatch
+  Emulators: [ralibretro]
+
 - Name: Nintendo Game Boy Advance
   Id: nintendo_gameboyadvance
   IgdbId: 24
   Databases: [Nintendo - Game Boy Advance]
   Emulators: [ares, bizhawk, gbe+, higan, mednafen, mgba, nanoboyadvance, retroarch, visualboyadvance, visualboyadvance-m]
-  
+
 - Name: Nintendo Game Boy Color
   Id: nintendo_gameboycolor
   IgdbId: 22
   Databases: [Nintendo - Game Boy Color]
   Emulators: [ares, bgb, bizhawk, gambatte, gbe+, higan, jgenesis, mednafen, mesen, mgba, retroarch, sameboy, visualboyadvance, visualboyadvance-m]
-  
+
 - Name: Nintendo Game Boy
   Id: nintendo_gameboy
   IgdbId: 33
   Databases: [Nintendo - Game Boy]
   Emulators: [ares, bgb, bizhawk, gambatte, gbe+, higan, jgenesis, mednafen, mesen, mgba, retroarch, sameboy, visualboyadvance, visualboyadvance-m]
-  
+
 - Name: Nintendo GameCube
   Id: nintendo_gamecube
   IgdbId: 21
   Databases: [Nintendo - GameCube]
   Emulators: [dolphin, retroarch]
-  
+
 - Name: Nintendo SNES
   Id: nintendo_super_nes
   IgdbId: 19
   Databases: [Nintendo - Super Nintendo Entertainment System]
-  Emulators: [ares, bizhawk, bsnes, bsnes-hd, bsnes-mt, higan, jgenesis, mednafen, mesen, mesen-s, retroarch, snes9x, zsnes]
-  
+  Emulators: [ares, bizhawk, bsnes, bsnes-hd, bsnes-mt, fbneo, higan, jgenesis, mednafen, mesen, mesen-s, retroarch, snes9x, zsnes]
+
 - Name: Nintendo Switch
   Id: nintendo_switch
   IgdbId: 130
+  Emulators: [eden, sudachi] #Suyu and Citron are supported but not recommended for download here due to inactivity (Suyu)/shady behavior (Citron)
 
 - Name: Nintendo Switch 2
   Id: nintendo_switch2
   IgdbId: 508
-  
+
 - Name: Nintendo Virtual Boy
   Id: nintendo_virtualboy
   IgdbId: 87
   Databases: [Nintendo - Virtual Boy]
   Emulators: [bizhawk, mednafen, retroarch]
-  
+
 - Name: Nintendo Wii U
   Id: nintendo_wiiu
   IgdbId: 41
   Databases: [Nintendo - Wii U, Nintendo - Wii U (Digital)]
   Emulators: [cemu, decaf-emu]
-  
+
 - Name: Nintendo Wii
   Id: nintendo_wii
   IgdbId: 5
   Databases: [Nintendo - Wii, Nintendo - Wii (Digital)]
   Emulators: [dolphin, retroarch]
-  
+
 - Name: PC (DOS)
   Id: pc_dos
   IgdbId: 13
   Databases: [DOS]
   Emulators: [dosbox, pcem, retroarch, scummvm]
-  
+
 - Name: PC (Linux)
   Id: pc_linux
   IgdbId: 3
-  
+
 - Name: PC (Windows)
   Id: pc_windows
   IgdbId: 6
   Emulators: [pcem, scummvm]
-  
+
 - Name: Sega 32X
   Id: sega_32x
   IgdbId: 30
   Databases: [Sega - 32X]
-  Emulators: [ares, jgenesis, kegafusion, retroarch]
-  
+  Emulators: [ares, bizhawk, jgenesis, kegafusion, retroarch]
+
 - Name: Sega CD
   Id: sega_cd
   IgdbId: 78
   Databases: [Sega - Mega-CD - Sega CD]
-  Emulators: [ares, jgenesis, kegafusion, retroarch]
-  
+  Emulators: [ares, bizhawk, jgenesis, kegafusion, retroarch]
+
 - Name: Sega Dreamcast
   Id: sega_dreamcast
   IgdbId: 23
   Databases: [Sega - Dreamcast]
   Emulators: [demul, flycast, nulldc, redream, reicast, retroarch]
-  
+
 - Name: Sega Game Gear
   Id: sega_gamegear
   IgdbId: 35
   Databases: [Sega - Game Gear]
-  Emulators: [ares, bizhawk, higan, jgenesis, kegafusion, mednafen, retroarch]
-  
+  Emulators: [ares, bizhawk, fbneo, higan, jgenesis, kegafusion, mednafen, retroarch]
+
 - Name: Sega Genesis
   Id: sega_genesis
   IgdbId: 29
   Databases: [Sega - Mega Drive - Genesis]
-  Emulators: [bizhawk, blastem, higan, jgenesis, kegafusion, mednafen, retroarch, ares]
-  
+  Emulators: [bizhawk, blastem, fbneo, higan, jgenesis, kegafusion, mednafen, retroarch, ares]
+
 - Name: Sega Master System
   Id: sega_mastersystem
   IgdbId: 64
   Databases: [Sega - Master System - Mark III]
-  Emulators: [ares, bizhawk, higan, jgenesis, kegafusion, mednafen, retroarch]
-  
+  Emulators: [ares, bizhawk, fbneo, higan, jgenesis, kegafusion, mednafen, retroarch]
+
 - Name: Sega Saturn
   Id: sega_saturn
   IgdbId: 32
   Databases: [Sega - Saturn]
   Emulators: [ares, bizhawk, mednafen, retroarch, yabuse, ymir]
-  
+
 - Name: Sega SG-1000
   Id: sega_sg1000
   IgdbId: 84
   Databases: [Sega - SG-1000]
-  Emulators: [ares, retroarch]
-  
+  Emulators: [ares, bizhawk, fbneo, retroarch]
+
+- Name: Sharp X1
+  Id: sharp_x1
+  Emulators: [ralibretro]
+
 - Name: Sharp X68000
   Id: sharp_x68000
   IgdbId: 121
   Databases: [Sharp - X68000]
-  Emulators: [retroarch]
-  
+  Emulators: [retroarch, ralibretro]
+
 - Name: Sinclair ZX Spectrum +3
   Id: sinclair_zxspectrum3
   Databases: [Sinclair - ZX Spectrum +3]
   Emulators: [fuse, retroarch]
-  
+
 - Name: Sinclair ZX Spectrum
   Id: sinclair_zxspectrum
   IgdbId: 26
   Databases: [Sinclair - ZX Spectrum]
-  Emulators: [bizhawk, fuse, retroarch]
-  
+  Emulators: [bizhawk, fbneo, fuse, retroarch]
+
 - Name: Sinclair ZX81
   Id: sinclair_zx81
   IgdbId: 373
   Databases: [Sinclair - ZX 81]
   Emulators: [retroarch]
-  
+
 - Name: SNK Neo Geo AES
   Id: snk_neogeo_aes
   IgdbId: 80
   Emulators: [ares]
-  
+
 - Name: SNK Neo Geo CD
   Id: snk_neogeo_cd
   IgdbId: 136
   Databases: [SNK - Neo Geo CD]
-  Emulators: [retroarch]
-  
+  Emulators: [fbneo, retroarch]
+
 - Name: SNK Neo Geo Pocket Color
   Id: snk_neogeopocket_color
   IgdbId: 120
   Databases: [SNK - Neo Geo Pocket Color]
   Emulators: [ares, bizhawk, mednafen, retroarch]
-  
+
 - Name: SNK Neo Geo Pocket
   Id: snk_neogeopocket
   IgdbId: 119
   Databases: [SNK - Neo Geo Pocket]
-  Emulators: [ares, bizhawk, mednafen, retroarch]
-  
+  Emulators: [ares, bizhawk, fbneo, mednafen, retroarch]
+
 - Name: Sony PlayStation 2
   Id: sony_playstation2
   IgdbId: 8
   Databases: [Sony - PlayStation 2]
   Emulators: [pcsx2, retroarch]
-  
+
 - Name: Sony PlayStation 3
   Id: sony_playstation3
   IgdbId: 9
   Databases: [Sony - PlayStation 3, Sony - PlayStation 3 (PSN)]
   Emulators: [rpcs3]
-  
+
 - Name: Sony PlayStation 4
   Id: sony_playstation4
   IgdbId: 48
   Emulators: [shadps4]
-  
+
 - Name: Sony PlayStation 5
   Id: sony_playstation5
   IgdbId: 167
-  
+
 - Name: Sony PlayStation Portable
   Id: sony_psp
   IgdbId: 38
   Databases: [Sony - PlayStation Portable, Sony - PlayStation Portable (PSN), Sony - PlayStation Portable (PSX2PSP)]
   Emulators: [ppsspp, retroarch]
-  
+
 - Name: Sony PlayStation Vita
   Id: sony_vita
   IgdbId: 46
   Databases: [Sony - PlayStation Vita, Sony - PlayStation Vita (PSN)]
   Emulators: [vita3k]
-  
+
 - Name: Sony PlayStation
   Id: sony_playstation
   IgdbId: 7
   Databases: [Sony - PlayStation]
   Emulators: [ares, bizhawk, duckstation, epsxe, mednafen, pcsxr-pgxp, retroarch]
-  
+
 - Name: Texas Instruments TI-83
   Id: ti_83
   Databases: [TIC-80]
-  Emulators: [bizhawk]
-  
+  Emulators: [bizhawk, retroarch]
+
 - Name: Thomson MO5
   Id: thomson_mo5
   IgdbId: 156
   Databases: [Thomson - MOTO]
   Emulators: [retroarch]
-  
+
 - Name: Thomson TO7
   Id: thomson_to7
   Databases: [Thomson - MOTO]
   Emulators: [retroarch]
-  
+
 - Name: TIC-80
   Id: tic_80
   Emulators: [bizhawk]
-  
+
 - Name: Uzebox
   Id: uzebox
   Databases: [Uzebox]
   Emulators: [bizhawk]
+
+- Name: WASM-4
+  Id: wasm4
+  Emulators: [ralibretro]
 
 - Name: Watara Supervision
   Id: watara_supervision
@@ -488,6 +522,4 @@
 - Name: Pokémon mini
   Id: pokemon_mini
   IgdbId: 166
-
-- Name: Arcade
-  Id: arcade
+  Emulators: [ralibretro]


### PR DESCRIPTION
This is basically all of Extra Emulator Profiles. Few changes:

- Less Switch emulators listed with the platform just to not recommend them (commented in platforms.yaml).
- Removed two TODO comments from RetroArch: `ep128emu` and `m2000` - didn't get around to figuring out how they work
- Removed an added `-nogui` from PCSX2. Don't think it's necessary when fullscreen is already a command line switch that's used. Maybe there's a use case where it makes sense though? Don't feel strongly either way.

One thing that probably deserves some explanation is the `-d` addition to shadPS4: it selects the default instance of shadPS4 to launch your game. The QT launcher can host multiple instances now. Tested again to confirm it works with 0.15.