### PR TITLE
Run the SDL event loop on a dedicated thread

### DIFF
--- a/source/Playnite.DesktopApp/DesktopApplication.cs
+++ b/source/Playnite.DesktopApp/DesktopApplication.cs
@@ -26,6 +26,7 @@ using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -42,7 +43,7 @@ namespace Playnite.DesktopApp
         private TaskbarIcon trayIcon;
         private SplashScreen splashScreen;
         private bool sdlInitialized = false;
-        private bool exitSDLEventLoop = false;
+        private volatile bool exitSDLEventLoop = false;
 
         private DesktopAppViewModel mainModel;
         public DesktopAppViewModel MainModel
@@ -396,7 +397,10 @@ namespace Playnite.DesktopApp
 
         private void SDLEventLoop()
         {
-            Task.Run(async () =>
+            // SDL's event pump and the Windows joystick hotplug path expect a single thread.
+            // Task.Run + await resumes on whatever pool thread is free, which moved every SDL
+            // call in this loop to a different thread on each tick.
+            var sdlThread = new Thread(() =>
             {
                 while (!exitSDLEventLoop)
                 {
@@ -414,9 +418,15 @@ namespace Playnite.DesktopApp
                     }
 
                     GameController?.ProcessInputs();
-                    await Task.Delay(16);
+                    Thread.Sleep(16);
                 }
-            });
+            })
+            {
+                IsBackground = true,
+                Name = "SDLEventLoop"
+            };
+
+            sdlThread.Start();
         }
 
         public void SetupInputs()

--- a/source/Playnite.FullscreenApp/FullscreenApplication.cs
+++ b/source/Playnite.FullscreenApp/FullscreenApplication.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
@@ -48,7 +49,7 @@ namespace Playnite.FullscreenApp
         public static IntPtr NavigateSound { get; private set; }
         public static IntPtr ActivateSound { get; private set; }
         public static IntPtr BackgroundMusic { get; private set; }
-        private bool exitSDLEventLoop = false;
+        private volatile bool exitSDLEventLoop = false;
 
         public new static FullscreenApplication Current
         {
@@ -302,7 +303,10 @@ namespace Playnite.FullscreenApp
 
         private void SDLEventLoop()
         {
-            Task.Run(async () =>
+            // SDL's event pump and the Windows joystick hotplug path expect a single thread.
+            // Task.Run + await resumes on whatever pool thread is free, which moved every SDL
+            // call in this loop to a different thread on each tick.
+            var sdlThread = new Thread(() =>
             {
                 while (!exitSDLEventLoop)
                 {
@@ -328,9 +332,15 @@ namespace Playnite.FullscreenApp
                             Audio.CloseAudio();
                     }
 
-                    await Task.Delay(16);
+                    Thread.Sleep(16);
                 }
-            });
+            })
+            {
+                IsBackground = true,
+                Name = "SDLEventLoop"
+            };
+
+            sdlThread.Start();
         }
 
         public void SetupInputs()


### PR DESCRIPTION
`SDLEventLoop()` runs in `Task.Run` and awaits `Task.Delay(16)` each iteration. There's no SynchronizationContext on a pool thread, so each iteration resumes on whatever thread is free rather than the one it started on. The SDL calls in that loop — polling events, updating controllers, opening and closing them — end up on a different thread roughly 60 times a second.

SDL expects its event pump to stay on one thread, and on Windows the controller connect/disconnect notifications belong to the thread that registered them.

This moves the loop onto its own thread. Desktop and Fullscreen had the same code, so both change.

`SDL_Init` and the `GameControllerManager` constructor stay where they are on purpose: the manager captures `SynchronizationContext.Current` and uses it to raise its events, so creating it off the UI thread would break that. `exitSDLEventLoop` is now `volatile`, since one thread writes it and another reads it.

I found this chasing a crash on controller disconnect — heap corruption with SDL on the stack, at the same second Playnite logged "Removed controller". I can't prove they're connected, but the loop looked wrong either way. I still have the dump if it's useful.
