### PR TITLE
Fix game list confirm button ignoring the A/B swap setting

### DIFF
--- a/source/Playnite.FullscreenApp/Controls/Views/Main.cs
+++ b/source/Playnite.FullscreenApp/Controls/Views/Main.cs
@@ -101,12 +101,6 @@ namespace Playnite.FullscreenApp.Controls.Views
 
             this.mainModel.AppSettings.Fullscreen.PropertyChanged += Fullscreen_PropertyChanged;
             this.mainModel.PropertyChanged += MainModel_PropertyChanged;
-            GameControllerGesture.ConfirmationBindingChanged += GameControllerGesture_ConfirmationBindingChanged;
-        }
-
-        private void GameControllerGesture_ConfirmationBindingChanged(object sender, EventArgs e)
-        {
-            SetListCommandBindings();
         }
 
         private void MainModel_PropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -146,7 +140,8 @@ namespace Playnite.FullscreenApp.Controls.Views
             {
                 SetBackgroundEffect();
             }
-            else if (e.PropertyName == nameof(FullscreenSettings.SwapStartDetailsAction))
+            else if (e.PropertyName == nameof(FullscreenSettings.SwapStartDetailsAction) ||
+                     e.PropertyName == nameof(FullscreenSettings.SwapConfirmCancelButtons))
             {
                 SetListCommandBindings();
             }

--- a/source/Playnite.FullscreenApp/Controls/Views/Main.cs
+++ b/source/Playnite.FullscreenApp/Controls/Views/Main.cs
@@ -101,6 +101,12 @@ namespace Playnite.FullscreenApp.Controls.Views
 
             this.mainModel.AppSettings.Fullscreen.PropertyChanged += Fullscreen_PropertyChanged;
             this.mainModel.PropertyChanged += MainModel_PropertyChanged;
+            GameControllerGesture.ConfirmationBindingChanged += GameControllerGesture_ConfirmationBindingChanged;
+        }
+
+        private void GameControllerGesture_ConfirmationBindingChanged(object sender, EventArgs e)
+        {
+            SetListCommandBindings();
         }
 
         private void MainModel_PropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -154,17 +160,20 @@ namespace Playnite.FullscreenApp.Controls.Views
             }
 
             var swapStartInput = mainModel.AppSettings.Fullscreen.SwapStartDetailsAction;
+            // was hardcoded to A, which ignored the confirm/cancel swap setting
+            var confirmInput = GameControllerGesture.ConfirmationBinding;
+            var confirmHint = confirmInput == ControllerInput.B ? "ButtonPromptB" : "ButtonPromptA";
             ListGameItems.InputBindings.Clear();
             ListGameItems.InputBindings.Add(new KeyBinding() { Command = mainModel.OpenGameMenuCommand, Key = swapStartInput ? Key.A : Key.X });
             ListGameItems.InputBindings.Add(new KeyBinding() { Command = mainModel.ToggleGameDetailsCommand, Key = swapStartInput ? Key.X : Key.A });
             ListGameItems.InputBindings.Add(new KeyBinding() { Command = mainModel.ActivateSelectedCommand, Key = Key.Enter });
             ListGameItems.InputBindings.Add(new GameControllerInputBinding(mainModel.OpenGameMenuCommand, ControllerInput.Start));
-            ListGameItems.InputBindings.Add(new GameControllerInputBinding(mainModel.ToggleGameDetailsCommand, swapStartInput ? ControllerInput.X : ControllerInput.A));
-            ListGameItems.InputBindings.Add(new GameControllerInputBinding(mainModel.ActivateSelectedCommand, swapStartInput ? ControllerInput.A : ControllerInput.X));
+            ListGameItems.InputBindings.Add(new GameControllerInputBinding(mainModel.ToggleGameDetailsCommand, swapStartInput ? ControllerInput.X : confirmInput));
+            ListGameItems.InputBindings.Add(new GameControllerInputBinding(mainModel.ActivateSelectedCommand, swapStartInput ? confirmInput : ControllerInput.X));
 
-            ButtonPlay?.SetResourceReference(ButtonEx.InputHintProperty, swapStartInput ? "ButtonPromptA" : "ButtonPromptX");
-            ButtonInstall?.SetResourceReference(ButtonEx.InputHintProperty, swapStartInput ? "ButtonPromptA" : "ButtonPromptX");
-            ButtonDetails?.SetResourceReference(ButtonEx.InputHintProperty, swapStartInput ? "ButtonPromptX" : "ButtonPromptA");
+            ButtonPlay?.SetResourceReference(ButtonEx.InputHintProperty, swapStartInput ? confirmHint : "ButtonPromptX");
+            ButtonInstall?.SetResourceReference(ButtonEx.InputHintProperty, swapStartInput ? confirmHint : "ButtonPromptX");
+            ButtonDetails?.SetResourceReference(ButtonEx.InputHintProperty, swapStartInput ? "ButtonPromptX" : confirmHint);
         }
 
         private void SetBackgroundBinding()


### PR DESCRIPTION
The main game grid bound its select/open-details actions to a hardcoded physical A button instead of the live confirm binding, so enabling "Swap confirmation/cancellation button binding" left the list out of sync with every other screen in fullscreen mode (details, menus, dialogs), which already track the swap correctly.

Now the list follows GameControllerGesture.ConfirmationBinding and rebuilds its bindings when the setting changes, and the on-screen button hints update to match.

Fixes #3706

I know things are generally on pause because majority of code base is being rewritten for Playnite 11 but was hoping a small safe pr like this could taken still as the button mapping has been causing me havoc lately 😆 