### PR TITLE
Add search modes support (Normal, Fuzzy, Regex) to different components

### DIFF
--- a/source/Playnite.DesktopApp/Controls/DdItemListSelectionBox.cs
+++ b/source/Playnite.DesktopApp/Controls/DdItemListSelectionBox.cs
@@ -171,6 +171,14 @@ namespace Playnite.DesktopApp.Controls
                     this,
                     nameof(ItemsList) + "." + nameof(ItemsList.SearchText),
                     BindingMode.TwoWay);
+
+                BindingTools.SetBinding(
+                    TextSearchBox,
+                    SearchBox.SearchModeProperty,
+                    this,
+                    nameof(ItemsList) + "." + nameof(ItemsList.SearchMode),
+                    BindingMode.TwoWay,
+                    delay: 100);
             }
 
             UpdateTextStatus();

--- a/source/Playnite.DesktopApp/Controls/SearchBox.cs
+++ b/source/Playnite.DesktopApp/Controls/SearchBox.cs
@@ -1,5 +1,6 @@
 ﻿using Playnite.Common;
 using Playnite.DesktopApp.ViewModels;
+using Playnite.SDK.Models;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -14,15 +15,47 @@ namespace Playnite.DesktopApp.Controls
     [TemplatePart(Name = "PART_SeachIcon", Type = typeof(FrameworkElement))]
     [TemplatePart(Name = "PART_ClearTextIcon", Type = typeof(FrameworkElement))]
     [TemplatePart(Name = "PART_TextInpuText", Type = typeof(TextBox))]
+    [TemplatePart(Name = "PART_ModeButton", Type = typeof(Button))]
     public class SearchBox : Control
     {
         private FrameworkElement ElemSeachIcon;
         private FrameworkElement ElemClearTextIcon;
         private TextBox TextInputText;
+        private Button ElemModeButton;
 
         private int oldCarret;
         private bool ignoreTextCallback;
+
         internal IInputElement previousFocus;
+
+        public SearchMode SearchMode
+        {
+            get
+            {
+                return (SearchMode)GetValue(SearchModeProperty);
+            }
+            set
+            {
+                SetValue(SearchModeProperty, value);
+            }
+        }
+
+        public static readonly DependencyProperty SearchModeProperty =
+            DependencyProperty.Register(
+                nameof(SearchMode),
+                typeof(SearchMode),
+                typeof(SearchBox),
+                new PropertyMetadata(
+                    SearchMode.Normal,
+                    SearchModeChangedCalllback));
+
+        private static void SearchModeChangedCalllback(
+            DependencyObject sender,
+            DependencyPropertyChangedEventArgs e)
+        {
+            var control = (SearchBox)sender;
+            control.UpdateModeButton();
+        }
 
         public string Text
         {
@@ -87,6 +120,14 @@ namespace Playnite.DesktopApp.Controls
             {
             }
 
+            ElemModeButton = Template.FindName("PART_ModeButton", this) as Button;
+            if (ElemModeButton != null)
+            {
+                ElemModeButton.Click += ModeButton_Click;
+                // To keep textbox focused
+                ElemModeButton.Focusable = false;
+            }
+
             ElemClearTextIcon = Template.FindName("PART_ClearTextIcon", this) as FrameworkElement;
             if (ElemClearTextIcon != null)
             {
@@ -110,13 +151,64 @@ namespace Playnite.DesktopApp.Controls
                     trigger: System.Windows.Data.UpdateSourceTrigger.PropertyChanged);
             }
 
+            UpdateModeButton();
             UpdateIconStates();
+        }
+
+        private void UpdateModeButton()
+        {
+            if (ElemModeButton == null)
+            {
+                return;
+            }
+
+            switch (SearchMode)
+            {
+                case SearchMode.Normal:
+                    ElemModeButton.Content = "⌕";
+                    ElemModeButton.ToolTip =
+                        "Normal Search\nFinds exact text matches.";
+                    break;
+
+                case SearchMode.Fuzzy:
+                    ElemModeButton.Content = "≈";
+                    ElemModeButton.ToolTip =
+                        "Fuzzy Search\nApproximate matching that tolerates typos and partial matches.";
+                    break;
+
+                case SearchMode.Regex:
+                    ElemModeButton.Content = ".*";
+                    ElemModeButton.ToolTip =
+                        "Regex Search\nUses regular expression patterns.";
+                    break;
+            }
+        }
+
+        private void ModeButton_Click(
+            object sender,
+            RoutedEventArgs e)
+        {
+            switch (SearchMode)
+            {
+                case SearchMode.Normal:
+                    SearchMode = SearchMode.Fuzzy;
+                    break;
+
+                case SearchMode.Fuzzy:
+                    SearchMode = SearchMode.Regex;
+                    break;
+
+                case SearchMode.Regex:
+                    SearchMode = SearchMode.Normal;
+                    break;
+            }
         }
 
         private void TextInputText_GotFocus(object sender, RoutedEventArgs e)
         {
             UpdateIconStates();
         }
+
 
         private void UpdateIconStates()
         {

--- a/source/Playnite.DesktopApp/Controls/SearchBox.cs
+++ b/source/Playnite.DesktopApp/Controls/SearchBox.cs
@@ -1,5 +1,6 @@
 ﻿using Playnite.Common;
 using Playnite.DesktopApp.ViewModels;
+using Playnite.SDK;
 using Playnite.SDK.Models;
 using System;
 using System.Collections.Generic;
@@ -167,19 +168,25 @@ namespace Playnite.DesktopApp.Controls
                 case SearchMode.Normal:
                     ElemModeButton.Content = "⌕";
                     ElemModeButton.ToolTip =
-                        "Normal Search\nFinds exact text matches.";
+                        ResourceProvider.GetString(LOC.SearchModeNormalLabel) +
+                        Environment.NewLine +
+                        ResourceProvider.GetString(LOC.SearchModeNormalDescription);
                     break;
 
                 case SearchMode.Fuzzy:
                     ElemModeButton.Content = "≈";
                     ElemModeButton.ToolTip =
-                        "Fuzzy Search\nApproximate matching that tolerates typos and partial matches.";
+                        ResourceProvider.GetString(LOC.SearchModeFuzzyLabel) +
+                        Environment.NewLine +
+                        ResourceProvider.GetString(LOC.SearchModeFuzzyDescription);
                     break;
 
                 case SearchMode.Regex:
                     ElemModeButton.Content = ".*";
                     ElemModeButton.ToolTip =
-                        "Regex Search\nUses regular expression patterns.";
+                        ResourceProvider.GetString(LOC.SearchModeRegexLabel) +
+                        Environment.NewLine +
+                        ResourceProvider.GetString(LOC.SearchModeRegexDescription);
                     break;
             }
         }

--- a/source/Playnite.DesktopApp/Controls/SettingsSections/General.xaml
+++ b/source/Playnite.DesktopApp/Controls/SettingsSections/General.xaml
@@ -113,11 +113,6 @@
                 Content="{DynamicResource LOCSettingsScanLibInstallSizeOnLibUpdate}"
                 ToolTip="{DynamicResource LOCSettingsScanLibInstallSizeOnLibUpdateTooltip}"
                 IsChecked="{Binding Settings.ScanLibInstallSizeOnLibUpdate}"/>
-
-        <CheckBox Name="CheckFuzzyMatchingInNameFilter" Margin="5,15,5,5"
-                Content="{DynamicResource NameFilterUseFuzzyMatching}"
-                ToolTip="{DynamicResource NameFilterUseFuzzyMatchingTooltip}"
-                IsChecked="{Binding Settings.FuzzyMatchingInNameFilter}"/>
         
         <TextBlock Text="{DynamicResource LOCSettingsPlaytimeImportMode}" Margin="5,15,5,0"
                    ToolTip="{DynamicResource LOCSettingsPlaytimeImportModeTooltip}"

--- a/source/Playnite.DesktopApp/Controls/Views/FilterPanel.cs
+++ b/source/Playnite.DesktopApp/Controls/Views/FilterPanel.cs
@@ -138,7 +138,7 @@ namespace Playnite.DesktopApp.Controls.Views
             SetFilterSelectionBoxFilter(nameof(DatabaseFilter.Libraries), nameof(FilterSettings.Library), false);
 
             SetLabelTag(nameof(FilterSettings.Name), LOC.NameLabel, new StringNullOrEmptyToBoolConverter(), nameof(FilterSettings.Name));
-            SetFilterSearchBoxFilter(nameof(FilterSettings.Name));
+            SetFilterSearchBoxBindings(nameof(FilterSettings.Name), nameof(FilterSettings.NameSearchMode));
 
             SetLabelTag(nameof(FilterSettings.Genre), LOC.GenreLabel);
             SetFilterSelectionBoxFilter(nameof(DatabaseFilter.Genres), nameof(FilterSettings.Genre));
@@ -183,7 +183,7 @@ namespace Playnite.DesktopApp.Controls.Views
             SetFilterSelectionBoxFilter(nameof(DatabaseFilter.AgeRatings), nameof(FilterSettings.AgeRating));
 
             SetLabelTag(nameof(FilterSettings.Version), LOC.VersionLabel, new StringNullOrEmptyToBoolConverter(), nameof(FilterSettings.Version));
-            SetFilterSearchBoxFilter(nameof(FilterSettings.Version));
+            SetFilterSearchBoxBindings(nameof(FilterSettings.Version), nameof(FilterSettings.VersionSearchMode));
 
             SetLabelTag(nameof(FilterSettings.UserScore), LOC.UserScore);
             SetFilterEnumSelectionBoxFilter(nameof(FilterSettings.UserScore), typeof(ScoreGroup));
@@ -257,7 +257,7 @@ namespace Playnite.DesktopApp.Controls.Views
             PanelItemsHost.Children.Add(elem);
         }
 
