### PR TITLE
Fix locale-aware CJK font fallback in Fullscreen mode

### DIFF
--- a/source/Playnite/Controls/WindowBase.cs
+++ b/source/Playnite/Controls/WindowBase.cs
@@ -15,6 +15,7 @@ using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Interop;
+using System.Windows.Markup;
 using System.Windows.Media;
 
 namespace Playnite.Controls
@@ -219,6 +220,7 @@ namespace Playnite.Controls
 
         public WindowBase() : base()
         {
+            Language = XmlLanguage.GetLanguage(Localization.ApplicationLanguageCultureInfo.IetfLanguageTag);
             emptyAutomationPeer = new EmptyWindowAutomationPeer(this);
             Style defaultStyle = (Style)Application.Current?.TryFindResource(typeof(WindowBase));
             if (defaultStyle != null)

--- a/source/Playnite/Controls/WindowBase.cs
+++ b/source/Playnite/Controls/WindowBase.cs
@@ -220,7 +220,7 @@ namespace Playnite.Controls
 
         public WindowBase() : base()
         {
-            Language = XmlLanguage.GetLanguage(Localization.ApplicationLanguageCultureInfo.IetfLanguageTag);
+            Language = XmlLanguage.GetLanguage(Localization.ApplicationLanguageCultureInfo.Name);
             emptyAutomationPeer = new EmptyWindowAutomationPeer(this);
             Style defaultStyle = (Style)Application.Current?.TryFindResource(typeof(WindowBase));
             if (defaultStyle != null)

--- a/source/Tests/Playnite.Tests/LocalizationTests.cs
+++ b/source/Tests/Playnite.Tests/LocalizationTests.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using NUnit.Framework;
 using Playnite;
+using Playnite.Controls;
 
 namespace Playnite.Tests
 {
@@ -13,6 +15,25 @@ namespace Playnite.Tests
         public void AvailableLangsTest()
         {
             CollectionAssert.IsNotEmpty(Localization.AvailableLanguages);
+        }
+
+        [Test]
+        [Apartment(ApartmentState.STA)]
+        public void WindowLanguageMatchesApplicationLanguageTest()
+        {
+            var originalLanguage = Localization.CurrentLanguage;
+            try
+            {
+                Localization.SetLanguage("zh_CN");
+                var window = new WindowBase();
+                Assert.AreEqual(
+                    Localization.ApplicationLanguageCultureInfo.Name,
+                    window.Language.GetEquivalentCulture().Name);
+            }
+            finally
+            {
+                Localization.SetLanguage(originalLanguage);
+            }
         }
     }
 }

--- a/source/Tests/Playnite.Tests/Playnite.Tests.csproj
+++ b/source/Tests/Playnite.Tests/Playnite.Tests.csproj
@@ -310,6 +310,11 @@
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="..\..\Playnite\Localization\zh_CN.xaml">
+      <Link>Localization\zh_CN.xaml</Link>
+      <SubType>Designer</SubType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Content Include="Resources\Images\mec_icon.ico">


### PR DESCRIPTION
Fixes #3710

## Problem

Simplified Chinese text in Fullscreen mode can be rendered with regional Han glyph variants that do not match Simplified Chinese.

Fullscreen themes use Titillium Web, which contains no CJK glyphs. WPF therefore has to select a fallback font. However, `FrameworkElement.Language` defaults to `en-US`, and Playnite did not update it when a localized UI language was loaded. WPF consequently selected and shaped fallback glyphs without the active Playnite locale.

Microsoft documents that [`FrameworkElement.Language`](https://learn.microsoft.com/en-us/dotnet/api/system.windows.frameworkelement.language) defaults to `en-US`, inherits to descendant elements, and that [`xml:lang` affects font fallback](https://learn.microsoft.com/en-us/dotnet/desktop/wpf/advanced/wpf-globalization-and-localization-overview).

## Change

- Initialize `WindowBase.Language` from `Localization.ApplicationLanguageCultureInfo`.
- Add a `zh-CN` regression test verifying that a window uses the selected application culture.

All 19 Fullscreen windows derive from `WindowBase`, so the language value is inherited by their content. This deliberately avoids hard-coding Microsoft YaHei or any other locale-specific font and also works for other languages and themes.

## Validation

- The new regression test fails before the fix (`zh-CN` expected, `en-US` actual).
- The regression test passes after the fix.
- `LocalizationTests`: 2/2 passed.
- Full `Playnite.sln` Debug/x86 build passed, including Fullscreen and test projects.
- Full `Playnite.Tests`: 279/283 passed locally. The four remaining failures are environment-dependent and unrelated to this change: one fixed checksum affected by Git CRLF conversion, and three process tests that assume English Windows output and no existing Notepad processes.
