### PR TITLE
Fixes for description focus and spacing

### DIFF
--- a/source/Playnite.DesktopApp/Themes/Desktop/Default/DefaultControls/Button.xaml
+++ b/source/Playnite.DesktopApp/Themes/Desktop/Default/DefaultControls/Button.xaml
@@ -42,4 +42,8 @@
             </Trigger>
         </Style.Triggers>
     </Style>                  
+
+    <Style x:Key="LoadMoreButton" BasedOn="{StaticResource {x:Type Button}}" TargetType="Button">
+        <Setter Property="Margin" Value="0,5,0,5" />
+    </Style>               
 </ResourceDictionary>

--- a/source/Playnite.FullscreenApp/Controls/ScrollViewerEx.cs
+++ b/source/Playnite.FullscreenApp/Controls/ScrollViewerEx.cs
@@ -12,6 +12,7 @@ namespace Playnite.FullscreenApp.Controls
 {
     public class ScrollViewerEx : ScrollViewer
     {
+        private bool focusMovedWithin;
         public double CustomScrollAmount { get; set; } = 0;
 
         static ScrollViewerEx()
@@ -29,12 +30,19 @@ namespace Playnite.FullscreenApp.Controls
         {
             ScrollChanged += ScrollViewerEx_ScrollChanged;
             PreviewKeyDown += ScrollViewerEx_PreviewKeyDown;
+            GotKeyboardFocus += ScrollViewerEx_GotKeyboardFocus;
         }
 
         private void ScrollViewerEx_Unloaded(object sender, RoutedEventArgs e)
         {
             ScrollChanged -= ScrollViewerEx_ScrollChanged;
             PreviewKeyDown -= ScrollViewerEx_PreviewKeyDown;
+            GotKeyboardFocus -= ScrollViewerEx_GotKeyboardFocus;
+        }
+
+        private void ScrollViewerEx_GotKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
+        {
+            focusMovedWithin = e.NewFocus is DependencyObject newFocus && IsAncestorOf(newFocus);
         }
 
         private void ScrollViewerEx_PreviewKeyDown(object sender, KeyEventArgs e)
@@ -71,6 +79,9 @@ namespace Playnite.FullscreenApp.Controls
 
         private void ScrollViewerEx_ScrollChanged(object sender, ScrollChangedEventArgs e)
         {
+            var focusJustMoved = focusMovedWithin;
+            focusMovedWithin = false;
+
             if (e.VerticalChange == 0 && e.HorizontalChange == 0)
             {
                 return;
@@ -81,7 +92,7 @@ namespace Playnite.FullscreenApp.Controls
                 MoveFocus(new TraversalRequest(FocusNavigationDirection.Up));
                 e.Handled = true;
             }
-            else if (VerticalOffset >= ScrollableHeight)
+            else if (!focusJustMoved && VerticalOffset >= ScrollableHeight)
             {
                 MoveFocus(new TraversalRequest(FocusNavigationDirection.Down));
                 e.Handled = true;

--- a/source/Playnite.FullscreenApp/FullscreenApplication.cs
+++ b/source/Playnite.FullscreenApp/FullscreenApplication.cs
@@ -24,6 +24,8 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
 using static SDL2.SDL;
+using Playnite.Controls;
+using Playnite.FullscreenApp.Controls;
 
 namespace Playnite.FullscreenApp
 {
@@ -71,6 +73,7 @@ namespace Playnite.FullscreenApp
             UpdateWindowFactory.SetWindowType<UpdateWindow>();
             SingleItemSelectionWindowFactory.SetWindowType<SingleItemSelectionWindow>();
             MultiItemSelectionWindowFactory.SetWindowType<MultiItemSelectionWindow>();
+            HtmlTextView.CreateMoreButton = () => new ButtonEx();
             Dialogs = new FullscreenDialogs();
             Playnite.Dialogs.SetHandler(Dialogs);
         }

--- a/source/Playnite.FullscreenApp/Themes/Fullscreen/Default/DefaultControls/Button.xaml
+++ b/source/Playnite.FullscreenApp/Themes/Fullscreen/Default/DefaultControls/Button.xaml
@@ -27,7 +27,7 @@
                                 BorderBrush="{TemplateBinding BorderBrush}"
                                 x:Name="BorderStandard" />
                         
-                        <Border x:Name="BorderFocus" Margin="-3"
+                        <Border x:Name="BorderFocus" Margin="0,-3,0,-3"
                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                 BorderBrush="{DynamicResource SelectionBrush}"
                                 BorderThickness="3" Visibility="Hidden" />
@@ -56,5 +56,9 @@
     </Style>
 
     <Style TargetType="ButtonEx" BasedOn="{StaticResource {x:Type Button}}">
+    </Style>
+
+    <Style x:Key="LoadMoreButton" BasedOn="{StaticResource {x:Type Button}}" TargetType="ButtonEx">
+        <Setter Property="Margin" Value="0,0,0,5" />
     </Style>
 </ResourceDictionary>

--- a/source/Playnite/Controls/HtmlTextView.cs
+++ b/source/Playnite/Controls/HtmlTextView.cs
@@ -16,6 +16,7 @@ using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
 using TheArtOfDev.HtmlRenderer.WPF;
+using Playnite.SDK;
 
 namespace Playnite.Controls
 {
@@ -59,6 +60,7 @@ namespace Playnite.Controls
         internal string templateContent = string.Empty;
         private readonly HtmlPanel htmlPanel;
         private readonly Button moreButton;
+        public static Func<Button> CreateMoreButton { get; set; }
 
         public string TemplatePath
         {
@@ -287,13 +289,14 @@ namespace Playnite.Controls
             }
             else
             {
-                moreButton.Visibility = Visibility.Hidden;
+                moreButton.Visibility = Visibility.Collapsed;
                 SetHtmlContent(HtmlText ?? string.Empty);
             };
         }
 
         internal void SetHtmlContent(string htmlContent)
         {
+            htmlPanel.Focusable = !HtmlText.IsNullOrEmpty();
             var content = string.Empty;
             if (!templateContent.IsNullOrEmpty())
             {
@@ -328,20 +331,18 @@ namespace Playnite.Controls
             ScrollViewer.SetHorizontalScrollBarVisibility(htmlPanel, ScrollBarVisibility.Disabled);
             ScrollViewer.SetVerticalScrollBarVisibility(htmlPanel, ScrollBarVisibility.Disabled);
 
-            moreButton = new Button
-            {
-                HorizontalAlignment = HorizontalAlignment.Center,
-                Content = LOC.LoadMore.GetLocalized(),
-                Visibility = Visibility.Hidden,
-                Margin = new Thickness(0, 0, 0, 5)
-            };
+            moreButton = CreateMoreButton?.Invoke() ?? new Button();
+            moreButton.HorizontalAlignment = HorizontalAlignment.Center;
+            moreButton.Content = LOC.LoadMore.GetLocalized();
+            moreButton.Visibility = Visibility.Collapsed;
+            moreButton.Style = ResourceProvider.GetResource("LoadMoreButton") as Style;
 
             moreButton.Click += (_, __) =>
             {
                 currentLoadedLength += loadPartLength;
                 if (currentLoadedLength > HtmlText.Length)
                 {
-                    moreButton.Visibility = Visibility.Hidden;
+                    moreButton.Visibility = Visibility.Collapsed;
                     SetHtmlContent(HtmlText);
                 }
                 else


### PR DESCRIPTION
### Description

Several small fixes to how game descriptions render and behave in Fullscreen mode in both the stock and custom themes. They address separate problems but overlap in the same layout, so they're intended to be taken together.

### Changes

**HtmlTextView.cs**
- `moreButton` used `Hidden` rather than `Collapsed`, reserving layout space on every description short enough not to need the button.
- `moreButton` had a hardcoded 5px bottom margin. Being inside the scroll viewer's extent, it shifted the text when scrolling to the bottom. It had no style of its own, so themes could only reach it via an implicit `Button` style affecting every plain Button. It now looks up "LoadMoreButton", falling back to the implicit style if a theme doesn't define it.
- Block-level elements kept their default bottom margin. The renderer does not collapse the last one, so descriptions ending in a paragraph or list reported more height than they rendered, leaving empty scrollable space.

**DescriptionView.html** — the same CSS rule. Needed in both, since a theme shipping its own template overrides the built-in one.

**ScrollViewerEx.cs** — `ScrollChanged` moved focus on any scroll reaching the bottom, including one caused by `MakeVisible` revealing a newly focused child. The Load More button was therefore unreachable whenever another
focusable element followed the description. Now suppressed only for scrolls that follow focus moving into the content, so scrolling to the bottom still advances focus as before.

**Button.xaml** — adds a `LoadMoreButton` style with the spacing, applied only to that button. Spacing previously came from the description's trailing block margin, so it varied by formatting and was absent for plain text.

The `moreButton` margin removal and the `ScrollViewerEx` change depend on each other; the margin and the default theme not having anything selectable below `moreButton` were masking the focus bug.

Tested in Fullscreen with descriptions that fit, that scroll, that end in lists or plain text, and that exceed 10,000 characters. Tested in both default theme, and custom theme with different layouts.

### Screenshots

Here are some example screenshots which highlight some of the fixes in the default theme, although they don't cover all the fixes above:

### Before fixes:

<img width="1560" height="790" alt="Screenshot 2026-08-30 095729" src="https://github.com/user-attachments/assets/610beadb-20a1-46b3-bf77-ca712e11b8e2" />
<img width="1567" height="699" alt="Screenshot 2026-08-30 223903" src="https://github.com/user-attachments/assets/18a82970-7ae3-49a4-b33f-e0272edbb9dc" />
<img width="1544" height="682" alt="Screenshot 2026-08-30 224056" src="https://github.com/user-attachments/assets/596b1e90-ae48-4e26-8cbd-1aa37f7c1f82" />

### After fixes:

<img width="1533" height="714" alt="Screenshot 2026-08-30 224313" src="https://github.com/user-attachments/assets/3482660e-ba45-44d9-889a-d977deea46a5" />
<img width="1548" height="695" alt="Screenshot 2026-08-30 223943" src="https://github.com/user-attachments/assets/4bff6f4b-cf62-4a19-b184-b4d6f0929e2f" />
<img width="1546" height="681" alt="Screenshot 2026-08-30 224047" src="https://github.com/user-attachments/assets/3795a9ae-a6b5-4729-be94-46457564ff4a" />