### PR TITLE
Fix ProcessMonitor game tracking

### DIFF
--- a/source/Playnite/Common/ProcessMonitor.cs
+++ b/source/Playnite/Common/ProcessMonitor.cs
@@ -133,6 +133,11 @@ namespace Playnite.Common
             {
                 logger.Error(e, $"Failed to get target path for a directory {directory}");
             }
+
+            dir = dir
+                .Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar)
+                .TrimEnd(Path.DirectorySeparatorChar)
+                + Path.DirectorySeparatorChar;
         }
 
         public bool IsTrackable()


### PR DESCRIPTION
### Changes:

1. Fixes process monitor tracking incorrectly detecting processes that share pointed directory as a subset string in their path: https://www.reddit.com/r/playnite/comments/1tjh21p/is_there_any_way_to_run_the_game_fallout_4_with/
2. Fixes failing to track directory if configured tracking path uses alternate directory separator character (`/`)

---

This is due to the logic only checking for a subset of characters here:

https://github.com/JosefNemec/Playnite/blob/03814e96341807058e958e2e44ef184470726aa1/source/Playnite/Common/ProcessMonitor.cs#L152-L156

For example:

Tracking directory: **C:\Users\asdasd\qweqwe\TestingMonitorDir\Folder Name**
Other running process directory: **C:\Users\asdasd\qweqwe\TestingMonitorDir\Folder Name** and Something else\Program.exe

This can be fixed by simply adding a directory separator character at the end of the dir path.

With this change, the example directory will be converted to `C:\Users\asdasd\qweqwe\TestingMonitorDir\Folder Name\`, which will fix the incorrect matching thanks to the trailing `\` character.

---



One thing I'm not sure about is if the method should still use `IndexOf` here instead of `StartsWith` since it has the potential to still cause false positives if the configured directory is not rooted but I think it's very unlikely to happen and I don't want to break something so I left it as it is.

https://github.com/JosefNemec/Playnite/blob/03814e96341807058e958e2e44ef184470726aa1/source/Playnite/Common/ProcessMonitor.cs#L153
