### PR TITLE
Notify FullscreenListItemCoverObject when Game.CoverImage changes [GamesCollectionViewEntry.cs]

### DIFF
--- a/source/Playnite/GamesCollectionViewEntry.cs
+++ b/source/Playnite/GamesCollectionViewEntry.cs
@@ -393,6 +393,7 @@ namespace Playnite
                 PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CoverImageObject)));
                 PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CoverImageObjectCached)));
                 PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(GridViewCoverObjectCached)));
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(FullscreenListItemCoverObject)));
             }
 
             if (propertyName == nameof(Game.BackgroundImage))


### PR DESCRIPTION
**VIDEO OF THE ISSUE:** https://streamable.com/npgqt1

**VIDEO TESTING PR CHANGE WITH A LOCAL PATCHED PLAYNITE BUILD THAT FIXES THE ISSUE:** https://streamable.com/sefvcf

**Plugins Impacted:** BackgroundChanger & ImageRotater

### ISSUE: Fullscreen grid tiles do not update when `Game.CoverImage` changes.


> `GamesCollectionViewEntry` raises `PropertyChanged` for three cover
> properties when the cover changes: `CoverImageObject`, `CoverImageObjectCached` and `GridViewCoverObjectCached`.  These properties are all Desktop-facing. `FullscreenListItemCoverObject` isn't among them, and that's the property the Fullscreen grid binds: `GameListItem.OnApplyTemplate` binds `PART_ImageCover`'s `Source` to it (`Playnite.FullscreenApp/Controls/GameListItem.cs`).

> The consequence is that `Game.CoverImage` updates every Desktop view while a Fullscreen tile keeps the cover image it first resolved, until the view is rebuilt (which is unreliable to change via reflection). Plugins attempting to refresh the tile have experienced issues updating the cover image, which negatively impacts Fullscreen theme experiences (see video 1 link).

### SOLUTION

**File:** `source/Playnite/GamesCollectionViewEntry.cs`

**Add one line**, inside the existing `Game.CoverImage` block (~line 396):

```csharp
PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(FullscreenListItemCoverObject)));
```

The PR diff will be this:

```diff
             if (propertyName == nameof(Game.CoverImage))
             {
                 PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CoverImageObject)));
                 PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CoverImageObjectCached)));
                 PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(GridViewCoverObjectCached)));
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(FullscreenListItemCoverObject)));
             }
```
### VERIFICATION
>
> I patched a local build of Playnite master source code and ran it as a portable install using ANIKI REMAKE theme, with one
> plugin that changes `Game.CoverImage` (ImageRotater). Fullscreen grid covers now update on change.

> I confirmed the notification is what's doing the work by disabling ImageRotater's own manual tile-refresh workaround first, so nothing plugin-side was touching
> the Fullscreen tiles. Desktop behaviour is unchanged. Video of it working attached.
>
> **On the test:** I don't have experience writing test coverage. Please advise if you want test files, and I will do my best to provide in a future comment.

> Related: https://github.com/Lacro59/playnite-backgroundchanger-plugin/issues/77 & https://github.com/aHuddini/ImageRotater/blob/main/docs/PLAYNITE_ISSUE_DRAFT.md