-        private void SetFilterSearchBoxFilter(string filterBinding)
+        private void SetFilterSearchBoxBindings(string filterBinding, string searchModeBinding)
         {
             if (PanelItemsHost == null)
             {
@@ -266,6 +266,14 @@ namespace Playnite.DesktopApp.Controls.Views
 
             var elem = new SearchBox();
             elem.SetResourceReference(SearchBox.StyleProperty, "FilterPanelFilterSearchBox");
+
+            BindingTools.SetBinding(elem,
+                SearchBox.SearchModeProperty,
+                mainModel.AppSettings.FilterSettings,
+                searchModeBinding,
+                BindingMode.TwoWay,
+                delay: 100);
+
             BindingTools.SetBinding(elem,
                 SearchBox.TextProperty,
                 mainModel.AppSettings.FilterSettings,

--- a/source/Playnite.DesktopApp/Controls/Views/TopPanel.cs
+++ b/source/Playnite.DesktopApp/Controls/Views/TopPanel.cs
@@ -254,6 +254,12 @@ namespace Playnite.DesktopApp.Controls.Views
                     BindingMode.TwoWay,
                     delay: 100);
                 BindingTools.SetBinding(TextMainSearch,
+                    SearchBox.SearchModeProperty,
+                    mainModel.AppSettings.FilterSettings,
+                    nameof(FilterSettings.NameSearchMode),
+                    BindingMode.TwoWay,
+                    delay: 100);
+                BindingTools.SetBinding(TextMainSearch,
                     SearchBox.VisibilityProperty,
                     mainModel.AppSettings,
                     nameof(PlayniteSettings.ShowTopPanelSearchBox),

--- a/source/Playnite.DesktopApp/DesktopCollectionView.cs
+++ b/source/Playnite.DesktopApp/DesktopCollectionView.cs
@@ -139,11 +139,7 @@ namespace Playnite.DesktopApp
 
         private void Settings_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            if (e.PropertyName == nameof(PlayniteSettings.FuzzyMatchingInNameFilter))
-            {
-                Logger.Debug("Refreshing collection view filter.");
-                CollectionView.Refresh();
-            }
+
         }
 
         private void ViewSettings_PropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/source/Playnite.DesktopApp/Themes/Desktop/Default/CustomControls/SearchBox.xaml
+++ b/source/Playnite.DesktopApp/Themes/Desktop/Default/CustomControls/SearchBox.xaml
@@ -10,16 +10,32 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type SearchBox}">
                     <Grid>
-                        <ContentControl x:Name="PART_SeachIcon"
-                                        ContentTemplate="{DynamicResource SearchTextIconTemplate}"
-                                        VerticalAlignment="Center" HorizontalAlignment="Left" Margin="5,0,0,0"
-                                        Foreground="{DynamicResource TextBrushDarker}" />
-                        <TextBox x:Name="PART_TextInpuText"
-                                 VerticalContentAlignment="Center" Padding="5,0,25,0"/>
-                        <ContentControl x:Name="PART_ClearTextIcon"
-                                        ContentTemplate="{DynamicResource ClearTextIconTemplate}" 
-                                        FontSize="18" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,5,0" 
-                                        Foreground="{DynamicResource TextBrushDarker}" />
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        
+                        <Grid Grid.Column="0">
+                            <ContentControl x:Name="PART_SeachIcon"
+                                            ContentTemplate="{DynamicResource SearchTextIconTemplate}"
+                                            VerticalAlignment="Center" HorizontalAlignment="Left" Margin="5,0,0,0"
+                                            Foreground="{DynamicResource TextBrushDarker}" />
+
+                            <TextBox x:Name="PART_TextInpuText"
+                                     VerticalContentAlignment="Center" Padding="5,0,25,0"/>
+
+                            <ContentControl x:Name="PART_ClearTextIcon"
+                                            ContentTemplate="{DynamicResource ClearTextIconTemplate}" 
+                                            FontSize="18" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,5,0" 
+                                            Foreground="{DynamicResource TextBrushDarker}" />
+                        </Grid>
+                        
+                        <Button x:Name="PART_ModeButton"
+                                Grid.Column="1"
+                                FontSize="18"
+                                Margin="4,0,0,0"
+                                Foreground="{DynamicResource TextBrushDarker}" />
+
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>

--- a/source/Playnite/Common/TextMatcher.cs
+++ b/source/Playnite/Common/TextMatcher.cs
@@ -161,11 +161,11 @@ namespace Playnite.Common
             }
         }
 
