### PR TITLE
Move Fullscreen Mode's PlayMusic() Call

### DIFF
--- a/source/Playnite.FullscreenApp/FullscreenApplication.cs
+++ b/source/Playnite.FullscreenApp/FullscreenApplication.cs
@@ -419,10 +419,6 @@ namespace Playnite.FullscreenApp
                 {
                     BackgroundMusic = Audio.LoadMusic(backgroundSoundPath);
                     Audio.SetMusicVolume(AppSettings.Fullscreen.BackgroundVolume);
-                    if (Current.AppSettings.Fullscreen.BackgroundVolume > 0)
-                    {
-                        Audio.PlayMusic(BackgroundMusic);
-                    }
                 }
                 catch (Exception e) when (!PlayniteEnvironment.ThrowAllErrors)
                 {

--- a/source/Playnite.FullscreenApp/ViewModels/FullscreenAppViewModel.cs
+++ b/source/Playnite.FullscreenApp/ViewModels/FullscreenAppViewModel.cs
@@ -976,6 +976,12 @@ namespace Playnite.FullscreenApp.ViewModels
             GameListFocused = true;
             isInitialized = true;
             RunStartupScript();
+
+            if (AppSettings.Fullscreen.BackgroundVolume > 0)
+            {
+                audio.PlayMusic(FullscreenApplication.BackgroundMusic);
+            }
+
             Extensions.NotifiyOnApplicationStarted();
 
             try


### PR DESCRIPTION
Move Fullscreen PlayMusic() from FullscreenApplication.InitializeAudio to FullscreenAppViewModel.InitializeView

Addresses an issue where Fullscreen background music sometimes fires early before the fullscreen window fully appears.