### PR TITLE
Update FadeImage.xaml to display true 4k image backgrounds

### DIFF
--- a/source/Playnite/Controls/FadeImage.xaml
+++ b/source/Playnite/Controls/FadeImage.xaml
@@ -6,12 +6,6 @@
              mc:Ignorable="d" 
              Name="ControlRoot"             
              d:DesignHeight="450" d:DesignWidth="800">
-    
-    <UserControl.CacheMode>
-        <BitmapCache EnableClearType="False" 
-                     RenderAtScale="1" 
-                     SnapsToDevicePixels="False" />
-    </UserControl.CacheMode>
 
     <UserControl.Resources>
         <Storyboard x:Key="Image1FadeIn">


### PR DESCRIPTION
Removed <UserControl.CacheMode> bracket to display full resolution background images.
Now the 4k background images in desktop mode and fullscreen mode displays in native resolution.