-        private string CreateRegexCacheKey(
+        private static string CreateRegexCacheKey(
             string pattern,
             RegexOptions options)
         {
-            return $"{pattern}\u001F{(int)options}";
+            return string.Concat(pattern, "\u001F", (int)options);
         }
 
         public void ClearRegexCaches()

--- a/source/Playnite/Common/TextMatcher.cs
+++ b/source/Playnite/Common/TextMatcher.cs
@@ -1,4 +1,5 @@
-﻿using NLog.Filters;
+﻿using Microsoft.Scripting.Actions.Calls;
+using NLog.Filters;
 using NLog.Targets;
 using Playnite.SDK.Models;
 using System;
@@ -13,6 +14,14 @@ namespace Playnite.Common
 {
     public sealed class TextMatcher
     {
+        private readonly Dictionary<string, string[]> tokenCache =
+            new Dictionary<string, string[]>();
+
+        private readonly Dictionary<string, double> similarityCache =
+            new Dictionary<string, double>();
+
+        private const double EarlyFailThreshold = .4;
+
         private static readonly char[] WordSeparators =
         {
             ' ',
@@ -24,7 +33,7 @@ namespace Playnite.Common
             ')'
         };
 
-        private const int MaxRegexCacheSize = 15;
+        private const int MaxRegexCacheSize = 12;
 
         public static readonly TimeSpan RegexTimeout =
             TimeSpan.FromMilliseconds(100);
@@ -46,8 +55,7 @@ namespace Playnite.Common
         public bool FuzzyMatchAcronymStart { get; set; } = true;
        
         public bool IgnoreCase { get; set; } = true;
-
-        public double MinimumSimilarity { get; set; } = 0.92;
+        public double MinimumFuzzyScore { get; set; } = 0.70;
 
         public bool IsMatch(
             string query,
@@ -147,7 +155,7 @@ namespace Playnite.Common
             string pattern,
             RegexOptions options)
         {
-            return pattern + "\u001F" + (int)options;
+            return $"{pattern}\u001F{(int)options}";
         }
 
         public void ClearRegexCaches()
@@ -158,88 +166,283 @@ namespace Playnite.Common
         }
 
         public bool IsFuzzyMatch(
-            string filter,
+            string query,
             string target)
         {
-            if (IsMatch(filter, target))
+            var fuzzyScore = GetFuzzyScore(
+                query,
+                target);
+            var minimumFuzzyScore = GetMinimumFuzzyScore(query);
+            return fuzzyScore >= minimumFuzzyScore;
+        }
+
+        public double GetFuzzyScore(
+            string query,
+            string target)
+        {
+            if (query is null)
             {
-                return true;
+                throw new ArgumentNullException(nameof(query));
             }
 
+            if (target is null)
+            {
+                throw new ArgumentNullException(nameof(target));
+            }
+
+            if (query.Length == 0 ||
+                target.Length == 0)
+            {
+                return 0;
+            }
+
+            // To prevent unecessarily allocating new strings if there
+            // is no whitespace at the start or end of the query/target.
+            if (char.IsWhiteSpace(query[0]) ||
+                char.IsWhiteSpace(query[query.Length - 1]))
+            {
+                query = query.Trim();
+            }
+
+            if (char.IsWhiteSpace(target[0]) ||
+                char.IsWhiteSpace(target[target.Length - 1]))
+            {
+                target = target.Trim();
+            }
+
+            if (query.Length == 0 ||
+                target.Length == 0)
+            {
+                return 0;
+            }
+
+            var comparison = IgnoreCase
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+
+            // Exact
+            if (string.Equals(
+                query,
+                target,
+                comparison))
+            {
+                return 1.0;
+            }
+
+            // p5 -> Persona 5
+            // ac -> Assassin's Creed
+            // GOW -> Gears of War (Not God of War, the inferior franchise)
             if (FuzzyMatchAcronymStart &&
-                filter.IsStartOfStringAcronym(target))
+                query.IsStartOfStringAcronym(target))
             {
-                return true;
+                return .95;
             }
 
-            if (filter
-                .GetJaroWinklerSimilarityIgnoreCase(
-                    target)
-                >= MinimumSimilarity)
+            // Tiny searches can produce very bad similarity scores due to the way Jaro-Winkler works,
+            // so we can short circuit some of the more expensive checks for very short queries.
+            // using a specially tuned scoring method for short queries.
+            if (query.Length <= 2)
             {
-                return true;
+                return ScoreShortQuery(
+                    query,
+                    target,
+                    comparison);
             }
 
-            if (filter.Length >
-                target.Length)
+            if (target.IndexOf(query,comparison) >= 0)
+            {
+                return .95;
+            }
+
+            if (target.StartsWith(query, comparison))
+            {
+                return .90;
+            }
+
+            // Expensive path
+            var queryWords = GetTokens(query);
+            if (queryWords.Length == 0)
+            {
+                return 0;
+            }
+
+            var targetWords = GetTokens(target);
+            return ScoreWords(
+                queryWords,
+                targetWords);
+        }
+
+        private double ScoreShortQuery(
+            string query,
+            string target,
+            StringComparison comparison)
+        {
+            var words = GetTokens(target);
+            for (int i = 0; i < words.Length; i++)
+            {
+                if (words[i].StartsWith(query, comparison))
+                {
+                    return .90;
+                }
+            }
+
+            return 0;
+        }
+
+        private double ScoreWords(
+            string[] queryWords,
+            string[] targetWords)
+        {
+            double totalScore = 0;
+
+            for (int i = 0; i < queryWords.Length; i++)
+            {
+                var queryWord = queryWords[i];
+
+                double bestScore = 0;
+
+                for (int j = 0; j < targetWords.Length; j++)
+                {
+                    var targetWord = targetWords[j];
+
+                    var similarity = GetSimilarity(
+                        queryWord,
+                        targetWord);
+
+                    if (targetWord.StartsWith(
+                        queryWord,
+                        IgnoreCase
+                            ? StringComparison.OrdinalIgnoreCase
+                            : StringComparison.Ordinal))
+                    {
+                        similarity += .15;
+                    }
+
+                    if (similarity > bestScore)
+                    {
+                        bestScore = similarity;
+
+                        // Already a very good match, no need to check other words
+                        if (bestScore >= .95)
+                        {
+                            break;
+                        }
+                    }
+                }
+
+                totalScore += bestScore;
+
+                // Fail early
+                var average =
+                    totalScore /
+                    (i + 1);
+
+                if (average <
+                    EarlyFailThreshold)
+                {
+                    return average;
+                }
+            }
+
+            return totalScore / queryWords.Length;
+        }
+
+        private double GetSimilarity(
+            string left,
+            string right)
+        {
+            var key = string.Concat(left, "\u001F", right);
+            if (similarityCache.TryGetValue(key,
+                out var similarity))
+            {
+                return similarity;
+            }
+
+            similarity = left.GetJaroWinklerSimilarityIgnoreCase(right);
+            similarityCache[key] = similarity;
+
+            return similarity;
+        }
+
+        private string[] GetTokens(string text)
+        {
+            if (tokenCache.TryGetValue(text, out  var tokens))
+            {
+                return tokens;
+            }
+
+            tokens = Tokenize(text);
+            tokenCache[text] = tokens;
+
+            return tokens;
+        }
+
+        private static string[] Tokenize(string text)
+        {
+            var split =
+                text.Split(
+                    WordSeparators,
+                    StringSplitOptions.RemoveEmptyEntries);
+
+            var result = new List<string>(split.Length);
+            for (int i = 0; i < split.Length; i++)
+            {
+                if (IsValidToken(split[i]))
+                {
+                    result.Add(split[i]);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        private static bool IsValidToken(
+            string value)
+        {
+            if (value.IsNullOrWhiteSpace())
             {
                 return false;
             }
 
-            var filterWords =
-                filter.Split(
-                    WordSeparators,
-                    StringSplitOptions.RemoveEmptyEntries);
-
-            var targetWords =
-                target.Split(
-                    WordSeparators,
-                    StringSplitOptions.RemoveEmptyEntries);
-
+            int alphaNumericCount = 0;
             for (int i = 0;
-                 i < filterWords.Length;
+                 i < value.Length;
                  i++)
             {
-                var matched = false;
-
-                var filterWord =
-                    filterWords[i];
-
-                for (int j = 0;
-                     j < targetWords.Length;
-                     j++)
+                if (char.IsLetterOrDigit(
+                    value[i]))
                 {
-                    var targetWord =
-                        targetWords[j];
+                    alphaNumericCount++;
 
-                    if (targetWord
-                        .ContainsInvariantCulture(
-                            filterWord,
-                            CompareOptions.IgnoreCase |
-                            CompareOptions.IgnoreSymbols |
-                            CompareOptions.IgnoreNonSpace))
+                    if (alphaNumericCount >= 2)
                     {
-                        matched = true;
-                        break;
+                        return true;
                     }
-
-                    if (filterWord
-                        .GetJaroWinklerSimilarityIgnoreCase(
-                            targetWord)
-                        >= MinimumSimilarity)
-                    {
-                        matched = true;
-                        break;
-                    }
-                }
-
-                if (!matched)
-                {
-                    return false;
                 }
             }
 
-            return true;
+            return false;
         }
+
+        private double GetMinimumFuzzyScore(string query)
+        {
+            if (query.Length <= 1)
+            {
+                return .98;
+            }
+
+            if (query.Length == 2)
+            {
+                return .92;
+            }
+
+            if (query.Length == 3)
+            {
+                return .80;
+            }
+
+            return MinimumFuzzyScore;
+        }
+
     }
 }

--- a/source/Playnite/Common/TextMatcher.cs
+++ b/source/Playnite/Common/TextMatcher.cs
@@ -305,6 +305,10 @@ namespace Playnite.Common
         {
             double totalScore = 0;
 
+            var comparison = IgnoreCase
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+
             for (int i = 0; i < queryWords.Length; i++)
             {
                 var queryWord = queryWords[i];
@@ -314,25 +318,80 @@ namespace Playnite.Common
                 for (int j = 0; j < targetWords.Length; j++)
                 {
                     var targetWord = targetWords[j];
+                    double similarity;
 
-                    var similarity = GetSimilarity(
+                    // Exact word
+                    if (string.Equals(
                         queryWord,
-                        targetWord);
-
-                    if (targetWord.StartsWith(
-                        queryWord,
-                        IgnoreCase
-                            ? StringComparison.OrdinalIgnoreCase
-                            : StringComparison.Ordinal))
+                        targetWord,
+                        comparison))
                     {
-                        similarity += .15;
+                        similarity = 1;
+                    }
+
+                    // Prefix:
+                    // pers -> Persona
+                    else if (
+                        targetWord.StartsWith(
+                            queryWord,
+                            comparison))
+                    {
+                        similarity = .95;
+                    }
+
+                    // Contains:
+                    // sona -> Persona
+                    else if (targetWord.IndexOf(
+                        queryWord,
+                        comparison) >= 0)
+                    {
+                        similarity = .85;
+                    }
+
+                    else
+                    {
+                        similarity = GetSimilarity(
+                            queryWord,
+                            targetWord);
+
+                        // Reject suspicious Jaro scores
+                        // from unrelated words by checking length
+                        // difference and first char match and applying a
+                        // penalty if they do not line up.
+
+                        var lengthDifference = Math.Abs(
+                            queryWord.Length -
+                            targetWord.Length);
+
+                        var longestLength = Math.Max(
+                            queryWord.Length,
+                            targetWord.Length);
+
+                        var lengthPenalty =
+                            (double)lengthDifference /
+                            longestLength;
+
+                        // Cap penalty so long words
+                        // do not become impossible.
+
+                        lengthPenalty = Math.Min(
+                            lengthPenalty,
+                            .50);
+
+                        similarity *= 1 - lengthPenalty;
+
+                        // Require stronger similarity
+                        // when first chars differ
+                        if (char.ToUpperInvariant(queryWord[0]) !=
+                            char.ToUpperInvariant(targetWord[0]))
+                        {
+                            similarity *= .5;
+                        }
                     }
 
                     if (similarity > bestScore)
                     {
                         bestScore = similarity;
-
-                        // Already a very good match, no need to check other words
                         if (bestScore >= .95)
                         {
                             break;
@@ -342,13 +401,8 @@ namespace Playnite.Common
 
                 totalScore += bestScore;
 
-                // Fail early
-                var average =
-                    totalScore /
-                    (i + 1);
-
-                if (average <
-                    EarlyFailThreshold)
+                var average = totalScore / (i + 1);
+                if (average < EarlyFailThreshold)
                 {
                     return average;
                 }

--- a/source/Playnite/Common/TextMatcher.cs
+++ b/source/Playnite/Common/TextMatcher.cs
@@ -1,0 +1,238 @@
+﻿using NLog.Filters;
+using NLog.Targets;
+using Playnite.SDK.Models;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace Playnite.Common
+{
+    public sealed class TextMatcher
+    {
+        private static readonly char[] WordSeparators =
+        {
+            ' ',
+            '-',
+            '_',
+            '.',
+            ':',
+            '(',
+            ')'
+        };
+
+        private const int MaxRegexCacheSize = 15;
+
+        public static readonly TimeSpan RegexTimeout =
+            TimeSpan.FromMilliseconds(100);
+
+        private readonly Dictionary<string, Regex> regexCache =
+            new Dictionary<string, Regex>();
+
+        private readonly Queue<string> regexCacheOrder =
+            new Queue<string>();
+
+        /// <summary>
+        /// Stores regex patterns that previously failed compilation to avoid
+        /// repeatedly throwing exceptions during live search input.
+        /// </summary>
+        private readonly HashSet<string> invalidRegexPatterns =
+            new HashSet<string>();
+
+        public bool MatchAcronymStart { get; set; } = true;
+
+        public bool IgnoreCase { get; set; } = true;
+
+        public double MinimumSimilarity { get; set; } = 0.92;
+
+        public bool IsMatch(
+            string query,
+            string candidate)
+        {
+            if (query is null)
+            {
+                throw new ArgumentNullException(nameof(query));
+            }
+
+            if (candidate is null)
+            {
+                throw new ArgumentNullException(nameof(candidate));
+            }
+
+            return candidate.IndexOf(
+                query,
+                IgnoreCase
+                    ? StringComparison.OrdinalIgnoreCase
+                    : StringComparison.Ordinal)
+                >= 0;
+        }
+
+        public bool IsRegexMatch(
+            string pattern,
+            string target)
+        {
+            if (pattern.IsNullOrEmpty() ||
+                target.IsNullOrEmpty())
+            {
+                return false;
+            }
+
+            var regex = GetCompiledRegex(pattern);
+            if (regex is null)
+            {
+                return false;
+            }
+
+            return regex.IsMatch(target);
+        }
+
+        private Regex GetCompiledRegex(
+            string pattern)
+        {
+            var options = IgnoreCase ?
+                RegexOptions.IgnoreCase :
+                RegexOptions.Compiled;
+
+            var cacheKey = CreateRegexCacheKey(
+                pattern,
+                options);
+
+            if (invalidRegexPatterns.Contains(cacheKey))
+            {
+                return null;
+            }
+
+            if (regexCache.TryGetValue(
+                cacheKey, out var regex))
+            {
+                return regex;
+            }
+
+            try
+            {
+                regex = new Regex(
+                    pattern,
+                    options,
+                    RegexTimeout);
+
+                regexCache[cacheKey] = regex;
+                regexCacheOrder.Enqueue(cacheKey);
+
+                while (regexCacheOrder.Count > MaxRegexCacheSize)
+                {
+                    var oldest = regexCacheOrder.Dequeue();
+                    regexCache.Remove(oldest);
+                }
+
+                return regex;
+            }
+            catch (ArgumentException)
+            {
+                invalidRegexPatterns.Add(cacheKey);
+                return null;
+            }
+        }
+
+        private string CreateRegexCacheKey(
+            string pattern,
+            RegexOptions options)
+        {
+            return pattern + "\u001F" + (int)options;
+        }
+
+        public void ClearRegexCaches()
+        {
+            regexCache.Clear();
+            regexCacheOrder.Clear();
+            invalidRegexPatterns.Clear();
+        }
+
+        public bool IsFuzzyMatch(
+            string filter,
+            string target)
+        {
+            if (IsMatch(filter, target))
+            {
+                return true;
+            }
+
+            if (MatchAcronymStart &&
+                filter.IsStartOfStringAcronym(target))
+            {
+                return true;
+            }
+
+            if (filter
+                .GetJaroWinklerSimilarityIgnoreCase(
+                    target)
+                >= MinimumSimilarity)
+            {
+                return true;
+            }
+
+            if (filter.Length >
+                target.Length)
+            {
+                return false;
+            }
+
+            var filterWords =
+                filter.Split(
+                    WordSeparators,
+                    StringSplitOptions.RemoveEmptyEntries);
+
+            var targetWords =
+                target.Split(
+                    WordSeparators,
+                    StringSplitOptions.RemoveEmptyEntries);
+
+            for (int i = 0;
+                 i < filterWords.Length;
+                 i++)
+            {
+                var matched = false;
+
+                var filterWord =
+                    filterWords[i];
+
+                for (int j = 0;
+                     j < targetWords.Length;
+                     j++)
+                {
+                    var targetWord =
+                        targetWords[j];
+
+                    if (targetWord
+                        .ContainsInvariantCulture(
+                            filterWord,
+                            CompareOptions.IgnoreCase |
+                            CompareOptions.IgnoreSymbols |
+                            CompareOptions.IgnoreNonSpace))
+                    {
+                        matched = true;
+                        break;
+                    }
+
+                    if (filterWord
+                        .GetJaroWinklerSimilarityIgnoreCase(
+                            targetWord)
+                        >= MinimumSimilarity)
+                    {
+                        matched = true;
+                        break;
+                    }
+                }
+
+                if (!matched)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/source/Playnite/Common/TextMatcher.cs
+++ b/source/Playnite/Common/TextMatcher.cs
@@ -42,8 +42,9 @@ namespace Playnite.Common
         private readonly HashSet<string> invalidRegexPatterns =
             new HashSet<string>();
 
-        public bool MatchAcronymStart { get; set; } = true;
-
+        public bool NormalMatchAcronymStart { get; set; } = false;
+        public bool FuzzyMatchAcronymStart { get; set; } = true;
+       
         public bool IgnoreCase { get; set; } = true;
 
         public double MinimumSimilarity { get; set; } = 0.92;
@@ -60,6 +61,12 @@ namespace Playnite.Common
             if (candidate is null)
             {
                 throw new ArgumentNullException(nameof(candidate));
+            }
+
+            if (NormalMatchAcronymStart &&
+                query.IsStartOfStringAcronym(candidate))
+            {
+                return true;
             }
 
             return candidate.IndexOf(
@@ -159,7 +166,7 @@ namespace Playnite.Common
                 return true;
             }
 
-            if (MatchAcronymStart &&
+            if (FuzzyMatchAcronymStart &&
                 filter.IsStartOfStringAcronym(target))
             {
                 return true;

--- a/source/Playnite/Common/TextMatcher.cs
+++ b/source/Playnite/Common/TextMatcher.cs
@@ -14,11 +14,21 @@ namespace Playnite.Common
 {
     public sealed class TextMatcher
     {
+        private const int MaxFuzzyMatchTokenCacheSize = 2000;
+
+        private const int MaxFuzzyMatchSimilarityCacheSize = 5000;
+
         private readonly Dictionary<string, string[]> tokenCache =
             new Dictionary<string, string[]>();
 
         private readonly Dictionary<string, double> similarityCache =
             new Dictionary<string, double>();
+
+        private readonly Queue<string> tokenCacheOrder =
+            new Queue<string>();
+
+        private readonly Queue<string> similarityCacheOrder =
+            new Queue<string>();
 
         private const double EarlyFailThreshold = .4;
 
@@ -361,6 +371,13 @@ namespace Playnite.Common
             similarity = left.GetJaroWinklerSimilarityIgnoreCase(right);
             similarityCache[key] = similarity;
 
+            similarityCacheOrder.Enqueue(key);
+            while (similarityCacheOrder.Count > MaxFuzzyMatchSimilarityCacheSize)
+            {
+                var oldest = similarityCacheOrder.Dequeue();
+                similarityCache.Remove(oldest);
+            }
+
             return similarity;
         }
 
@@ -373,6 +390,13 @@ namespace Playnite.Common
 
             tokens = Tokenize(text);
             tokenCache[text] = tokens;
+
+            tokenCacheOrder.Enqueue(text);
+            while (tokenCacheOrder.Count > MaxFuzzyMatchTokenCacheSize)
+            {
+                var oldest = tokenCacheOrder.Dequeue();
+                tokenCache.Remove(oldest);
+            }
 
             return tokens;
         }

--- a/source/Playnite/Database/DatabaseExplorer.cs
+++ b/source/Playnite/Database/DatabaseExplorer.cs
@@ -898,8 +898,8 @@ namespace Playnite.Database
                     values.AddRange(database.GetSortedFilterPresets().Select(a => new SelectionObject(a)));
                     break;
                 case ExplorerField.Name:
-                    values.Add(new SelectionObject("[NameInitial]:#", "#"));
-                    values.AddRange(Enumerable.Range('A', 26).Select(a => new SelectionObject("[NameInitial]:" + ((char)a).ToString(), ((char)a).ToString())));
+                    values.Add(new SelectionObject("^:#", "#"));
+                    values.AddRange(Enumerable.Range('A', 26).Select(a => new SelectionObject("^:" + ((char)a).ToString(), ((char)a).ToString())));
                     break;
                 case ExplorerField.InstallStatus:
                     values.Add(new SelectionObject(true, LOC.GameIsInstalledTitle.GetLocalized()));

--- a/source/Playnite/Database/DatabaseExplorer.cs
+++ b/source/Playnite/Database/DatabaseExplorer.cs
@@ -898,8 +898,8 @@ namespace Playnite.Database
                     values.AddRange(database.GetSortedFilterPresets().Select(a => new SelectionObject(a)));
                     break;
                 case ExplorerField.Name:
-                    values.Add(new SelectionObject("^#", "#"));
-                    values.AddRange(Enumerable.Range('A', 26).Select(a => new SelectionObject("^" + ((char)a).ToString(), ((char)a).ToString())));
+                    values.Add(new SelectionObject("[NameInitial]:#", "#"));
+                    values.AddRange(Enumerable.Range('A', 26).Select(a => new SelectionObject("[NameInitial]:" + ((char)a).ToString(), ((char)a).ToString())));
                     break;
                 case ExplorerField.InstallStatus:
                     values.Add(new SelectionObject(true, LOC.GameIsInstalledTitle.GetLocalized()));

--- a/source/Playnite/Database/GameDatabase_Filters.cs
+++ b/source/Playnite/Database/GameDatabase_Filters.cs
@@ -187,7 +187,11 @@ namespace Playnite.Database
                 return false;
             }
 
-            if (filterSettings.NameSearchMode == SearchMode.Normal)
+            if (filterSettings.NameSearchMode == SearchMode.Fuzzy || useFuzzyNameMatch)
+            {
+                return nameMatcher.IsFuzzyMatch(filterSettings.Name, game.Name);
+            }
+            else if (filterSettings.NameSearchMode == SearchMode.Normal)
             {
                 if (filterSettings.Name.Length >= 2 && filterSettings.Name[0] == '^')
                 {
@@ -195,10 +199,6 @@ namespace Playnite.Database
                 }
 
                 return nameMatcher.IsMatch(filterSettings.Name, game.Name);
-            }
-            else if (filterSettings.NameSearchMode == SearchMode.Fuzzy)
-            {
-                return nameMatcher.IsFuzzyMatch(filterSettings.Name, game.Name);
             }
             else if (filterSettings.NameSearchMode == SearchMode.Regex)
             {

--- a/source/Playnite/Database/GameDatabase_Filters.cs
+++ b/source/Playnite/Database/GameDatabase_Filters.cs
@@ -57,7 +57,7 @@ namespace Playnite.Database
         {
             this.filterSettings = filterSettings;
             this.useFuzzyNameMatch = useFuzzyNameMatch;
-            this.nameMatcher = new TextMatcher();
+            this.nameMatcher = new TextMatcher { NormalMatchAcronymStart = true };
         }
 
         public bool Match(Game game)

--- a/source/Playnite/Database/GameDatabase_Filters.cs
+++ b/source/Playnite/Database/GameDatabase_Filters.cs
@@ -51,13 +51,13 @@ namespace Playnite.Database
     {
         private readonly FilterSettings filterSettings;
         private readonly bool useFuzzyNameMatch;
-        private readonly TextMatcher nameMatcher;
+        private static readonly TextMatcher nameMatcher =
+            new TextMatcher { NormalMatchAcronymStart = true };
 
         public FilterMatcher(FilterSettings filterSettings, bool useFuzzyNameMatch)
         {
             this.filterSettings = filterSettings;
             this.useFuzzyNameMatch = useFuzzyNameMatch;
-            this.nameMatcher = new TextMatcher { NormalMatchAcronymStart = true };
         }
 
         public bool Match(Game game)

--- a/source/Playnite/Database/GameDatabase_Filters.cs
+++ b/source/Playnite/Database/GameDatabase_Filters.cs
@@ -1,4 +1,5 @@
-﻿using Playnite.SDK.Models;
+﻿using Playnite.Common;
+using Playnite.SDK.Models;
 using Playnite.ViewModels;
 using System;
 using System.Collections.Generic;
@@ -50,11 +51,13 @@ namespace Playnite.Database
     {
         private readonly FilterSettings filterSettings;
         private readonly bool useFuzzyNameMatch;
+        private readonly TextMatcher nameMatcher;
 
         public FilterMatcher(FilterSettings filterSettings, bool useFuzzyNameMatch)
         {
             this.filterSettings = filterSettings;
             this.useFuzzyNameMatch = useFuzzyNameMatch;
+            this.nameMatcher = new TextMatcher();
         }
 
         public bool Match(Game game)
@@ -184,17 +187,25 @@ namespace Playnite.Database
                 return false;
             }
 
-            if (filterSettings.Name.Length >= 2 && filterSettings.Name[0] == '^')
+            if (filterSettings.NameSearchMode == SearchMode.Normal)
             {
-                return game.GetNameGroup() == filterSettings.Name[1];
+                if (filterSettings.Name.Length >= 2 && filterSettings.Name[0] == '^')
+                {
+                    return game.GetNameGroup() == filterSettings.Name[1];
+                }
+
+                return nameMatcher.IsMatch(filterSettings.Name, game.Name);
+            }
+            else if (filterSettings.NameSearchMode == SearchMode.Fuzzy)
+            {
+                return nameMatcher.IsFuzzyMatch(filterSettings.Name, game.Name);
+            }
+            else if (filterSettings.NameSearchMode == SearchMode.Regex)
+            {
+                return nameMatcher.IsRegexMatch(filterSettings.Name, game.Name);
             }
 
-            if (!useFuzzyNameMatch || filterSettings.Name[0] == '!')
-            {
-                return game.Name.IndexOf(filterSettings.Name.Substring(1), StringComparison.OrdinalIgnoreCase) >= 0;
-            }
-
-            return SearchViewModel.MatchTextFilter(filterSettings.Name, game.Name, true);
+            return false;
         }
 
         private bool MatchReleaseYear(Game game)

--- a/source/Playnite/Database/GameDatabase_Filters.cs
+++ b/source/Playnite/Database/GameDatabase_Filters.cs
@@ -188,9 +188,11 @@ namespace Playnite.Database
             }
 
             // Special branches for Explorer Panel functionality when using Name filter
-            if (filterSettings.Name.Length >= 2 && filterSettings.Name[0] == '^')
+            const string NameInitialPrefix = "[NameInitial]:";
+            if (filterSettings.Name.Length == NameInitialPrefix.Length + 1 &&
+                filterSettings.Name.StartsWith(NameInitialPrefix))
             {
-                return game.GetNameGroup() == filterSettings.Name[1];
+                return game.GetNameGroup() == filterSettings.Name[NameInitialPrefix.Length];
             }
             else if (filterSettings.Name[0] == '!')
             {

--- a/source/Playnite/Database/GameDatabase_Filters.cs
+++ b/source/Playnite/Database/GameDatabase_Filters.cs
@@ -187,17 +187,22 @@ namespace Playnite.Database
                 return false;
             }
 
+            // Special branches for Explorer Panel functionality when using Name filter
+            if (filterSettings.Name.Length >= 2 && filterSettings.Name[0] == '^')
+            {
+                return game.GetNameGroup() == filterSettings.Name[1];
+            }
+            else if (filterSettings.Name[0] == '!')
+            {
+                return game.Name.IndexOf(filterSettings.Name.Substring(1), StringComparison.OrdinalIgnoreCase) >= 0;
+            }
+
             if (filterSettings.NameSearchMode == SearchMode.Fuzzy || useFuzzyNameMatch)
             {
                 return nameMatcher.IsFuzzyMatch(filterSettings.Name, game.Name);
             }
             else if (filterSettings.NameSearchMode == SearchMode.Normal)
             {
-                if (filterSettings.Name.Length >= 2 && filterSettings.Name[0] == '^')
-                {
-                    return game.GetNameGroup() == filterSettings.Name[1];
-                }
-
                 return nameMatcher.IsMatch(filterSettings.Name, game.Name);
             }
             else if (filterSettings.NameSearchMode == SearchMode.Regex)

--- a/source/Playnite/Database/GameDatabase_Filters.cs
+++ b/source/Playnite/Database/GameDatabase_Filters.cs
@@ -188,7 +188,7 @@ namespace Playnite.Database
             }
 
             // Special branches for Explorer Panel functionality when using Name filter
-            const string NameInitialPrefix = "[NameInitial]:";
+            const string NameInitialPrefix = "^:";
             if (filterSettings.Name.Length == NameInitialPrefix.Length + 1 &&
                 filterSettings.Name.StartsWith(NameInitialPrefix))
             {

--- a/source/Playnite/GamesCollectionView.cs
+++ b/source/Playnite/GamesCollectionView.cs
@@ -63,7 +63,7 @@ namespace Playnite
                 return false;
             }
 
-            return Database.GetGameMatchesFilter(entry.Game, filterSettings, settings.FuzzyMatchingInNameFilter);
+            return Database.GetGameMatchesFilter(entry.Game, filterSettings, false);
         }
 
         private void FilterSettings_FilterChanged(object sender, FilterChangedEventArgs e)

--- a/source/Playnite/Localization/LocSource.xaml
+++ b/source/Playnite/Localization/LocSource.xaml
@@ -1200,9 +1200,6 @@ SHIFT-ENTER: open item menu</sys:String>
     <sys:String x:Key="LOCEmuOverridePlatformTooltip">When set, scanner will assign this platform to all games, overwriting any automatically detected platforms.</sys:String>
     <sys:String x:Key="LOCSearchIncludeCommandsInDefault">Include commands in default search</sys:String>
     <sys:String x:Key="LOCSearchIncludeCommandsInDefaultTooltip">When disabled, commands won't be included in default search until # prefix is used.</sys:String>
-    <sys:String x:Key="NameFilterUseFuzzyMatching">Use fuzzy matching in name filter</sys:String>
-    <sys:String x:Key="NameFilterUseFuzzyMatchingTooltip"  xml:space="preserve">When enabled, name filter will match game names the same way as global search.
-Strict matching can be enforced on an individual case by prefixing filter with ! character.</sys:String>
     <sys:String x:Key="LOCSearchViewGameFieldOptions">Fields to be displayed for game results:</sys:String>
     <sys:String x:Key="LOCHiddenStatus">Hidden Status</sys:String>
 

--- a/source/Playnite/Localization/LocSource.xaml
+++ b/source/Playnite/Localization/LocSource.xaml
@@ -1200,6 +1200,12 @@ SHIFT-ENTER: open item menu</sys:String>
     <sys:String x:Key="LOCEmuOverridePlatformTooltip">When set, scanner will assign this platform to all games, overwriting any automatically detected platforms.</sys:String>
     <sys:String x:Key="LOCSearchIncludeCommandsInDefault">Include commands in default search</sys:String>
     <sys:String x:Key="LOCSearchIncludeCommandsInDefaultTooltip">When disabled, commands won't be included in default search until # prefix is used.</sys:String>
+    <sys:String x:Key="LOCSearchModeNormalLabel">Normal search mode</sys:String>
+    <sys:String x:Key="LOCSearchModeFuzzyLabel">Fuzzy search mode</sys:String>
+    <sys:String x:Key="LOCSearchModeRegexLabel">Regex search mode</sys:String>
+    <sys:String x:Key="LOCSearchModeNormalDescription">Finds exact text matches.</sys:String>
+    <sys:String x:Key="LOCSearchModeFuzzyDescription">Approximate matching that tolerates typos and partial matches.</sys:String>
+    <sys:String x:Key="LOCSearchModeRegexDescription">Uses regular expression patterns.</sys:String>
     <sys:String x:Key="LOCSearchViewGameFieldOptions">Fields to be displayed for game results:</sys:String>
     <sys:String x:Key="LOCHiddenStatus">Hidden Status</sys:String>
 

--- a/source/Playnite/Localization/LocalizationKeys.cs
+++ b/source/Playnite/Localization/LocalizationKeys.cs
@@ -4290,6 +4290,30 @@ namespace Playnite
         /// </summary>
         public const string SearchIncludeCommandsInDefaultTooltip = "LOCSearchIncludeCommandsInDefaultTooltip";
         /// <summary>
+        /// Normal search mode
+        /// </summary>
+        public const string SearchModeNormalLabel = "LOCSearchModeNormalLabel";
+        /// <summary>
+        /// Fuzzy search mode
+        /// </summary>
+        public const string SearchModeFuzzyLabel = "LOCSearchModeFuzzyLabel";
+        /// <summary>
+        /// Regex search mode
+        /// </summary>
+        public const string SearchModeRegexLabel = "LOCSearchModeRegexLabel";
+        /// <summary>
+        /// Finds exact text matches.
+        /// </summary>
+        public const string SearchModeNormalDescription = "LOCSearchModeNormalDescription";
+        /// <summary>
+        /// Approximate matching that tolerates typos and partial matches.
+        /// </summary>
+        public const string SearchModeFuzzyDescription = "LOCSearchModeFuzzyDescription";
+        /// <summary>
+        /// Uses regular expression patterns.
+        /// </summary>
+        public const string SearchModeRegexDescription = "LOCSearchModeRegexDescription";
+        /// <summary>
         /// Fields to be displayed for game results:
         /// </summary>
         public const string SearchViewGameFieldOptions = "LOCSearchViewGameFieldOptions";

--- a/source/Playnite/Localization/LocalizationKeys.cs
+++ b/source/Playnite/Localization/LocalizationKeys.cs
@@ -4290,14 +4290,6 @@ namespace Playnite
         /// </summary>
         public const string SearchIncludeCommandsInDefaultTooltip = "LOCSearchIncludeCommandsInDefaultTooltip";
         /// <summary>
-        /// Use fuzzy matching in name filter
-        /// </summary>
-        public const string NameFilterUseFuzzyMatching = "NameFilterUseFuzzyMatching";
-        /// <summary>
-        /// When enabled, name filter will match game names the same way as global search.
-        /// </summary>
-        public const string NameFilterUseFuzzyMatchingTooltip = "NameFilterUseFuzzyMatchingTooltip";
-        /// <summary>
         /// Fields to be displayed for game results:
         /// </summary>
         public const string SearchViewGameFieldOptions = "LOCSearchViewGameFieldOptions";

--- a/source/Playnite/SelectableItem.cs
+++ b/source/Playnite/SelectableItem.cs
@@ -515,7 +515,8 @@ namespace System
     public class SelectableDbItemList : SelectableIdItemList<DatabaseObject>, INotifyCollectionChanged
     {
         private readonly bool includeNoneItem;
-        private readonly TextMatcher textMatcher = new TextMatcher();
+        private readonly TextMatcher textMatcher =
+            new TextMatcher() { NormalMatchAcronymStart = true };
         private bool showSelectedOnly = false;
         public bool ShowSelectedOnly
         {

--- a/source/Playnite/SelectableItem.cs
+++ b/source/Playnite/SelectableItem.cs
@@ -1,4 +1,5 @@
 ﻿using Playnite;
+using Playnite.Common;
 using Playnite.SDK;
 using Playnite.SDK.Models;
 using Playnite.SDK.Plugins;
@@ -514,7 +515,7 @@ namespace System
     public class SelectableDbItemList : SelectableIdItemList<DatabaseObject>, INotifyCollectionChanged
     {
         private readonly bool includeNoneItem;
-
+        private readonly TextMatcher textMatcher = new TextMatcher();
         private bool showSelectedOnly = false;
         public bool ShowSelectedOnly
         {
@@ -542,6 +543,22 @@ namespace System
             set
             {
                 searchText = value;
+                OnPropertyChanged();
+                CollectionView?.Refresh();
+            }
+        }
+
+        private SearchMode searchMode = SearchMode.Normal;
+        public SearchMode SearchMode
+        {
+            get
+            {
+                return searchMode;
+            }
+
+            set
+            {
+                searchMode = value;
                 OnPropertyChanged();
                 CollectionView?.Refresh();
             }
@@ -693,7 +710,31 @@ namespace System
         private bool CollectionViewFilter(object item)
         {
             var entry = (SelectableItem<DatabaseObject>)item;
-            return (ShowSelectedOnly ? entry.Selected == true : true) && entry.Item.Name.Contains(SearchText, StringComparison.OrdinalIgnoreCase);
+            if (ShowSelectedOnly && entry.Selected == false)
+            {
+                return false;
+            }
+
+            if (SearchMode == SearchMode.Normal)
+            {
+                return textMatcher.IsMatch(
+                    SearchText,
+                    entry.Item.Name);
+            }
+            else if (SearchMode == SearchMode.Fuzzy)
+            {
+                return textMatcher.IsFuzzyMatch(
+                    SearchText,
+                    entry.Item.Name);
+            }
+            else if (SearchMode == SearchMode.Regex)
+            {
+                return textMatcher.IsRegexMatch(
+                    SearchText,
+                    entry.Item.Name);
+            }
+
+            return false;
         }
 
         public override string ToString()

--- a/source/Playnite/Settings/FilterSettings.cs
+++ b/source/Playnite/Settings/FilterSettings.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Playnite.Common;
+using Playnite.SDK.Models;
 using SdkModels = Playnite.SDK.Models;
 
 namespace Playnite
@@ -372,6 +373,48 @@ namespace Playnite
                     name = value;
                     OnPropertyChanged();
                     OnFilterChanged(nameof(Name));
+                    OnPropertyChanged(nameof(IsActive));
+                    OnPropertyChanged(nameof(SearchActive));
+                }
+            }
+        }
+
+        private SearchMode nameSearchMode;
+        public SearchMode NameSearchMode
+        {
+            get
+            {
+                return nameSearchMode;
+            }
+
+            set
+            {
+                if (nameSearchMode != value)
+                {
+                    nameSearchMode = value;
+                    OnPropertyChanged();
+                    OnFilterChanged(nameof(NameSearchMode));
+                    OnPropertyChanged(nameof(IsActive));
+                    OnPropertyChanged(nameof(SearchActive));
+                }
+            }
+        }
+
+        private SearchMode versionSearchMode;
+        public SearchMode VersionSearchMode
+        {
+            get
+            {
+                return versionSearchMode;
+            }
+
+            set
+            {
+                if (versionSearchMode != value)
+                {
+                    versionSearchMode = value;
+                    OnPropertyChanged();
+                    OnFilterChanged(nameof(VersionSearchMode));
                     OnPropertyChanged(nameof(IsActive));
                     OnPropertyChanged(nameof(SearchActive));
                 }
@@ -964,6 +1007,12 @@ namespace Playnite
                 filterChanges.Add(nameof(Name));
             }
 
+            if (NameSearchMode != SearchMode.Normal)
+            {
+                NameSearchMode = SearchMode.Normal;
+                filterChanges.Add(nameof(NameSearchMode));
+            }
+
             if (Genre?.IsSet == true)
             {
                 Genre = null;
@@ -986,6 +1035,12 @@ namespace Playnite
             {
                 Version = null;
                 filterChanges.Add(nameof(Version));
+            }
+
+            if (VersionSearchMode != SearchMode.Normal)
+            {
+                VersionSearchMode = SearchMode.Normal;
+                filterChanges.Add(nameof(VersionSearchMode));
             }
 
             if (Publisher?.IsSet == true)
@@ -1155,7 +1210,9 @@ namespace Playnite
                 Hidden = Hidden,
                 Favorite = Favorite,
                 Name = Name,
+                NameSearchMode = NameSearchMode,
                 Version = Version,
+                VersionSearchMode = VersionSearchMode,
                 ReleaseYear = ReleaseYear?.ToSdkModel(),
                 Genre = Genre?.ToSdkModel(),
                 Platform = Platform?.ToSdkModel(),
@@ -1191,7 +1248,9 @@ namespace Playnite
                 Hidden = settings.Hidden,
                 Favorite = settings.Favorite,
                 Name = settings.Name,
+                NameSearchMode = settings.NameSearchMode,
                 Version = settings.Version,
+                VersionSearchMode = settings.VersionSearchMode,
                 ReleaseYear = StringFilterItemProperties.FromSdkModel(settings.ReleaseYear),
                 Genre = IdItemFilterItemProperties.FromSdkModel(settings.Genre),
                 Platform = IdItemFilterItemProperties.FromSdkModel(settings.Platform),
@@ -1233,6 +1292,18 @@ namespace Playnite
             {
                 Name = settings.Name;
                 filterChanges.Add(nameof(Name));
+            }
+
+            if (NameSearchMode != settings.NameSearchMode)
+            {
+                NameSearchMode = settings.NameSearchMode;
+                filterChanges.Add(nameof(NameSearchMode));
+            }
+
+            if (VersionSearchMode != settings.VersionSearchMode)
+            {
+                VersionSearchMode = settings.VersionSearchMode;
+                filterChanges.Add(nameof(VersionSearchMode));
             }
 
             if (Genre?.Equals(settings.Genre) != true)

--- a/source/Playnite/Settings/PlayniteSettings.cs
+++ b/source/Playnite/Settings/PlayniteSettings.cs
@@ -1871,17 +1871,6 @@ namespace Playnite
             }
         }
 
-        private bool fuzzyMatchingInNameFilter = true;
-        public bool FuzzyMatchingInNameFilter
-        {
-            get => fuzzyMatchingInNameFilter;
-            set
-            {
-                fuzzyMatchingInNameFilter = value;
-                OnPropertyChanged();
-            }
-        }
-
         private double topPanelSectionSeparatorWidth = 15;
         public double TopPanelSectionSeparatorWidth
         {

--- a/source/PlayniteSDK/Models/FilterPreset.cs
+++ b/source/PlayniteSDK/Models/FilterPreset.cs
@@ -80,6 +80,13 @@ namespace Playnite.SDK.Models
         [Description("LOCRecentActivityLabel")] RecentActivity = 26
     }
 
+    public enum SearchMode : int
+    {
+        Normal = 0,
+        Fuzzy = 1,
+        Regex = 2
+    }
+
     public class FilterPresetSettings
     {
         public bool UseAndFilteringStyle { get; set; }
@@ -88,7 +95,9 @@ namespace Playnite.SDK.Models
         public bool Hidden { get; set; }
         public bool Favorite { get; set; }
         public string Name { get; set; }
+        public SearchMode NameSearchMode { get; set; } = SearchMode.Normal;
         public string Version { get; set; }
+        public SearchMode VersionSearchMode { get; set; } = SearchMode.Normal;
         public StringFilterItemProperties ReleaseYear { get; set; }
         public IdItemFilterItemProperties Genre { get; set; }
         public IdItemFilterItemProperties Platform { get; set; }

--- a/source/PlayniteSDK/Models/FilterPreset.cs
+++ b/source/PlayniteSDK/Models/FilterPreset.cs
@@ -82,9 +82,9 @@ namespace Playnite.SDK.Models
 
     public enum SearchMode : int
     {
-        Normal = 0,
-        Fuzzy = 1,
-        Regex = 2
+        [Description("LOCSearchModeNormalLabel")] Normal = 0,
+        [Description("LOCSearchModeFuzzyLabel")] Fuzzy = 1,
+        [Description("LOCSearchModeRegexLabel")] Regex = 2
     }
 
     public class FilterPresetSettings

--- a/source/Tests/Playnite.Tests/Database/GameLibraryFilterTests.cs
+++ b/source/Tests/Playnite.Tests/Database/GameLibraryFilterTests.cs
@@ -269,10 +269,10 @@ namespace Playnite.Tests.Database
             AssertNameMatch("game alpga", true, GameA);
             AssertNameMatch("game alpga", false, expected: Array.Empty<Game>());
             AssertNameMatch("!game alpga", true, expected: Array.Empty<Game>());
-            AssertNameMatch("[NameInitial]:A", false, expected: Array.Empty<Game>()); //[NameInitial]: at the start of strings matches the name grouping character
-            AssertNameMatch("[NameInitial]:A", true, expected: Array.Empty<Game>());
-            AssertNameMatch("[NameInitial]:G", false, GameNone, GameA, GameB, GameBoth);
-            AssertNameMatch("[NameInitial]:G", true, GameNone, GameA, GameB, GameBoth);
+            AssertNameMatch("^:A", false, expected: Array.Empty<Game>()); //^: at the start of strings matches the name grouping character
+            AssertNameMatch("^:A", true, expected: Array.Empty<Game>());
+            AssertNameMatch("^:G", false, GameNone, GameA, GameB, GameBoth);
+            AssertNameMatch("^:G", true, GameNone, GameA, GameB, GameBoth);
         }
 
         [Test]

--- a/source/Tests/Playnite.Tests/Database/GameLibraryFilterTests.cs
+++ b/source/Tests/Playnite.Tests/Database/GameLibraryFilterTests.cs
@@ -269,10 +269,10 @@ namespace Playnite.Tests.Database
             AssertNameMatch("game alpga", true, GameA);
             AssertNameMatch("game alpga", false, expected: Array.Empty<Game>());
             AssertNameMatch("!game alpga", true, expected: Array.Empty<Game>());
-            AssertNameMatch("^A", false, expected: Array.Empty<Game>()); //^ at the start of strings matches the name grouping character
-            AssertNameMatch("^A", true, expected: Array.Empty<Game>());
-            AssertNameMatch("^G", false, GameNone, GameA, GameB, GameBoth);
-            AssertNameMatch("^G", true, GameNone, GameA, GameB, GameBoth);
+            AssertNameMatch("[NameInitial]:A", false, expected: Array.Empty<Game>()); //[NameInitial]: at the start of strings matches the name grouping character
+            AssertNameMatch("[NameInitial]:A", true, expected: Array.Empty<Game>());
+            AssertNameMatch("[NameInitial]:G", false, GameNone, GameA, GameB, GameBoth);
+            AssertNameMatch("[NameInitial]:G", true, GameNone, GameA, GameB, GameBoth);
         }
 
         [Test]

--- a/source/Tests/Playnite.Tests/Playnite.Tests.csproj
+++ b/source/Tests/Playnite.Tests/Playnite.Tests.csproj
@@ -143,6 +143,7 @@
     <Compile Include="InstallSizeScanTests.cs" />
     <Compile Include="M3UTests.cs" />
     <Compile Include="SearchViewModelTests.cs" />
+    <Compile Include="TextMatcherTests.cs" />
     <Compile Include="_TestTools\GameDbTestWrapper.cs" />
     <Compile Include="GameFieldComparerTests.cs" />
     <Compile Include="GamesEditorTests.cs" />

--- a/source/Tests/Playnite.Tests/SearchViewModelTests.cs
+++ b/source/Tests/Playnite.Tests/SearchViewModelTests.cs
@@ -47,15 +47,6 @@ namespace Playnite.Tests
             Assert.IsFalse(SearchViewModel.MatchTextFilter("GOW ", "god of war 3", true));
             Assert.IsFalse(SearchViewModel.MatchTextFilter("gOw3", "god of war 2", true));
             Assert.IsFalse(SearchViewModel.MatchTextFilter("g OW", "god of war 3", true));
-
-            // JaroWinklerSimilarity tests
-            var filter = "mario pary";
-            var minimumSimilarity = 0.90;
-            var gameNames = new List<string> { "Mario Party", "Mario Party 1", "Mario Party 2", "Mario Party Advance", "Mario Tennis", "Super Mario 64" };
-            foreach (var gameName in gameNames)
-            {
-                Assert.AreEqual(filter.GetJaroWinklerSimilarityIgnoreCase(gameName) >= minimumSimilarity, SearchViewModel.MatchTextFilter(filter, gameName, false, minimumSimilarity));
-            }
         }
 
         [Test]

--- a/source/Tests/Playnite.Tests/TextMatcherTests.cs
+++ b/source/Tests/Playnite.Tests/TextMatcherTests.cs
@@ -209,11 +209,227 @@ namespace Playnite.Tests
         [Test]
         public void FuzzyWordMatchTest()
         {
-            var matcher = new TextMatcher();
+            var matcher = new TextMatcher
+            {
+                FuzzyMatchAcronymStart = true,
+                IgnoreCase = true
+            };
+
+            // Exact
+            Assert.IsTrue(
+                matcher.IsFuzzyMatch(
+                    "Persona",
+                    "Persona"));
+
+            Assert.IsTrue(
+                matcher.IsFuzzyMatch(
+                    "persona",
+                    "Persona"));
+
+            Assert.IsTrue(
+                matcher.IsFuzzyMatch(
+                    "PERSONA",
+                    "Persona"));
+
+            // Partial words
+            Assert.IsTrue(
+                matcher.IsFuzzyMatch(
+                    "pers",
+                    "Persona"));
+
+            Assert.IsTrue(
+                matcher.IsFuzzyMatch(
+                    "meta",
+                    "Metaphor ReFantazio"));
+
+            Assert.IsTrue(
+                matcher.IsFuzzyMatch(
+                    "roy",
+                    "Persona 5 Royal"));
+
+            // Typo correction
+            Assert.IsTrue(
+                matcher.IsFuzzyMatch(
+                    "persna",
+                    "Persona"));
+
+            Assert.IsTrue(
+                matcher.IsFuzzyMatch(
+                    "metphor",
+                    "Metaphor"));
+
+            Assert.IsTrue(
+                matcher.IsFuzzyMatch(
+                    "fnal fantasy",
+                    "Final Fantasy"));
+
+            // Multi-word
+
             Assert.IsTrue(
                 matcher.IsFuzzyMatch(
                     "pers 5",
                     "Persona 5 Royal"));
+
+            Assert.IsTrue(
+                matcher.IsFuzzyMatch(
+                    "persona royal",
+                    "Persona 5 Royal"));
+
+            Assert.IsTrue(
+                matcher.IsFuzzyMatch(
+                    "fant 7",
+                    "Final Fantasy 7 Remake"));
+
+            // Acronyms
+
+            Assert.IsTrue(
+                matcher.IsFuzzyMatch(
+                    "p5",
+                    "Persona 5"));
+
+            Assert.IsTrue(
+                matcher.IsFuzzyMatch(
+                    "ac",
+                    "Assassin's Creed"));
+
+            Assert.IsTrue(
+                matcher.IsFuzzyMatch(
+                    "ff",
+                    "Final Fantasy"));
+
+            // Word-start behavior for tiny searches
+
+            // Too short, default obtained fuzzy score is 0.90 and minimum is 0.92 for two chars
+            Assert.IsFalse(
+                matcher.IsFuzzyMatch(
+                    "pe",
+                    "Persona"));
+
+            // Too short, default obtained fuzzy score is 0.90 and minimum is 0.92 for two chars
+            Assert.IsFalse(
+                matcher.IsFuzzyMatch(
+                    "me",
+                    "Metaphor"));
+
+            // Tiny searches should not match everything
+            Assert.IsFalse(
+                matcher.IsFuzzyMatch(
+                    "a",
+                    "Persona"));
+
+            Assert.IsFalse(
+                matcher.IsFuzzyMatch(
+                    "e",
+                    "Metaphor"));
+
+            Assert.IsFalse(
+                matcher.IsFuzzyMatch(
+                    "o",
+                    "Game Beta"));
+
+            // Symbols should not create garbage matches
+            Assert.IsFalse(
+                matcher.IsFuzzyMatch(
+                    "^A",
+                    "Game Beta"));
+
+            Assert.IsFalse(
+                matcher.IsFuzzyMatch(
+                    ".*",
+                    "Persona"));
+
+            Assert.IsFalse(
+                matcher.IsFuzzyMatch(
+                    "---",
+                    "Persona"));
+
+            Assert.IsFalse(
+                matcher.IsFuzzyMatch(
+                    "()",
+                    "Persona"));
+
+            // Wrong words
+
+            Assert.IsFalse(
+                matcher.IsFuzzyMatch(
+                    "Halo",
+                    "Persona"));
+
+            Assert.IsFalse(
+                matcher.IsFuzzyMatch(
+                    "Mario",
+                    "Metaphor"));
+
+            // Gibberish
+            Assert.IsFalse(
+                matcher.IsFuzzyMatch(
+                    "xyzabc",
+                    "Persona"));
+
+            Assert.IsFalse(
+                matcher.IsFuzzyMatch(
+                    "qwerty",
+                    "Final Fantasy"));
+
+            // Punctuation separators
+
+            Assert.IsTrue(
+                matcher.IsFuzzyMatch(
+                    "street 6",
+                    "Street-Fighter_6"));
+
+            Assert.IsTrue(
+                matcher.IsFuzzyMatch(
+                    "fighter",
+                    "Street.Fighter:6"));
+
+
+
+            // Ordering
+
+            Assert.IsTrue(
+                matcher.IsFuzzyMatch(
+                    "persona 5",
+                    "Persona 5 Royal"));
+
+            // Fuzzy Score: 0.68756613756613749
+            Assert.IsFalse(
+                matcher.IsFuzzyMatch(
+                    "royal persona impossible",
+                    "Persona 5"));
+
+            // Whitespace handling
+            Assert.IsTrue(
+                matcher.IsFuzzyMatch(
+                    "   persona",
+                    "Persona"));
+
+            Assert.IsTrue(
+                matcher.IsFuzzyMatch(
+                    "persona   ",
+                    "Persona"));
+
+            // Long titles
+            Assert.IsTrue(
+                matcher.IsFuzzyMatch(
+                    "red dead",
+                    "Red Dead Redemption 2"));
+
+            Assert.IsTrue(
+                matcher.IsFuzzyMatch(
+                    "redemptn",
+                    "Red Dead Redemption 2"));
+
+            // Very short non-acronym garbage
+            Assert.IsFalse(
+                matcher.IsFuzzyMatch(
+                    "x",
+                    "Red Dead Redemption"));
+
+            Assert.IsFalse(
+                matcher.IsFuzzyMatch(
+                    "z",
+                    "Final Fantasy"));
         }
 
         [Test]

--- a/source/Tests/Playnite.Tests/TextMatcherTests.cs
+++ b/source/Tests/Playnite.Tests/TextMatcherTests.cs
@@ -1,0 +1,286 @@
+﻿using NUnit.Framework;
+using Playnite.Common;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Playnite.Tests
+{
+    [TestFixture]
+    public class TextMatcherTests
+    {
+        [Test]
+        public void IsMatchTest()
+        {
+            var matcher = new TextMatcher();
+
+            Assert.IsTrue(
+                matcher.IsMatch(
+                    "persona",
+                    "Persona 5"));
+
+            Assert.IsTrue(
+                matcher.IsMatch(
+                    "sona",
+                    "Persona 5"));
+
+            Assert.IsFalse(
+                matcher.IsMatch(
+                    "final",
+                    "Persona 5"));
+        }
+
+        [Test]
+        public void IsMatchCaseSensitiveTest()
+        {
+            var matcher = new TextMatcher
+            {
+                IgnoreCase = false
+            };
+
+            Assert.IsFalse(
+                matcher.IsMatch(
+                    "persona",
+                    "Persona"));
+        }
+
+        [Test]
+        public void IsMatchCaseInsensitiveTest()
+        {
+            var matcher = new TextMatcher
+            {
+                IgnoreCase = true
+            };
+
+            Assert.IsTrue(
+                matcher.IsMatch(
+                    "persona",
+                    "Persona"));
+        }
+
+        [Test]
+        public void NormalAcronymMatchTest()
+        {
+            var matcher = new TextMatcher
+            {
+                NormalMatchAcronymStart = true
+            };
+
+            Assert.IsTrue(
+                matcher.IsMatch(
+                    "p5",
+                    "Persona 5"));
+
+            Assert.IsTrue(
+                matcher.IsMatch(
+                    "ac",
+                    "Assassin's Creed"));
+
+            Assert.IsFalse(
+                matcher.IsMatch(
+                    "xyz",
+                    "Persona 5"));
+        }
+
+        [Test]
+        public void RegexMatchTest()
+        {
+            var matcher = new TextMatcher();
+
+            // Whole word matching
+            Assert.IsTrue(
+                matcher.IsRegexMatch(
+                    @"\bDemo\b",
+                    "Demo Game"));
+
+            Assert.IsTrue(
+                matcher.IsRegexMatch(
+                    @"\bDemo\b",
+                    "Persona 3 Reloaded Demo"));
+
+            Assert.IsFalse(
+                matcher.IsRegexMatch(
+                    @"\bDemo\b",
+                    "Demolition"));
+
+            // IgnoreCase enabled by default
+            Assert.IsTrue(
+                matcher.IsRegexMatch(
+                    @"\bdemo\b",
+                    "Demo Game"));
+
+            Assert.IsTrue(
+                matcher.IsRegexMatch(
+                    @"\bDEMO\b",
+                    "demo game"));
+
+            // Start anchor
+            Assert.IsTrue(
+                matcher.IsRegexMatch(
+                    @"^Persona",
+                    "Persona 5 Royal"));
+
+            Assert.IsFalse(
+                matcher.IsRegexMatch(
+                    @"^Persona",
+                    "Super Persona 5 Royal"));
+
+            // End anchor
+            Assert.IsTrue(
+                matcher.IsRegexMatch(
+                    @"Royal$",
+                    "Persona 5 Royal"));
+
+            Assert.IsFalse(
+                matcher.IsRegexMatch(
+                    @"Royal$",
+                    "Royal Edition Game"));
+
+            // Character classes
+            Assert.IsTrue(
+                matcher.IsRegexMatch(
+                    @"Persona \d",
+                    "Persona 5"));
+
+            Assert.IsFalse(
+                matcher.IsRegexMatch(
+                    @"Persona \d",
+                    "Persona Royal"));
+
+            // Alternation
+            Assert.IsTrue(
+                matcher.IsRegexMatch(
+                    @"Persona|Metaphor",
+                    "Metaphor ReFantazio"));
+
+            Assert.IsTrue(
+                matcher.IsRegexMatch(
+                    @"Persona|Metaphor",
+                    "Persona 3 Reload"));
+
+            Assert.IsFalse(
+                matcher.IsRegexMatch(
+                    @"Persona|Metaphor",
+                    "Final Fantasy"));
+        }
+
+        [Test]
+        public void InvalidRegexDoesNotThrowTest()
+        {
+            var matcher = new TextMatcher();
+            Assert.DoesNotThrow(() =>
+            {
+                matcher.IsRegexMatch(
+                    @"\bDemo\",
+                    "Demo");
+            });
+
+            Assert.IsFalse(
+                matcher.IsRegexMatch(
+                    @"\bDemo\",
+                    "Demo"));
+        }
+
+        [Test]
+        public void InvalidRegexCanBeRepeatedTest()
+        {
+            var matcher = new TextMatcher();
+            for (int i = 0; i < 100; i++)
+            {
+                Assert.IsFalse(
+                    matcher.IsRegexMatch(
+                        @"\bDemo\",
+                        "Demo"));
+            }
+        }
+
+        [Test]
+        public void FuzzySimilarityMatchTest()
+        {
+            var matcher = new TextMatcher();
+            Assert.IsTrue(
+                matcher.IsFuzzyMatch(
+                    "persna",
+                    "Persona"));
+        }
+
+        [Test]
+        public void FuzzyWordMatchTest()
+        {
+            var matcher = new TextMatcher();
+            Assert.IsTrue(
+                matcher.IsFuzzyMatch(
+                    "pers 5",
+                    "Persona 5 Royal"));
+        }
+
+        [Test]
+        public void FuzzyAcronymMatchTest()
+        {
+            var matcher = new TextMatcher();
+            Assert.IsTrue(
+                matcher.IsFuzzyMatch(
+                    "p5",
+                    "Persona 5 Royal"));
+
+            Assert.IsTrue(
+                matcher.IsFuzzyMatch(
+                    "aco",
+                    "Assassin's Creed Odyssey"));
+        }
+
+        [Test]
+        public void FuzzyNoMatchTest()
+        {
+            var matcher = new TextMatcher();
+
+            Assert.IsFalse(
+                matcher.IsFuzzyMatch(
+                    "zelda",
+                    "Persona 5"));
+        }
+
+        [Test]
+        public void NullQueryThrowsTest()
+        {
+            var matcher = new TextMatcher();
+
+            Assert.Throws<ArgumentNullException>(
+                () => matcher.IsMatch(
+                    null,
+                    "Persona"));
+        }
+
+        [Test]
+        public void NullTargetThrowsTest()
+        {
+            var matcher = new TextMatcher();
+
+            Assert.Throws<ArgumentNullException>(
+                () => matcher.IsMatch(
+                    "Persona",
+                    null));
+        }
+
+        [Test]
+        public void ClearRegexCachesTest()
+        {
+            var matcher = new TextMatcher();
+
+            matcher.IsRegexMatch(
+                @"\bDemo\b",
+                "Demo");
+
+            matcher.ClearRegexCaches();
+
+            Assert.DoesNotThrow(() =>
+            {
+                matcher.IsRegexMatch(
+                    @"\bDemo\b",
+                    "Demo");
+            });
+        }
+    }
+}


### PR DESCRIPTION
Adds support for multiple search modes across SearchBox and filtering logic with support to switch between modes by clicking a button:

- Normal search
- Fuzzy search
- Regex search

**Changes:**
- Introduced a reusable `TextMatcher` utility to centralize matching behavior and ensure consistent search logic across different component across Playnite.
- Implemented a three-state search mode toggle button directly in the SearchBox control to allow users to quickly switch search behavior without opening settings.
- Added support to Game Edit Dialog dropdowns as well.

**TODO:**

- ~~Replace placeholder strings with proper localization strings~~ Done
- ~~Remove now obsolete global fuzzy search setting and localization entries~~ Done
- ~~Test in Fullscreen Mode~~ Done
- ~~Add/update tests (Unless they are not needed?  😁)~~ Done
- ~~Implement same functionality in Keyboard Launcher~~ Canceled
- ~~Reuse `TextMatcher` in Keyboard Launcher for consistent behavior~~ Canceled

**Edit:** There's too many moving parts in the Keyboard Launcher and I don't want to break something. I've canceled adding it, at least as part of this PR.