### PR TITLE
Group Games by first meaningful character in name

### DIFF
--- a/source/PlayniteSDK/Models/Game.cs
+++ b/source/PlayniteSDK/Models/Game.cs
@@ -2371,11 +2371,21 @@ namespace Playnite.SDK.Models
             {
                 return '#';
             }
-            else
+
+            foreach (var c in nameMatch)
             {
-                var firstChar = char.ToUpper(nameMatch[0]);
-                return char.IsLetter(firstChar) ? firstChar : '#';
+                if (char.IsDigit(c))
+                {
+                    return '#';
+                }
+
+                if (char.IsLetter(c))
+                {
+                    return char.ToUpper(c);
+                }
             }
+
+            return '#';
         }
 
         /// <summary>


### PR DESCRIPTION
This improves title grouping for games with leading special characters. Games like `>observer_`, `[REDACTED]` and `.hack//G.U.`  currently are grouped in the `#` section that is intended for numbers. With this change they are now grouped under the first letter in their name while games starting with numbers continue to use `#`. In my opinion this is more natural.

**Before:**

<img width="675" height="1001" alt="Playnite DesktopApp_i2azOAW2Ge" src="https://github.com/user-attachments/assets/716d326a-74d8-45f6-914b-cdaf10ed0b52" />

**After:**

<img width="635" height="685" alt="image" src="https://github.com/user-attachments/assets/4cd25c79-5147-4c59-ac07-cc24b93abf1e" />

<img width="624" height="497" alt="image" src="https://github.com/user-attachments/assets/08e81e66-0411-4cfb-99cc-240fe7580f38" />

<img width="623" height="286" alt="image" src="https://github.com/user-attachments/assets/d1f6b594-a94f-4d50-a96a-6d0b26923773" />

