### PR TITLE
Fix: Apply scan exclusions to script-based emulator imports (RPCS3)

### DIFF
--- a/source/Playnite/Emulators/Scanner.cs
+++ b/source/Playnite/Emulators/Scanner.cs
@@ -589,8 +589,8 @@ namespace Playnite.Emulators
 
                     if (scriptTask.IsCompleted)
                     {
-                        return ParseScriptScanResult(
-                            scannedGames, emuProf);
+                        var scriptResults = ParseScriptScanResult(scannedGames, emuProf);
+                        return FilterScriptScanResults(scriptResults, fileExclusions, directoryExclusions);
                     }
 
                     if (scriptTask.IsCanceled || scriptTask.IsFaulted)
@@ -1184,6 +1184,59 @@ namespace Playnite.Emulators
             }
 
             return game;
+        }
+
+        private List<ScannedGame> FilterScriptScanResults(
+            List<ScannedGame> games,
+            List<GameScanner.ScanExclusion> fileExclusions,
+            List<GameScanner.ScanExclusion> directoryExclusions)
+        {
+            if (!fileExclusions.HasItems() && !directoryExclusions.HasItems())
+            {
+                return games;
+            }
+
+            var result = new List<ScannedGame>();
+
+            foreach (var game in games)
+            {
+                var filteredRoms = new ObservableCollection<ScannedRom>();
+
+                foreach (var rom in game.Roms)
+                {
+                    var romPath = Path.GetFullPath(rom.Path);
+                    var romDirectory = Path.GetDirectoryName(romPath);
+
+                    bool isFileExcluded = fileExclusions.HasItems() &&
+                                          GetFileExclusionMatches(new List<string> { romPath }, fileExclusions).HasItems();
+
+                    bool isDirExcluded = false;
+                    if (directoryExclusions.HasItems() && !string.IsNullOrEmpty(romDirectory))
+                    {
+                        foreach (var excl in directoryExclusions)
+                        {
+                            if (romDirectory.StartsWith(excl.Path.TrimEnd('\\', '/'), StringComparison.OrdinalIgnoreCase))
+                            {
+                                isDirExcluded = true;
+                                break;
+                            }
+                        }
+                    }
+
+                    if (!isFileExcluded && !isDirExcluded)
+                    {
+                        filteredRoms.Add(rom);
+                    }
+                }
+
+                if (filteredRoms.HasItems())
+                {
+                    game.Roms = filteredRoms;
+                    result.Add(game);
+                }
+            }
+
+            return result;
         }
 
         private List<ScannedGame> ParseScriptScanResult(


### PR DESCRIPTION
Fixes #4208

## Problem

Folder and file exclusions configured in the scan settings were being ignored when importing games from emulators that use a PowerShell import script (such as RPCS3).

This happened because exclusions are handled inside `ScanDirectoryBase`, which is only called for standard emulator profiles. When an emulator profile uses `ScriptGameImport`, the scan is delegated entirely to a PowerShell script via `importRuntime.ExecuteFile()`, and the results are returned directly without any exclusion filtering applied.

## Root Cause

In `GameScanner.ScanDirectory()` , when `emuProf.ScriptGameImport` is true, `fileExclusions` and `directoryExclusions` are parsed correctly but never used, the script runs independently and Playnite processes its output as-is.

Additionally, `GetDirectoryExclusionMatches` cannot be used directly here because it performs an exact directory match. Script-based emulators like RPCS3 return deep paths (e.g. `dev_hdd0\game\BCUS98111\USRDIR`) rather than top-level directories, so a `StartsWith` check is needed to correctly detect whether a ROM falls inside an excluded folder.

## Fix

Added a `FilterScriptScanResults()` method in `GameScanner` that is called after `ParseScriptScanResult()` in the script-based import branch. It filters out any ROMs whose path matches the configured file or directory exclusions, using:
- `GetFileExclusionMatches()` for file exclusions (preserving support for regex and relative exclusions)
- A `StartsWith` check for directory exclusions, to correctly handle ROMs located inside excluded subdirectories